### PR TITLE
Handle BOM in TextDecoder

### DIFF
--- a/crates/core/prelude/text-encoding.js
+++ b/crates/core/prelude/text-encoding.js
@@ -35,8 +35,7 @@
                 throw new TypeError("The provided value is not of type '(ArrayBuffer or ArrayBufferView)'");
             }
 
-            // ignoreBOM does not appear to change behaviour for UTF-8
-            return __javy_decodeUtf8BufferToString(input, byteOffset, byteLength, this.fatal);
+            return __javy_decodeUtf8BufferToString(input, byteOffset, byteLength, this.fatal, this.ignoreBOM);
         }
     }
 

--- a/wpt/test_spec.js
+++ b/wpt/test_spec.js
@@ -25,10 +25,10 @@ export default [
   // { // FIXME need to add streaming support
   //   testFile: "upstream/encoding/textdecoder-arguments.any.js",
   // },
-  // { // FIXME need to fix failing BOM test
-  //   testFile: "upstream/encoding/textdecoder-byte-order-marks.any.js",
-  //   ignoredTests: ["Byte-order marks: utf-16le", "Byte-order marks: utf-16be"],
-  // },
+  {
+    testFile: "upstream/encoding/textdecoder-byte-order-marks.any.js",
+    ignoredTests: ["Byte-order marks: utf-16le", "Byte-order marks: utf-16be"],
+  },
   {
     testFile: "upstream/encoding/textdecoder-eof.any.js",
     ignoredTests: ["/stream: true/"],
@@ -40,10 +40,10 @@ export default [
   //   testFile: "upstream/encoding/textdecoder-fatal.any.js",
   //   ignoredTests: ["Fatal flag: utf-16le - truncated code unit"],
   // },
-  // { // FIXME need to fix failing BOM test
-  //   testFile: "upstream/encoding/textdecoder-ignorebom.any.js",
-  //   ignoredTests: ["/utf-16/"]
-  // },
+  {
+    testFile: "upstream/encoding/textdecoder-ignorebom.any.js",
+    ignoredTests: ["/utf-16/"]
+  },
   // { // FIXME script importing isn't working
   //   testFile: "upstream/encoding/textdecoder-labels.any.js",
   // },


### PR DESCRIPTION
Fixes failing WPT suites for handling a BOM in `TextDecoder`.