### PR TITLE
Move release profile settings to workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,7 @@ members = [
   "crates/core",
   "crates/cli",
 ]
+
+[profile.release]
+lto = true
+opt-level = 3

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,9 +17,5 @@ wee_alloc = "0.4.5"
 serde_json = { version = "1", optional = true }
 once_cell = "1.4.0"
 
-[profile.release]
-lto = true
-opt-level = 3
-
 [features]
 json-io = ["serde_json"]


### PR DESCRIPTION
This should fix a small bug where profile configurations weren't being picked up as expected.

As to why this works, from [the Cargo docs](https://doc.rust-lang.org/cargo/reference/profiles.html):
> Cargo only looks at the profile settings in the Cargo.toml manifest at the root of the workspace. Profile settings defined in dependencies will be ignored.

Did a quick size check and `javy_core.wasm` shrank from 2.7M to 1.3M with a very basic JS Wasm module shrank from 979K to 968K.