### PR TITLE
Switch from unmaintained GH action to gh release upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,14 +95,9 @@ jobs:
           path: ${{ matrix.asset_name }}.gz
 
       - name: Upload assets to release
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./${{ matrix.asset_name }}.gz
-          asset_name: ${{ matrix.asset_name }}.gz
-          asset_content_type: application/gzip
+        run: gh release upload ${{ github.event.release.tag_name }} ${{ matrix.asset_name }}.gz
 
       - name: Generate asset hash
         run: ${{ matrix.shasum_cmd }} ${{ matrix.asset_name }}.gz | awk '{ print $1 }' > ${{ matrix.asset_name }}.gz.sha256
@@ -114,11 +109,6 @@ jobs:
           path: ${{ matrix.asset_name }}.gz.sha256
 
       - name: Upload asset hash to release
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./${{ matrix.asset_name }}.gz.sha256
-          asset_name: ${{ matrix.asset_name }}.gz.sha256
-          asset_content_type: plain/text
+        run: gh release upload ${{ github.event.release.tag_name }} ${{ matrix.asset_name }}.gz.sha256


### PR DESCRIPTION
[actions/upload-release-asset](https://github.com/actions/upload-release-asset) is unmaintained and currently returning deprecation notices indicating it will stop working in a few months. I've opted to use the Github CLI built-in to Github actions to attach the assets to the release instead.