### PR TITLE
Flush to stdout in engine.store

### DIFF
--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -32,6 +32,7 @@ pub fn store(bytes: &[u8]) -> Result<()> {
 
     let mut handle = stdout();
     handle.write_all(bytes)?;
+    handle.flush()?;
 
     Ok(())
 }


### PR DESCRIPTION
This guarantees that the output of the script reaches stdout.

Was encountering a bug where the result of the script wasn't always flushed to stdout when the script result was extremely small like a single digit integer. 