### PR TITLE
remove case conversion from `serialize` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,12 +326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "cpp_demangle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,7 +1159,6 @@ name = "quickjs-wasm-rs"
 version = "0.1.2"
 dependencies = [
  "anyhow",
- "convert_case",
  "once_cell",
  "quickcheck",
  "quickjs-wasm-sys",

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -16,7 +16,6 @@ rmp-serde = { version = "^0.15", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 serde-transcode = { version = "1.1", optional = true }
-convert_case = "0.4"
 once_cell = "1.16"
 
 [dev-dependencies]

--- a/crates/quickjs-wasm-rs/src/serialize/mod.rs
+++ b/crates/quickjs-wasm-rs/src/serialize/mod.rs
@@ -3,12 +3,10 @@ pub mod err;
 pub mod ser;
 
 use super::js_binding::value::Value;
-use convert_case::{Case, Casing};
 
-fn sanitize_key(v: &Value, case: Case) -> anyhow::Result<String> {
+fn as_key(v: &Value) -> anyhow::Result<&str> {
     if v.is_str() {
         let v = v.as_str()?;
-        let v = v.to_case(case);
         Ok(v)
     } else {
         anyhow::bail!("map keys must be a string")


### PR DESCRIPTION
Per the discussion in #143, we've decided case conversion that was being done in `sanitize_key` is no longer desirable.  This commit removes it.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>