### PR TITLE
Rename Context -> JSContextRef, Value -> JSValueRef

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "0.1.4"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ docs:
 	cargo doc --package=javy-core --open --target=wasm32-wasi
 
 test-quickjs-wasm-rs:
-	cargo wasi test --package=quickjs-wasm-rs --features json -- --nocapture
+	cargo wasi test --package=quickjs-wasm-rs --features json,messagepack -- --nocapture
 
 test-core:
 	cargo wasi test --package=javy-core -- --nocapture

--- a/crates/core/src/execution.rs
+++ b/crates/core/src/execution.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
-use quickjs_wasm_rs::Context;
+use quickjs_wasm_rs::JSContextRef;
 
-pub fn run_bytecode(context: &Context, bytecode: &[u8]) -> Result<()> {
+pub fn run_bytecode(context: &JSContextRef, bytecode: &[u8]) -> Result<()> {
     context.eval_binary(bytecode)?;
     if cfg!(feature = "experimental_event_loop") {
         context.execute_pending()?;

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -1,17 +1,17 @@
 use once_cell::sync::OnceCell;
-use quickjs_wasm_rs::Context;
+use quickjs_wasm_rs::JSContextRef;
 use std::io::{self, Read};
 use std::string::String;
 
 mod execution;
 mod globals;
 
-static mut CONTEXT: OnceCell<Context> = OnceCell::new();
+static mut CONTEXT: OnceCell<JSContextRef> = OnceCell::new();
 static mut BYTECODE: OnceCell<Vec<u8>> = OnceCell::new();
 
 #[export_name = "wizer.initialize"]
 pub extern "C" fn init() {
-    let context = Context::default();
+    let context = JSContextRef::default();
     globals::inject_javy_globals(&context, io::stderr(), io::stderr()).unwrap();
 
     let mut contents = String::new();

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-rs"
-version = "0.1.4"
+version = "1.0.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/quickjs-wasm-rs/README.md
+++ b/crates/quickjs-wasm-rs/README.md
@@ -4,12 +4,12 @@ High-level bindings and serializers for a Wasm build of QuickJS.
 
 ## Bindings
 
-`Context` corresponds to a QuickJS `JSContext` and `Value` corresponds to a QuickJS `JSValue`.
+`JSContextRef` corresponds to a QuickJS `JSContext` and `JSValueRef` corresponds to a QuickJS `JSValue`.
 
 ```rust
-use quickjs_wasm_rs::Context;
+use quickjs_wasm_rs::JSContextRef;
 
-let mut context = Context::default();
+let mut context = JSContextRef::default();
 ```
 
 will create a new context.
@@ -17,19 +17,19 @@ will create a new context.
 ## Serializers
 
 This crate provides optional transcoding features for converting between
-serialization formats and `Value`:
+serialization formats and `JSValueRef`:
 - `messagepack` provides `quickjs_wasm_rs::messagepack` for msgpack, using `rmp_serde`.
 - `json` provides `quickjs_wasm_rs::json` for JSON, using `serde_json`.
 
 msgpack example:
 
 ```rust
-use quickjs_wasm_rs::{messagepack, Context, Value};
+use quickjs_wasm_rs::{messagepack, JSContextRef, JSValueRef};
 
-let context = Context::default();
+let context = JSContextRef::default();
 let input_bytes: &[u8] = ...;
 let input_value = messagepack::transcode_input(&context, input_bytes).unwrap();
-let output_value: Value = ...;
+let output_value: JSValueRef = ...;
 let output = messagepack::transcode_output(output_value).unwrap();
 ```
 

--- a/crates/quickjs-wasm-rs/src/js_binding/exception.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/exception.rs
@@ -1,4 +1,4 @@
-use super::value::Value;
+use super::value::JSValueRef;
 use anyhow::{anyhow, Result};
 use quickjs_wasm_sys::{JSContext, JS_GetException, JS_IsError};
 use std::fmt;
@@ -22,10 +22,10 @@ impl fmt::Display for Exception {
 impl Exception {
     pub(super) fn new(context: *mut JSContext) -> Result<Self> {
         let exception_value = unsafe { JS_GetException(context) };
-        Self::from(Value::new_unchecked(context, exception_value))
+        Self::from(JSValueRef::new_unchecked(context, exception_value))
     }
 
-    pub fn from(exception_obj: Value) -> Result<Self> {
+    pub fn from(exception_obj: JSValueRef) -> Result<Self> {
         let msg = exception_obj.as_str().map(ToString::to_string)?;
         let mut stack = None;
 

--- a/crates/quickjs-wasm-rs/src/json.rs
+++ b/crates/quickjs-wasm-rs/src/json.rs
@@ -1,16 +1,16 @@
 use crate::serialize::de::Deserializer;
 use crate::serialize::ser::Serializer;
-use crate::{Context, Value};
+use crate::{JSContextRef, JSValueRef};
 use anyhow::Result;
 
-pub fn transcode_input(context: &Context, bytes: &[u8]) -> Result<Value> {
+pub fn transcode_input(context: &JSContextRef, bytes: &[u8]) -> Result<JSValueRef> {
     let mut deserializer = serde_json::Deserializer::from_slice(bytes);
     let mut serializer = Serializer::from_context(context)?;
     serde_transcode::transcode(&mut deserializer, &mut serializer)?;
     Ok(serializer.value)
 }
 
-pub fn transcode_output(val: Value) -> Result<Vec<u8>> {
+pub fn transcode_output(val: JSValueRef) -> Result<Vec<u8>> {
     let mut output = Vec::new();
     let mut deserializer = Deserializer::from(val);
     let mut serializer = serde_json::Serializer::new(&mut output);

--- a/crates/quickjs-wasm-rs/src/lib.rs
+++ b/crates/quickjs-wasm-rs/src/lib.rs
@@ -1,10 +1,10 @@
 mod js_binding;
 mod serialize;
 
-pub use crate::js_binding::context::Context;
+pub use crate::js_binding::context::JSContextRef;
 pub use crate::js_binding::error::JSError;
 pub use crate::js_binding::exception::Exception;
-pub use crate::js_binding::value::Value;
+pub use crate::js_binding::value::JSValueRef;
 pub use crate::serialize::de::Deserializer;
 pub use crate::serialize::ser::Serializer;
 

--- a/crates/quickjs-wasm-rs/src/messagepack.rs
+++ b/crates/quickjs-wasm-rs/src/messagepack.rs
@@ -1,16 +1,16 @@
 use crate::serialize::de::Deserializer;
 use crate::serialize::ser::Serializer;
-use crate::{Context, Value};
+use crate::{JSContextRef, JSValueRef};
 use anyhow::Result;
 
-pub fn transcode_input(context: &Context, bytes: &[u8]) -> Result<Value> {
+pub fn transcode_input(context: &JSContextRef, bytes: &[u8]) -> Result<JSValueRef> {
     let mut deserializer = rmp_serde::Deserializer::from_read_ref(bytes);
     let mut serializer = Serializer::from_context(context)?;
     serde_transcode::transcode(&mut deserializer, &mut serializer)?;
     Ok(serializer.value)
 }
 
-pub fn transcode_output(val: Value) -> Result<Vec<u8>> {
+pub fn transcode_output(val: JSValueRef) -> Result<Vec<u8>> {
     let mut output = Vec::new();
     let mut deserializer = Deserializer::from(val);
     let mut serializer = rmp_serde::Serializer::new(&mut output);

--- a/crates/quickjs-wasm-rs/src/serialize/mod.rs
+++ b/crates/quickjs-wasm-rs/src/serialize/mod.rs
@@ -2,9 +2,9 @@ pub mod de;
 pub mod err;
 pub mod ser;
 
-use super::js_binding::value::Value;
+use super::js_binding::value::JSValueRef;
 
-fn as_key(v: &Value) -> anyhow::Result<&str> {
+fn as_key(v: &JSValueRef) -> anyhow::Result<&str> {
     if v.is_str() {
         let v = v.as_str()?;
         Ok(v)
@@ -17,7 +17,7 @@ fn as_key(v: &Value) -> anyhow::Result<&str> {
 mod tests {
     use super::de::Deserializer as ValueDeserializer;
     use super::ser::Serializer as ValueSerializer;
-    use crate::js_binding::context::Context;
+    use crate::js_binding::context::JSContextRef;
     use anyhow::Result;
     use quickcheck::quickcheck;
     use serde::de::DeserializeOwned;
@@ -269,7 +269,7 @@ mod tests {
         E: Serialize,
         A: DeserializeOwned,
     {
-        let context = Context::default();
+        let context = JSContextRef::default();
         let mut serializer = ValueSerializer::from_context(&context).unwrap();
         expected.serialize(&mut serializer).unwrap();
         let mut deserializer = ValueDeserializer::from(serializer.value);


### PR DESCRIPTION
Part of #295 

# Motivation

As we plan to introduce an new enum named `JSValue` (see #295), this rename will help us disambiguate things. It also helps clarify the responsibility of the type by making it more explicit that it’s simple a Wrapper/Ref.

So at the end of all the improvements, the available types would look something like this

- `enum JSValue`: A high level representation of `JSValue` with native rust types
- `JSValueRef`: Contains the raw pointer to a `quickjs_wasm_sys::JSValue`
- `JSContextRef`: Contains the raw pointer to a `quickjs_wasm_sys::JSContext`
- `quickjs_wasm_sys::JSValue`: The quickjs type
- `quickjs_wasm_sys::JSContext`: The quickjs type

# Regarding version
We decided to start using the suffix `alpha.x` to indicate a breaking change for when we pushing changes to the repo but have not published a new version to `crates.io` yet. So given this PR is a breaking change, I've set the new version to be `1.0.0-alpha.1` (assuming we are aligned that we are working towards a `1.0.0` release)