### PR TITLE
Add tests for u8, u16, f32

### DIFF
--- a/crates/core/src/serialize/mod.rs
+++ b/crates/core/src/serialize/mod.rs
@@ -29,9 +29,13 @@ mod tests {
             Ok(expected == actual)
         }
 
-        fn test_f32(expected: f32) -> Result<bool> {
+        fn test_f32(expected: f32) -> quickcheck::TestResult {
+            if expected.is_nan() {
+                return quickcheck::TestResult::discard();
+            }
+
             let actual = do_roundtrip::<_, f32>(&expected);
-            Ok(expected == actual)
+            quickcheck::TestResult::from_bool(expected == actual)
         }
 
         fn test_i32(expected: i32) -> Result<bool> {


### PR DESCRIPTION
pretty self explanatory. u32 and bigger are not currently supported so we can't test theses just yet.