### PR TITLE
Remove `ls` step from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,10 +76,6 @@ jobs:
           name: provider
           path: target/wasm32-wasi/release/
 
-      - name: ls
-        run: ls -R
-        working-directory: crates/cli/
-
       - name: Build CLI ${{ matrix.os }}
         env:
           JAVY_ENGINE_PATH: javy_core.wasm


### PR DESCRIPTION
I don't think we need this step