### PR TITLE
feat: Windows support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,11 +38,15 @@ jobs:
           - name: linux
             os: ubuntu-latest
             path: target/release/javy
-            asset_name: javy-x86_64-linux-${{github.event.release.tag_name}}
+            asset_name: javy-x86_64-linux-${{ github.event.release.tag_name }}
           - name: macos
             os: macos-latest
             path: target/release/javy
-            asset_name: javy-x86_64-macos-${{github.event.release.tag_name}}
+            asset_name: javy-x86_64-macos-${{ github.event.release.tag_name }}
+          - name: windows
+            os: windows-latest
+            path: target\release\javy.exe
+            asset_name: javy-x86_64-windows-${{ github.event.release.tag_name }}
 
     steps:
       - uses: actions/checkout@v1

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install:
 	cargo install --path crates/cli
 
 cli: core
-		cd crates/cli && cargo build && cd -
+		cd crates/cli && cargo build --release && cd -
 
 check-benchmarks:
 		cd crates/benchmarks \


### PR DESCRIPTION
This commit ensures Windows support.

As of rust 1.3x fs::canonicalize  returns Windows [NT UNC paths](https://github.com/rust-lang/rust/issues/42869)
(\\?\C:\foo) which are not gracefully handled by all rust/windows versions.

This change ensures windows support by relying on stdin rather than passing files around, this removes the need to handle UNC paths in windows. 


<details>

![VirtualBox_WinDev2108Eval_06_10_2021_10_34_43](https://user-images.githubusercontent.com/1423601/136229652-492c3e4a-2c08-4c28-8286-7228183abbfd.png)

</details>