### PR TITLE
Run release workflow on `published`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   release:
     types:
-      - created
+      - published
 
 jobs:
   compile_core:

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ For more information on the commands you can run `javy --help`
 
 1. Create a tag for the new version like `v0.2.0`
 ```
-git tag tag v0.2.0
+git tag v0.2.0
 git push origin --tags
 ```
-2. Create a new release from the new tag in github [here](https://github.com/Shopify/javy/releases/new)
-3. Github action will trigger for `publish.yml` and create the artifacts for downloading. However this does not currently support `arm-macos`, ie. M1 Macs.
-4. Manually build this on a m1 mac 
+2. Create a new release from the new tag in github [here](https://github.com/Shopify/javy/releases/new).
+3. A GitHub Action will trigger for `publish.yml` when a release is published ([i.e. it doesn't run on drafts](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#:~:text=created%2C%20edited%2C%20or%20deleted%20activity%20types%20for%20draft%20releases)), creating the artifacts for downloading. However this does not currently support `arm-macos`, ie. M1 Macs.
+4. Manually build this on a m1 mac
 
 ```
 gzip -k -f target/release/javy && mv target/release/javy.gz javy-arm-macos-v0.2.0.gz


### PR DESCRIPTION
I was confused as to why the GitHub workflow wasn't triggered on the
Javy 0.3.0 release, so I figured I'd try to make things a little better.

With this, the publish workflow will (should?) run when a draft
release is published.

I've also updated the README to mention that.

---

The PR has 2 commits. The first one is only linter fixes to `publish.yml`,
feel free to gloss over it.