### PR TITLE
Update publish.yml to archive assets with gzip

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
         run: cargo build --release --package javy
 
       - name: Archive assets
-        run: gzip -c ${{ matrix.path }} > ${{ matrix.asset_name }}.gz
+        run: gzip -k -f ${{ matrix.path }} && mv ${{ matrix.path }}.gz ${{ matrix.asset_name }}.gz
 
       - name: Upload assets to artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Part of https://github.com/Shopify/script-service/issues/3718

In the CLI, it is easier to use gzip that zip for archiving files. Ruby has a native gzip library, whereas we would have to use system calls or a gem (which the CLI doesn't support). The extensions team has already done this and tested their approach in both mac and windows.

Instead of zipping the entire `targets/release/javy` path including the folders, we now gzip only `javy`. 

[Here](https://github.com/Shopify/javy/actions/runs/1370238288) is an example build that I triggered. Note that from that example build I omitted windows because it was taking too long, and the file names/extensions aren't changed. 