### PR TITLE
Use name in build assets matrix job

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -77,7 +77,7 @@ jobs:
         run: gh release upload ${{ github.event.release.tag_name }} javy-quickjs_provider.wasm.gz.sha256
 
   compile_cli:
-    name: Compile CLI
+    name: Compile CLI - ${{ matrix.name }}
     needs: compile_core
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
The existing names for the matrix jobs when compiling the CLI are pretty long. I'm going to see if this helps shorten them to a reasonable size.