### PR TITLE
chore: Switch to github actions for CI and building binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  checks:
+    name: Tests + Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+       
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: 1.53.0
+          default: true
+          components: clippy, rustfmt
+
+      - name: Cargo Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo
+
+      - name: Cargo Target Cache
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-target
+
+      - name: Install wasmtime-cli
+        run: cargo install wasmtime-cli
+
+      - name: Install cargo-wasi
+        run: cargo install cargo-wasi
+
+      - name: Tests
+        run: make tests
+
+      - name: Lint
+        run: make fmt
+
+
+  

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publish
 
-on: push
+on: release
+  types: 
+    - created
 
 jobs:
   compile_core: 
@@ -36,15 +38,11 @@ jobs:
           - name: linux
             os: ubuntu-latest
             path: target/release/javy
-            asset_name: javy-x86_64-linux # TODO: append version
+            asset_name: javy-x86_64-linux-${{github.event.release.tag_name}}
           - name: macos
             os: macos-latest
             path: target/release/javy
-            asset_name: javy-x86_64-macos # TODO: append version
-          - name: windows
-            os: windows-latest
-            path: target\release\javy.exe
-            asset_name: javy-x86_64-windows # TODO: append version
+            asset_name: javy-x86_64-macos-${{github.event.release.tag_name}}
 
     steps:
       - uses: actions/checkout@v1
@@ -65,15 +63,21 @@ jobs:
           toolchain: 1.53.0
           default: true
 
-          
-      - name: Build CLI
+      - name: Build CLI ${{ matrix.os }}
         env:
           JAVY_ENGINE_PATH: javy_core.wasm
         run: cargo build --release --package javy
 
-      - name: Upload CLI binary to artifacts
-        uses: actions/upload-artifact@v2
-        with: 
-          name: ${{ matrix.asset_name }}
-          path: ${{ matrix.path }} 
+      - name: Archive assets
+        uses: thedoctor0/zip-release@master
+        with:
+          type: 'zip'
+          filename: ${{ matrix.asset_name }}.zip
+          path: ${{ matrix.path }}
 
+      - name: Upload assets to release
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./${{ matrix.asset_name }}.zip
+          asset_name: ${{ matrix.asset_name }}.zip

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -25,8 +25,9 @@ fn stub_engine_for_clippy() {
 fn copy_engine_binary() {
     let override_engine_path = env::var("JAVY_ENGINE_PATH");
     let is_override = override_engine_path.is_ok();
-    let mut engine_path =
-        PathBuf::from(override_engine_path.unwrap_or(env::var("CARGO_MANIFEST_DIR").unwrap()));
+    let mut engine_path = PathBuf::from(
+        override_engine_path.unwrap_or_else(|_| env::var("CARGO_MANIFEST_DIR").unwrap()),
+    );
 
     if !is_override {
         engine_path.pop();


### PR DESCRIPTION
This PR sets the base to build automated binary generation per release, per operating system. As of this PR, I'm building `x86_64` for linux (Ubuntu) and MacOS. 


I tried building Windows and even though it works, when executing Javy, I'm getting an error that I don't fully understand:

<details>
<img width="1218" alt="Screen Shot 2021-10-04 at 1 26 50 PM" src="https://user-images.githubusercontent.com/1423601/135896630-17d3ef1a-0dba-4b90-a649-8847409fb9f4.png">

It seems like pre-opening directories is not working as it should.
</details>

I'd like to merge this PR as it is since it is a good start to have an automated build pipeline, it also unlocks value for beta purposes as we'd be able to give partners in the beta access to binaries for linux and Mac. Support for windows and M1 should definitely be added before GA (cc/ @reconbot)

An example of the built artifacts can be found here https://github.com/Shopify/javy/actions/runs/1303432858

I'm going to allocate a small portion of my time to see if I can get to the root cause of the failures in Windows.


This change also swaps Buildkite for Github Actions which is the recommended approach for open source repos. Once this is merged I'll remove the Buildkite pipeline in a follow up PR (to make sure they are equivalent)