### PR TITLE
Update repo in javy-cli NPM package

### DIFF
--- a/npm/javy-cli/index.js
+++ b/npm/javy-cli/index.js
@@ -8,7 +8,7 @@ import * as stream from "stream";
 import fetch from "node-fetch";
 import cachedir from "cachedir";
 
-const REPO = "Shopify/javy";
+const REPO = "bytecodealliance/javy";
 const NAME = "javy";
 
 async function main() {

--- a/npm/javy-cli/package-lock.json
+++ b/npm/javy-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "javy-cli",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "javy-cli",
-      "version": "0.1.3",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "cachedir": "^2.3.0",

--- a/npm/javy-cli/package.json
+++ b/npm/javy-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javy-cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Have `javy-cli` download from the Bytecode Alliance's Javy repository. Also bumps the version to v0.1.5 since we'll need to publish this as an update.