### PR TITLE
add return values for hostcall declarations

### DIFF
--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -1,8 +1,8 @@
 #[link(wasm_import_module = "shopify_v1")]
 extern "C" {
-  pub fn input_len(len: *const usize);
-  pub fn input_copy(buffer: *mut u8);
-  pub fn output_copy(buffer: *const u8, len: usize);
+  pub fn input_len(len: *const usize) -> u32;
+  pub fn input_copy(buffer: *mut u8) -> u32;
+  pub fn output_copy(buffer: *const u8, len: usize) -> u32;
 }
 
 pub fn load() -> Vec<u8> {


### PR DESCRIPTION
Since the wasitime changes have been merged, we can add the return values to the hostcall declarations and use the latest runtime engine.