### PR TITLE
Bump quickjs-wasm-rs version so we can publish updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-rs"
-version = "0.1.2"
+version = "0.1.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
I want to publish a new version of the `quickjs-wasm-rs` crate to crates.io so I need to bump the version first.