### PR TITLE
Fix javy NPM package npm test and run in CI

### DIFF
--- a/.github/workflows/ci-npm-javy.yml
+++ b/.github/workflows/ci-npm-javy.yml
@@ -1,0 +1,29 @@
+name: javy NPM package CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: javy_npm_test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install wasmtime-cli
+        env:
+          WASMTIME_VERSION: 6.0.1
+        run: |
+          wget -nv 'https://github.com/bytecodealliance/wasmtime/releases/download/v${{ env.WASMTIME_VERSION }}/wasmtime-v${{ env.WASMTIME_VERSION }}-x86_64-linux.tar.xz' -O /tmp/wasmtime.tar.xz
+          mkdir /tmp/wasmtime
+          tar xvf /tmp/wasmtime.tar.xz --strip-components=1 -C /tmp/wasmtime
+          echo "/tmp/wasmtime" >> $GITHUB_PATH
+
+      - run: npm install
+        working-directory: npm/javy
+
+      - run: npm test
+        working-directory: npm/javy

--- a/npm/javy/package-lock.json
+++ b/npm/javy/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@rollup/plugin-node-resolve": "^15.0.1",
+				"javy-cli": "^0.1.4",
 				"rollup": "^3.7.4",
 				"rollup-plugin-swc": "^0.2.1",
 				"typescript": "^4.9.4",
@@ -451,6 +452,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/cachedir": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
+			"integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/code-block-writer": {
 			"version": "11.0.3",
 			"resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
@@ -474,6 +484,15 @@
 			"optional": true,
 			"engines": {
 				"node": "^12.20.0 || >=14"
+			}
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/debug": {
@@ -582,6 +601,29 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -592,6 +634,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
 			}
 		},
 		"node_modules/fs-extra": {
@@ -730,6 +784,19 @@
 				"node": ">=0.12.0"
 			}
 		},
+		"node_modules/javy-cli": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/javy-cli/-/javy-cli-0.1.4.tgz",
+			"integrity": "sha512-cSafsb8gXP4BnwjpogfU04ZUnbJ/uxPLzIc2dz6VeG70JB3yqdOhlf1r4cXlK7aloijs5vgz70ty4ogC0YEqpw==",
+			"dev": true,
+			"dependencies": {
+				"cachedir": "^2.3.0",
+				"node-fetch": "^3.2.10"
+			},
+			"bin": {
+				"javy": "index.js"
+			}
+		},
 		"node_modules/jju": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
@@ -852,6 +919,43 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+			"integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+			"dev": true,
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
 			}
 		},
 		"node_modules/path-browserify": {
@@ -1234,6 +1338,15 @@
 				"vite": ">=2.9.0"
 			}
 		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -1606,6 +1719,12 @@
 			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
 			"dev": true
 		},
+		"cachedir": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
+			"integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
+			"dev": true
+		},
 		"code-block-writer": {
 			"version": "11.0.3",
 			"resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
@@ -1624,6 +1743,12 @@
 			"integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
 			"dev": true,
 			"optional": true
+		},
+		"data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true
 		},
 		"debug": {
 			"version": "4.3.4",
@@ -1710,6 +1835,16 @@
 				"reusify": "^1.0.4"
 			}
 		},
+		"fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"requires": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			}
+		},
 		"fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1717,6 +1852,15 @@
 			"dev": true,
 			"requires": {
 				"to-regex-range": "^5.0.1"
+			}
+		},
+		"formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"requires": {
+				"fetch-blob": "^3.1.2"
 			}
 		},
 		"fs-extra": {
@@ -1818,6 +1962,16 @@
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true
 		},
+		"javy-cli": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/javy-cli/-/javy-cli-0.1.4.tgz",
+			"integrity": "sha512-cSafsb8gXP4BnwjpogfU04ZUnbJ/uxPLzIc2dz6VeG70JB3yqdOhlf1r4cXlK7aloijs5vgz70ty4ogC0YEqpw==",
+			"dev": true,
+			"requires": {
+				"cachedir": "^2.3.0",
+				"node-fetch": "^3.2.10"
+			}
+		},
 		"jju": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
@@ -1915,6 +2069,23 @@
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
 			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
 			"dev": true
+		},
+		"node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"dev": true
+		},
+		"node-fetch": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+			"integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+			"dev": true,
+			"requires": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			}
 		},
 		"path-browserify": {
 			"version": "1.0.1",
@@ -2138,6 +2309,12 @@
 				"kolorist": "^1.6.0",
 				"ts-morph": "^16.0.0"
 			}
+		},
+		"web-streams-polyfill": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+			"dev": true
 		},
 		"yallist": {
 			"version": "4.0.0",

--- a/npm/javy/package.json
+++ b/npm/javy/package.json
@@ -22,11 +22,12 @@
 		}
 	},
 	"devDependencies": {
-		"vite": "^4.0.4",
-		"vite-plugin-dts": "^1.7.1",
-		"typescript": "^4.9.4",
 		"@rollup/plugin-node-resolve": "^15.0.1",
+		"javy-cli": "^0.1.4",
 		"rollup": "^3.7.4",
-		"rollup-plugin-swc": "^0.2.1"
+		"rollup-plugin-swc": "^0.2.1",
+		"typescript": "^4.9.4",
+		"vite": "^4.0.4",
+		"vite-plugin-dts": "^1.7.1"
 	}
 }


### PR DESCRIPTION
This applies a fix to the `javy` NPM package tests and runs them in CI.

I've opted to use the `javy-cli` package to download Javy rather than build it because this package hypothetically isn't tied to the version of Javy in `main` but rather to the last released version of Javy, there are a lot of build dependencies for Javy, and it takes a while to build. I could've included this package's tests in the main CI process but this seems like something that's easy to test in isolation outside of getting a build of Javy to test with.