### PR TITLE
Enable dependabot

### DIFF
--- a/.github/.dependabot
+++ b/.github/.dependabot
@@ -3,19 +3,19 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 100
   - package-ecosystem: npm
     directory: "/npm/javy"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 100
   - package-ecosystem: npm
     directory: "/npm/javy-cli"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 100
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
Enabling dependabot so we're better able to keep up with new versions of dependencies.

I don't see a way to test the configuration unfortunately. I also confirmed that the Github Actions directory needs to be set to `/` according to https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory.