### PR TITLE
refactor: Move value factory methods to context

### DIFF
--- a/crates/core/src/js_binding/globals.rs
+++ b/crates/core/src/js_binding/globals.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use quickjs_sys::*;
 use std::{io::Write, os::raw::c_int};
 
-use super::{context::Context, value::Value};
+use super::context::Context;
 
 pub fn register_globals<T>(ctx: &mut Context, log_stream: T) -> Result<()>
 where
@@ -10,7 +10,7 @@ where
 {
     let console_log_callback = unsafe { ctx.new_callback(console_log_to(log_stream))? };
     let global_object = ctx.global_object()?;
-    let console_object = Value::object(ctx.inner())?;
+    let console_object = ctx.object_value()?;
     console_object.set_property("log", &console_log_callback)?;
     global_object.set_property("console", &console_object)?;
     Ok(())

--- a/crates/core/src/js_binding/own_properties.rs
+++ b/crates/core/src/js_binding/own_properties.rs
@@ -74,7 +74,7 @@ impl OwnProperties {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::context::Context, super::value::Value, OwnProperties};
+    use super::{super::context::Context, OwnProperties};
     use anyhow::Result;
 
     #[test]
@@ -123,7 +123,7 @@ mod tests {
     #[test]
     fn test_invalid_access_to_own_props() -> Result<()> {
         let context = Context::default();
-        let val = Value::from_i32(context.inner(), 1_i32)?;
+        let val = context.value_from_i32(1_i32)?;
         let props = OwnProperties::from(&val);
         assert!(props.is_err());
         Ok(())

--- a/crates/core/src/serialize/de.rs
+++ b/crates/core/src/serialize/de.rs
@@ -371,7 +371,7 @@ impl<'de> de::SeqAccess<'de> for Deserializer {
 #[cfg(test)]
 mod tests {
     use super::Deserializer as ValueDeserializer;
-    use crate::js_binding::{context::Context, value::Value};
+    use crate::js_binding::context::Context;
     use anyhow::Result;
     use quickcheck::quickcheck;
     use serde::Deserialize;
@@ -379,7 +379,7 @@ mod tests {
     quickcheck! {
         fn test_i32(v: i32) -> Result<bool> {
             let context = Context::default();
-            let val = Value::from_i32(context.inner(), v)?;
+            let val = context.value_from_i32(v)?;
             let mut deserializer = ValueDeserializer::from_value(val)?;
 
             let result = i32::deserialize(&mut deserializer)?;
@@ -388,7 +388,7 @@ mod tests {
 
         fn test_bool(v: bool) -> Result<bool> {
             let context = Context::default();
-            let val = Value::from_bool(context.inner(), v)?;
+            let val = context.value_from_bool(v)?;
             let mut deserializer = ValueDeserializer::from_value(val)?;
 
             let result = bool::deserialize(&mut deserializer)?;
@@ -397,7 +397,7 @@ mod tests {
 
         fn test_str(v: String) -> Result<bool> {
             let context = Context::default();
-            let val = Value::from_str(context.inner(), &v)?;
+            let val = context.value_from_str(&v)?;
             let mut deserializer = ValueDeserializer::from_value(val)?;
 
             let result = String::deserialize(&mut deserializer)?;
@@ -408,7 +408,7 @@ mod tests {
     #[test]
     fn test_null() -> Result<()> {
         let context = Context::default();
-        let val = Value::null(context.inner())?;
+        let val = context.null_value()?;
         let mut deserializer = ValueDeserializer::from_value(val)?;
 
         let result = <()>::deserialize(&mut deserializer)?;
@@ -419,7 +419,7 @@ mod tests {
     #[test]
     fn test_undefined() -> Result<()> {
         let context = Context::default();
-        let val = Value::undefined(context.inner())?;
+        let val = context.undefined_value()?;
         let mut deserializer = ValueDeserializer::from_value(val)?;
 
         let result = <()>::deserialize(&mut deserializer)?;
@@ -430,7 +430,7 @@ mod tests {
     #[test]
     fn test_nan() -> Result<()> {
         let context = Context::default();
-        let val = Value::from_f64(context.inner(), f64::NAN)?;
+        let val = context.value_from_f64(f64::NAN)?;
         let mut deserializer = ValueDeserializer::from_value(val)?;
 
         let result = f64::deserialize(&mut deserializer)?;
@@ -441,7 +441,7 @@ mod tests {
     #[test]
     fn test_infinity() -> Result<()> {
         let context = Context::default();
-        let val = Value::from_f64(context.inner(), f64::INFINITY)?;
+        let val = context.value_from_f64(f64::INFINITY)?;
         let mut deserializer = ValueDeserializer::from_value(val)?;
 
         let result = f64::deserialize(&mut deserializer)?;
@@ -452,7 +452,7 @@ mod tests {
     #[test]
     fn test_negative_infinity() -> Result<()> {
         let context = Context::default();
-        let val = Value::from_f64(context.inner(), f64::NEG_INFINITY)?;
+        let val = context.value_from_f64(f64::NEG_INFINITY)?;
         let mut deserializer = ValueDeserializer::from_value(val)?;
 
         let result = f64::deserialize(&mut deserializer)?;

--- a/crates/core/src/serialize/ser.rs
+++ b/crates/core/src/serialize/ser.rs
@@ -19,8 +19,8 @@ impl<'c> Serializer<'c> {
     pub fn from_context(context: &'c Context) -> Result<Self> {
         Ok(Self {
             context,
-            value: Value::undefined(context.inner())?,
-            key: Value::undefined(context.inner())?,
+            value: context.undefined_value()?,
+            key: context.undefined_value()?,
         })
     }
 }
@@ -46,7 +46,7 @@ impl<'a> ser::Serializer for &'a mut Serializer<'_> {
     }
 
     fn serialize_i32(self, v: i32) -> Result<()> {
-        self.value = Value::from_i32(self.context.inner(), v)?;
+        self.value = self.context.value_from_i32(v)?;
         Ok(())
     }
 
@@ -75,12 +75,12 @@ impl<'a> ser::Serializer for &'a mut Serializer<'_> {
     }
 
     fn serialize_f64(self, v: f64) -> Result<()> {
-        self.value = Value::from_f64(self.context.inner(), v)?;
+        self.value = self.context.value_from_f64(v)?;
         Ok(())
     }
 
     fn serialize_bool(self, b: bool) -> Result<()> {
-        self.value = Value::from_bool(self.context.inner(), b)?;
+        self.value = self.context.value_from_bool(b)?;
 
         Ok(())
     }
@@ -90,7 +90,7 @@ impl<'a> ser::Serializer for &'a mut Serializer<'_> {
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
-        self.value = Value::from_str(self.context.inner(), v)?;
+        self.value = self.context.value_from_str(v)?;
         Ok(())
     }
 
@@ -99,7 +99,7 @@ impl<'a> ser::Serializer for &'a mut Serializer<'_> {
     }
 
     fn serialize_unit(self) -> Result<()> {
-        self.value = Value::null(self.context.inner())?;
+        self.value = self.context.null_value()?;
         Ok(())
     }
 
@@ -131,7 +131,7 @@ impl<'a> ser::Serializer for &'a mut Serializer<'_> {
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
-        self.value = Value::array(self.context.inner())?;
+        self.value = self.context.array_value()?;
         Ok(self)
     }
 
@@ -148,7 +148,7 @@ impl<'a> ser::Serializer for &'a mut Serializer<'_> {
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
-        self.value = Value::object(self.context.inner())?;
+        self.value = self.context.object_value()?;
         Ok(self)
     }
 
@@ -186,7 +186,7 @@ impl<'a> ser::Serializer for &'a mut Serializer<'_> {
     where
         T: ?Sized + Serialize,
     {
-        let object = Value::object(self.context.inner())?;
+        let object = self.context.object_value()?;
         value.serialize(&mut *self)?;
         object.set_property(variant, &self.value)?;
         self.value = object;


### PR DESCRIPTION
Moves all the factory functions from `value` to `context`.