### PR TITLE
Non-0 exit code when WPT fails and integrate into make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,12 @@ test-cli: core
 				&& cargo test --release \
 				&& cd -
 
+test-wpt: cli
+		cd wpt \
+			&& npm install \
+			&& npm test \
+			&& cd -
+
 tests: test-quickjs-wasm-rs test-core test-cli
 
 fmt: fmt-quickjs-wasm-sys fmt-quickjs-wasm-rs fmt-core fmt-cli

--- a/wpt/package-lock.json
+++ b/wpt/package-lock.json
@@ -1,0 +1,63 @@
+{
+  "name": "wpt",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wpt",
+      "version": "0.0.1",
+      "devDependencies": {
+        "rollup": "^3.5.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.3.tgz",
+      "integrity": "sha512-7e68MQbAWCX6mI4/0lG1WHd+NdNAlVamg0Zkd+8LZ/oXojligdGnCNyHlzXqXCZObyjs5FRc3AH0b17iJESGIQ==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    }
+  },
+  "dependencies": {
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "rollup": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.3.tgz",
+      "integrity": "sha512-7e68MQbAWCX6mI4/0lG1WHd+NdNAlVamg0Zkd+8LZ/oXojligdGnCNyHlzXqXCZObyjs5FRc3AH0b17iJESGIQ==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
+    }
+  }
+}

--- a/wpt/reporter.js
+++ b/wpt/reporter.js
@@ -1,3 +1,5 @@
+export let failedTestCount = 0;
+
 export function resultReporter(test) {
   // No logging on success;
   if (test.status === 0) return;
@@ -16,4 +18,5 @@ export function resultReporter(test) {
   console.log("[FAIL]", test.name);
   console.log(test.message);
   console.log(test.stack);
+  failedTestCount += 1;
 }

--- a/wpt/runner.js
+++ b/wpt/runner.js
@@ -1,6 +1,6 @@
 import "./global_fix.js";
 import "./upstream/resources/testharness.js";
-import { resultReporter } from "./reporter.js";
+import { failedTestCount, resultReporter } from "./reporter.js";
 
 // This is not a normal import and will be handled
 // by a custom rollup plugin in `rollup.config.js`.
@@ -14,6 +14,11 @@ function main() {
     console.log("[FAIL]");
     console.log(e);
   }
+
+  if (failedTestCount > 0) {
+    throw new Error(`${failedTestCount} web platform tests failed`);
+  }
+
   return new ArrayBuffer();
 }
 Shopify = { main };


### PR DESCRIPTION
I want a non-zero exit code when at least one test fails so we can hook this into a CI process and have CI fail when at least one test fails. I also want to hook this into `make` so it's consistent with our other test suites. The throw that happens occurs after the full suite has run so we should see all failures when there are failing test cases.

I'm also adding the `package-lock.json`. I'm open to adding it to a `.gitignore` if we don't want this committed for whatever reason.

I'm not adding this to `make tests` until the tests all pass and we currently have six failures.

The error message when there's a failure isn't the prettiest but that can be improved later:
```
thread 'main' panicked at 'Uncaught Error: 6 web platform tests failed
    at main (script.js:5072)
', crates/core/src/main.rs:57:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: failed to run main module `bundle.wasm`

Caused by:
    0: failed to invoke command default
    1: wasm trap: wasm `unreachable` instruction executed
       wasm backtrace:
           0: 0xe4b4 - <unknown>!<wasm function 248>
           1: 0xdadb - <unknown>!<wasm function 247>
           2: 0xda27 - <unknown>!<wasm function 246>
           3: 0x3055 - <unknown>!<wasm function 71>
           4: 0x129b - <unknown>!<wasm function 38>
           5: 0xa715 - <unknown>!<wasm function 171>
           6: 0x9739 - <unknown>!<wasm function 165>
           7: 0x923e - <unknown>!<wasm function 164>
           8: 0xb2744 - <unknown>!<wasm function 1095>
       ```