### PR TITLE
Run build-assets workflow less

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -12,11 +12,10 @@ on:
   release:
     types:
       - published
-  # Test on every CI run too
+  # Test on main
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   compile_core:


### PR DESCRIPTION
Stop running build-assets workflow on PRs. This should help us get changes merged more quickly.

Changes can still be tested ahead of time by following the instructions to fork to a personal org and creating a release. I tried experimenting with using the branch filter to see if naming the branch a particular way would get this to run but unfortunately that only looks at the name of the branch being merged _into_ instead of _from_. We could probably do something clever with a PR comment to trigger a run but that seems like more work than we'd like to do right now.