### PR TITLE
Make serde code private to crate

### DIFF
--- a/crates/quickjs-wasm-rs/src/lib.rs
+++ b/crates/quickjs-wasm-rs/src/lib.rs
@@ -3,8 +3,6 @@ mod serialize;
 
 pub use crate::js_binding::context::Context;
 pub use crate::js_binding::value::Value;
-pub use crate::serialize::de::Deserializer;
-pub use crate::serialize::ser::Serializer;
 
 #[cfg(feature = "messagepack")]
 pub mod messagepack;

--- a/crates/quickjs-wasm-rs/src/messagepack.rs
+++ b/crates/quickjs-wasm-rs/src/messagepack.rs
@@ -1,4 +1,6 @@
-use crate::{Context, Deserializer, Serializer, Value};
+use crate::serialize::de::Deserializer;
+use crate::serialize::ser::Serializer;
+use crate::{Context, Value};
 use anyhow::Result;
 
 pub fn transcode_input(context: &Context, bytes: &[u8]) -> Result<Value> {


### PR DESCRIPTION
I realized when I was writing the docs that I had neglected to remove some temporary code while extracting the serialization logic from the core crate. This fixes that.