### PR TITLE
Add floating points tests + fix null terminated strings

### DIFF
--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::wrong_self_convention)]
-use core::slice;
 use quickjs_sys::*;
 use std::{ffi::CString, os::raw::c_char, ptr};
 
@@ -187,7 +186,7 @@ impl Context {
             let ptr = JS_ToCStringLen2(self.raw, &mut len, val, 0);
             let ptr = ptr as *const u8;
             let len = len as usize;
-            slice::from_raw_parts(ptr, len)
+            std::slice::from_raw_parts(ptr, len)
         }
     }
 

--- a/crates/core/src/serialization.rs
+++ b/crates/core/src/serialization.rs
@@ -931,8 +931,7 @@ mod tests {
             let context = Context::new().expect("Couldn't create context");
             let mut deserializer = ValueDeserializer::from(&context, (q::JS_TAG_NULL as u64) << 32);
 
-            type U = ();
-            let result = U::deserialize(&mut deserializer)?;
+            let result = <()>::deserialize(&mut deserializer)?;
             assert_eq!(result, ());
             Ok(())
         }
@@ -943,8 +942,7 @@ mod tests {
             let mut deserializer =
                 ValueDeserializer::from(&context, (q::JS_TAG_UNDEFINED as u64) << 32);
 
-            type U = ();
-            let result = U::deserialize(&mut deserializer)?;
+            let result = <()>::deserialize(&mut deserializer)?;
             assert_eq!(result, ());
             Ok(())
         }


### PR DESCRIPTION
ref: https://github.com/Shopify/script-service/issues/3540

Some of theses tests are actually redundant since they should already be covered by the property tests for floats. But at least it exposes pretty explicitly that they work as they should. I've also fixed null terminated strings where the null termination byte was in the middle of the byte sequence.

Next: 
- fix null terminated object properties
- add tests for array, maps (aka objects)