### PR TITLE
fix: Handle exceptions for functions that returns an error code

### DIFF
--- a/crates/core/src/js_binding/exception.rs
+++ b/crates/core/src/js_binding/exception.rs
@@ -1,9 +1,7 @@
-use std::fmt;
-use quickjs_sys::{
-    JSContext, JS_GetException, JS_IsError,
-};
-use anyhow::{Result, anyhow};
 use super::value::Value;
+use anyhow::{anyhow, Result};
+use quickjs_sys::{JSContext, JS_GetException, JS_IsError};
+use std::fmt;
 
 #[derive(Debug)]
 pub struct Exception {

--- a/crates/core/src/js_binding/mod.rs
+++ b/crates/core/src/js_binding/mod.rs
@@ -1,4 +1,4 @@
 pub mod context;
+pub mod exception;
 pub mod properties;
 pub mod value;
-pub mod exception;

--- a/crates/core/src/js_binding/properties.rs
+++ b/crates/core/src/js_binding/properties.rs
@@ -27,7 +27,7 @@ impl Properties {
 
         if ret < 0 {
             let exception = Exception::new(context)?;
-            return Err(exception.into_error())
+            return Err(exception.into_error());
         }
 
         Ok(Self {
@@ -117,6 +117,9 @@ mod tests {
         let context = Context::default();
         let val = context.value_from_i32(1_i32).unwrap();
         let err = val.properties().unwrap_err();
-        assert_eq!("Uncaught TypeError: not an object\n".to_string(), err.to_string());
+        assert_eq!(
+            "Uncaught TypeError: not an object\n".to_string(),
+            err.to_string()
+        );
     }
 }

--- a/crates/core/src/js_binding/value.rs
+++ b/crates/core/src/js_binding/value.rs
@@ -1,14 +1,13 @@
+use super::exception::Exception;
 use super::properties::Properties;
 use anyhow::{anyhow, Result};
 use quickjs_sys::{
     size_t as JS_size_t, JSContext, JSValue, JS_DefinePropertyValueStr,
-    JS_DefinePropertyValueUint32, JS_GetPropertyStr, JS_GetPropertyUint32,
-    JS_IsArray, JS_IsFloat64_Ext, JS_ToCStringLen2, JS_ToFloat64, JS_PROP_C_W_E,
-    JS_TAG_BOOL, JS_TAG_EXCEPTION, JS_TAG_INT, JS_TAG_NULL, JS_TAG_OBJECT, JS_TAG_STRING,
-    JS_TAG_UNDEFINED,
+    JS_DefinePropertyValueUint32, JS_GetPropertyStr, JS_GetPropertyUint32, JS_IsArray,
+    JS_IsFloat64_Ext, JS_ToCStringLen2, JS_ToFloat64, JS_PROP_C_W_E, JS_TAG_BOOL, JS_TAG_EXCEPTION,
+    JS_TAG_INT, JS_TAG_NULL, JS_TAG_OBJECT, JS_TAG_STRING, JS_TAG_UNDEFINED,
 };
 use std::ffi::CString;
-use super::exception::Exception;
 
 #[derive(Debug, Clone)]
 pub struct Value {
@@ -220,16 +219,26 @@ mod tests {
     fn test_value_set_property_returns_exception() {
         let ctx = Context::default();
         let val = ctx.value_from_i32(1337).unwrap();
-        let err = val.set_property("foo", ctx.value_from_str("hello").unwrap()).unwrap_err();
-        assert_eq!("Uncaught TypeError: not an object\n".to_string(), err.to_string());
+        let err = val
+            .set_property("foo", ctx.value_from_str("hello").unwrap())
+            .unwrap_err();
+        assert_eq!(
+            "Uncaught TypeError: not an object\n".to_string(),
+            err.to_string()
+        );
     }
 
     #[test]
     fn test_value_append_property_returns_exception() {
         let ctx = Context::default();
         let val = ctx.value_from_i32(1337).unwrap();
-        let err = val.append_property(ctx.value_from_str("hello").unwrap()).unwrap_err();
-        assert_eq!("Uncaught TypeError: not an object\n".to_string(), err.to_string());
+        let err = val
+            .append_property(ctx.value_from_str("hello").unwrap())
+            .unwrap_err();
+        assert_eq!(
+            "Uncaught TypeError: not an object\n".to_string(),
+            err.to_string()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://github.com/Shopify/script-service/issues/3625.

Some functions in Quickjs returns a `c_int` with an error code. Since this could differ on a per-function basis (it currently isn't, but it's easier to modelize it that way), methods like `set_property`, `append_property` and `properties` checks if the return `value < 0` and return an error if that's the case.

To do so, we are constructing an error by pulling the global exception state and creating an exception object.

I've also added a `new_unchecked` function on `Value`, otherwise it creates a never ending recursive function call.