### PR TITLE
Compile bytecode as module instead of as global

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn compile_src(js_src_ptr: *const u8, js_src_len: usize) -
     // Use fresh context to avoid depending on Wizened context
     let context = Context::default();
     let js_src = str::from_utf8(slice::from_raw_parts(js_src_ptr, js_src_len)).unwrap();
-    let bytecode = context.compile_global("function.mjs", js_src).unwrap();
+    let bytecode = context.compile_module("function.mjs", js_src).unwrap();
     let bytecode_len = bytecode.len();
     // We need the bytecode buffer to live longer than this function so it can be read from memory
     let bytecode_ptr = Box::leak(bytecode.into_boxed_slice()).as_ptr();

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -15,7 +15,7 @@ pub extern "C" fn init() {
 
     let mut contents = String::new();
     io::stdin().read_to_string(&mut contents).unwrap();
-    let bytecode = context.compile_global("function.mjs", &contents).unwrap();
+    let bytecode = context.compile_module("function.mjs", &contents).unwrap();
 
     unsafe {
         CONTEXT.set(context).unwrap();


### PR DESCRIPTION
We want to offer the option to compile bytecode as a JS module instead of using the JavaScript global environment and to switch Javy to use a JS module.

I'm keeping the existing `compile_global` function in `quickjs-wasm-rs` and having it compile to use the global environment and adding a `compile_module` function to compile to a JS module.

I've tweaked the tests a bit too. `await` doesn't behave that differently between global and module but importing a module does. So I've tweaked the tests to use that as an example of a syntax error in global mode and a different error in module mode. I've also added a test to check that module compilation doesn't leak variables into the global object.