### PR TITLE
refactor: Refactor own properties

### DIFF
--- a/crates/core/src/js_binding/mod.rs
+++ b/crates/core/src/js_binding/mod.rs
@@ -1,4 +1,4 @@
 pub mod context;
 pub mod globals;
-pub mod own_properties;
+pub mod properties;
 pub mod value;

--- a/crates/core/src/js_binding/value.rs
+++ b/crates/core/src/js_binding/value.rs
@@ -1,4 +1,4 @@
-use super::own_properties::OwnProperties;
+use super::properties::Properties;
 use anyhow::{anyhow, Result};
 use quickjs_sys::{
     size_t as JS_size_t, JSContext, JSValue, JS_DefinePropertyValueStr,
@@ -80,12 +80,8 @@ impl Value {
         self.value
     }
 
-    pub fn inner_context(&self) -> *mut JSContext {
-        self.context
-    }
-
-    pub fn own_properties(&self) -> Result<OwnProperties> {
-        OwnProperties::from(self)
+    pub fn properties(&self) -> Result<Properties> {
+        Properties::new(self.context, self.value)
     }
 
     pub fn is_repr_as_f64(&self) -> bool {


### PR DESCRIPTION
- Construct own properties from a value relying on the underlying context and u64 value
- Rename own properties to properties
- Remove the `inner_context` from Value