### PR TITLE
chore: Use stable Rust by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: 1.53.0
+          toolchain: stable
           default: true
           components: clippy, rustfmt
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: 1.53.0
+          toolchain: stable
           target: wasm32-wasi
           default: true
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Javy is a beta project and will be under major development. We welcome feedback,
 
 ## Build
 
-- Rust v1.53.0
 - [rustup](https://rustup.rs/)
+- Stable Rust (`rustup install stable && rustup default stable`)
 - wasm32-wasi, can be installed via `rustup target add wasm32-wasi`
 - cmake, depending on your operating system and architecture, it might not be
   installed by default. On Mac it can be installed with `homebrew` via `brew


### PR DESCRIPTION
Our CI/Publish workflows currently test against Rust 1.53.0. This change makes it so we always test against stable.