### PR TITLE
chore(cli): Remove `which`, which is unused

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,6 @@ dependencies = [
  "wasmprinter",
  "wasmtime",
  "wasmtime-wasi",
- "which",
  "wizer",
 ]
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,7 +15,6 @@ experimental_event_loop = []
 
 [dependencies]
 wizer = "1.6.0"
-which = "4.2"
 structopt = "0.3"
 anyhow = { workspace = true }
 binaryen = { git = "https://github.com/pepyakin/binaryen-rs" }


### PR DESCRIPTION
I ran[ `cargo machete`](https://github.com/bnjbvr/cargo-machete) in our workspace and it detected this dependency as unused: 

```sh

❯ cargo machete
Analyzing dependencies of crates in this directory...
cargo-machete found the following unused dependencies in 
/src/github.com/Shopify/javy:
javy -- /src/github.com/Shopify/javy/crates/cli/Cargo.toml:
	which
Done!
```