### PR TITLE
quickjs-wasm-sys v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,7 +1459,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-sys"
-version = "0.1.2"
+version = "1.0.0"
 dependencies = [
  "bindgen",
  "cc",

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-sys = { version = "0.1.2", path = "../quickjs-wasm-sys" }
+quickjs-wasm-sys = { version = "1.0.0", path = "../quickjs-wasm-sys" }
 serde = { version = "1.0", features = ["derive"] }
 once_cell = "1.16"
 

--- a/crates/quickjs-wasm-sys/CHANGELOG.md
+++ b/crates/quickjs-wasm-sys/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## 1.0.0 - 2023-05-16
+
+No changes from 0.1.2. Just updating version to show we're confident in the existing bindings.

--- a/crates/quickjs-wasm-sys/Cargo.toml
+++ b/crates/quickjs-wasm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-sys"
-version = "0.1.2"
+version = "1.0.0"
 authors.workspace = true
 edition.workspace = true 
 license.workspace = true

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,9 +1,7 @@
 
 # cargo-vet audits file
 
-[audits]
-
 [[audits.quickjs-wasm-sys]]
-version = "1.0.0"
 who = "Jeff Charles <jeff.charles@shopify.com>"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
+version = "1.0.0"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2,3 +2,8 @@
 # cargo-vet audits file
 
 [audits]
+
+[[audits.quickjs-wasm-sys]]
+version = "1.0.0"
+who = "Jeff Charles <jeff.charles@shopify.com>"
+criteria = "safe-to-run"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -461,7 +461,7 @@ version = "1.0.3"
 criteria = "safe-to-run"
 
 [[exemptions.quickjs-wasm-sys]]
-version = "1.0.0"
+version = "0.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.quote]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -461,7 +461,7 @@ version = "1.0.3"
 criteria = "safe-to-run"
 
 [[exemptions.quickjs-wasm-sys]]
-version = "0.1.2"
+version = "1.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.quote]]


### PR DESCRIPTION
Cutting a v1.0.0 for `quickjs-wasm-sys` since we're confident in the bindings APIs.