### PR TITLE
feat: Add noop _start to make the generated binaries compatible with Node's WASI implementation

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -18,6 +18,10 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 static mut JS_CONTEXT: OnceCell<Context> = OnceCell::new();
 static mut ENTRYPOINT: (OnceCell<Value>, OnceCell<Value>) = (OnceCell::new(), OnceCell::new());
 
+#[cfg(not(test))]
+#[no_mangle]
+pub unsafe extern "C" fn _start() {}
+
 // TODO
 //
 // AOT validations:


### PR DESCRIPTION
Core and quickjs-sys are linked with `--no-entry` given that they are both libraries rather than binaries. Some WASI implementations require a `_start`export to be defined, like Node's. This change adds such export as an empty function and skips generating it within tests, as cargo wasi is generating the symbol.

This change makes modules generated by javy, compatible with https://github.com/Shopify/scriptsx