### PR TITLE
feat: Add strip passes to remove debug information

### DIFF
--- a/crates/cli/src/opt.rs
+++ b/crates/cli/src/opt.rs
@@ -37,8 +37,8 @@ impl<'a> Optimizer<'a> {
 
         if self.optimize {
             let codegen_cfg = CodegenConfig {
-                optimization_level: 3, // aggresively optimize for speed
-                shrink_level: 0,       // do not attempt to optimize for size at performance costs
+                optimization_level: 3, // Aggressively optimize for speed.
+                shrink_level: 0,       // Don't optimize for size at the expense of performance.
                 debug_info: false,
             };
 


### PR DESCRIPTION
Follow up to https://github.com/Shopify/javy/pull/54

This PR runs the custom `strip` pass on top of binaryen's default passes. This restores the previous binary size of 1MB:

```sh
twiggy top -n 20  build/index.wasm                                                                                              20:24:05
 Shallow Bytes │ Shallow % │ Item
───────────────┼───────────┼─────────────────────
         41184 ┊     4.04% ┊ code[375]
         26104 ┊     2.56% ┊ code[749]
         14166 ┊     1.39% ┊ code[761]
         13257 ┊     1.30% ┊ code[593]
         13017 ┊     1.28% ┊ code[741]
         10227 ┊     1.00% ┊ code[759]
         10133 ┊     0.99% ┊ code[746]
          9805 ┊     0.96% ┊ code[748]
          8723 ┊     0.86% ┊ code[1124]
          8319 ┊     0.82% ┊ data[363]
          8183 ┊     0.80% ┊ code[218]
          8105 ┊     0.80% ┊ code[752]
          7668 ┊     0.75% ┊ data[3818]
          6531 ┊     0.64% ┊ code[1083]
          6029 ┊     0.59% ┊ code[349]
          5549 ┊     0.54% ┊ code[314]
          5547 ┊     0.54% ┊ code[662]
          5371 ┊     0.53% ┊ code[736]
          4970 ┊     0.49% ┊ code[395]
          4962 ┊     0.49% ┊ code[568]
        801294 ┊    78.62% ┊ ... and 7003 more.
       1019144 ┊   100.00% ┊ Σ [7023 Total Rows]
````