### PR TITLE
Remove some console.error calls

### DIFF
--- a/npm/javy-cli/index.js
+++ b/npm/javy-cli/index.js
@@ -14,15 +14,10 @@ const NAME = "javy";
 async function main() {
 	const version = await getDesiredVersionNumber();
 	if (!(await isBinaryDownloaded(version))) {
-		console.error(`${NAME} ${version} is not available locally.`);
 		if (process.env.FORCE_FROM_SOURCE) {
-			console.error(`Building ${NAME} from source...`);
 			await buildBinary();
-			console.error(`Done.`);
 		} else {
-			console.error(`${NAME} needs to be downloaded...`);
 			await downloadBinary(version);
-			console.error(`Done.`);
 		}
 	}
 	try {
@@ -94,8 +89,7 @@ async function getDesiredVersionNumber() {
 	);
 	if (resp.status != 302) {
 		throw Error(
-			`Could not determine latest release using the GitHub (Status code ${
-				resp.status
+			`Could not determine latest release using the GitHub (Status code ${resp.status
 			}): ${await resp.text().catch(() => "<No error message>")}`
 		);
 	}

--- a/npm/javy-cli/package.json
+++ b/npm/javy-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javy-cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Apparently some of these `console.error` calls are causing issues with the Shopify CLI and we don't really need them so let's remove them.