### PR TITLE
Initialize random seed on first use of random

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,9 +755,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -1073,9 +1073,10 @@ dependencies = [
 
 [[package]]
 name = "javy-apis"
-version = "1.0.0"
+version = "1.1.0-alpha.1"
 dependencies = [
  "anyhow",
+ "fastrand",
  "javy",
 ]
 

--- a/crates/apis/CHANGELOG.md
+++ b/crates/apis/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Added `random` feature to override `Math.random` implementation with one that sets the random seed on first use of `Math.random`
+
 ## 1.0.0 - 2023-05-17
 
 Initial release

--- a/crates/apis/Cargo.toml
+++ b/crates/apis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-apis"
-version = "1.0.0"
+version = "1.1.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -11,9 +11,11 @@ categories = ["wasm"]
 
 [features]
 console = []
+random = ["dep:fastrand"]
 stream_io = []
 text_encoding = []
 
 [dependencies]
 anyhow = { workspace = true }
+fastrand = { version = "1.9.0", optional = true }
 javy = { workspace = true }

--- a/crates/apis/README.md
+++ b/crates/apis/README.md
@@ -24,6 +24,7 @@ If you want to customize the runtime or the APIs, you can use the `Runtime::new_
 ## Features
 * `console` - registers an implementation of the `console` API
 * `text_encoding` - registers implementations of `TextEncoder` and `TextDecoder`
+* `random` - overrides implementation of `Math.random` to one that seeds the RNG on first call to `Math.random`
 * `stream_io` - registers implementations of `Javy.IO.readSync` and `Javy.IO.writeSync`
 
 ## Building a project using this crate

--- a/crates/apis/README.md
+++ b/crates/apis/README.md
@@ -22,10 +22,10 @@ fn main() -> Result<()> {
 If you want to customize the runtime or the APIs, you can use the `Runtime::new_with_apis` method instead to provide a `javy::Config` for the underlying `Runtime` or an `APIConfig` for the APIs.
 
 ## Features
-* `console` - registers an implementation of the `console` API
-* `text_encoding` - registers implementations of `TextEncoder` and `TextDecoder`
-* `random` - overrides implementation of `Math.random` to one that seeds the RNG on first call to `Math.random`
-* `stream_io` - registers implementations of `Javy.IO.readSync` and `Javy.IO.writeSync`
+* `console` - Registers an implementation of the `console` API.
+* `text_encoding` - Registers implementations of `TextEncoder` and `TextDecoder`.
+* `random` - Overrides the implementation of `Math.random` to one that seeds the RNG on first call to `Math.random`. This is helpful to enable when using Wizer to snapshot a Javy Runtime so that the output of `Math.random` relies on the WASI context used at runtime and not the WASI context used when Wizening. Enabling this feature will increase the size of the Wasm module that includes the Javy Runtime and will introduce an additional hostcall invocation when `Math.random` is invoked for the first time.
+* `stream_io` - Registers implementations of `Javy.IO.readSync` and `Javy.IO.writeSync`.
 
 ## Building a project using this crate
 

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -32,6 +32,8 @@
 //! ## Features
 //! * `console` - registers an implementation of the `console` API
 //! * `text_encoding` - registers implementations of `TextEncoder` and `TextDecoder`
+//! * `random` - overrides implementation of `Math.random` to one that seeds the
+//!   RNG on first call to `Math.random`
 //! * `stream_io` - registers implementations of `Javy.IO.readSync` and `Javy.IO.writeSync`
 
 use anyhow::Result;
@@ -45,6 +47,8 @@ pub use runtime_ext::RuntimeExt;
 mod api_config;
 #[cfg(feature = "console")]
 mod console;
+#[cfg(feature = "random")]
+mod random;
 mod runtime_ext;
 #[cfg(feature = "stream_io")]
 mod stream_io;
@@ -69,6 +73,8 @@ pub(crate) trait JSApiSet {
 pub fn add_to_runtime(runtime: &Runtime, config: APIConfig) -> Result<()> {
     #[cfg(feature = "console")]
     console::Console::new().register(runtime, &config)?;
+    #[cfg(feature = "random")]
+    random::Random.register(runtime, &config)?;
     #[cfg(feature = "stream_io")]
     stream_io::StreamIO.register(runtime, &config)?;
     #[cfg(feature = "text_encoding")]

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -30,11 +30,17 @@
 //! for the underlying [`Runtime`] or an [`APIConfig`] for the APIs.
 //!
 //! ## Features
-//! * `console` - registers an implementation of the `console` API
-//! * `text_encoding` - registers implementations of `TextEncoder` and `TextDecoder`
-//! * `random` - overrides implementation of `Math.random` to one that seeds the
-//!   RNG on first call to `Math.random`
-//! * `stream_io` - registers implementations of `Javy.IO.readSync` and `Javy.IO.writeSync`
+//! * `console` - Registers an implementation of the `console` API.
+//! * `text_encoding` - Registers implementations of `TextEncoder` and `TextDecoder`.
+//! * `random` - Overrides the implementation of `Math.random` to one that
+//!   seeds the RNG on first call to `Math.random`. This is helpful to enable
+//!   when using Wizer to snapshot a [`javy::Runtime`] so that the output of
+//!   `Math.random` relies on the WASI context used at runtime and not the
+//!   WASI context used when Wizening. Enabling this feature will increase the
+//!   size of the Wasm module that includes the Javy Runtime and will
+//!   introduce an additional hostcall invocation when `Math.random` is
+//!   invoked for the first time.
+//! * `stream_io` - Registers implementations of `Javy.IO.readSync` and `Javy.IO.writeSync`.
 
 use anyhow::Result;
 use javy::Runtime;

--- a/crates/apis/src/random/mod.rs
+++ b/crates/apis/src/random/mod.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use javy::{quickjs::JSValue, Runtime};
+
+use crate::{APIConfig, JSApiSet};
+
+pub struct Random;
+
+impl JSApiSet for Random {
+    fn register(&self, runtime: &Runtime, _config: &APIConfig) -> Result<()> {
+        let ctx = runtime.context();
+        ctx.global_object()?.get_property("Math")?.set_property(
+            "random",
+            // TODO figure out if we can lazily initialize the PRNG
+            ctx.wrap_callback(|_ctx, _this, _args| Ok(JSValue::Float(fastrand::f64())))?,
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{random::Random, APIConfig, JSApiSet};
+    use anyhow::Result;
+    use javy::Runtime;
+
+    #[test]
+    fn test_random() -> Result<()> {
+        let runtime = Runtime::default();
+        Random.register(&runtime, &APIConfig::default())?;
+        let ctx = runtime.context();
+        ctx.eval_global("test.js", "result = Math.random()")?;
+        let result = ctx.global_object()?.get_property("result")?.as_f64()?;
+        assert!(result >= 0.0);
+        assert!(result < 1.0);
+        Ok(())
+    }
+}

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -120,7 +120,7 @@ fn test_same_module_outputs_different_random_result() {
     let mut runner = Runner::new("random.js");
     let (output, _, fuel_consumed) = runner.exec(&[]).unwrap();
     let (output2, _, _) = runner.exec(&[]).unwrap();
-    // in theory these could be equal with a correct implementation but it's very unlikely.
+    // In theory these could be equal with a correct implementation but it's very unlikely.
     assert!(output != output2);
     assert_fuel_consumed_within_threshold(100_543, fuel_consumed);
 }

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -120,7 +120,7 @@ fn test_same_module_outputs_different_random_result() {
     let mut runner = Runner::new("random.js");
     let (output, _, fuel_consumed) = runner.exec(&[]).unwrap();
     let (output2, _, _) = runner.exec(&[]).unwrap();
-    // in theory these could be equal with a correct implementation but it's very unlikely
+    // in theory these could be equal with a correct implementation but it's very unlikely.
     assert!(output != output2);
     assert_fuel_consumed_within_threshold(100_543, fuel_consumed);
 }

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -115,6 +115,16 @@ fn test_producers_section_present() {
     assert!(producers_string.contains("Javy"));
 }
 
+#[test]
+fn test_same_module_outputs_different_random_result() {
+    let mut runner = Runner::new("random.js");
+    let (output, _, fuel_consumed) = runner.exec(&[]).unwrap();
+    let (output2, _, _) = runner.exec(&[]).unwrap();
+    // in theory these could be equal with a correct implementation but it's very unlikely
+    assert!(output != output2);
+    assert_fuel_consumed_within_threshold(100_543, fuel_consumed);
+}
+
 fn run_with_u8s(r: &mut Runner, stdin: u8) -> (u8, String, u64) {
     let (output, logs, fuel_consumed) = run(r, &stdin.to_le_bytes());
     assert_eq!(1, output.len());

--- a/crates/cli/tests/sample-scripts/random.js
+++ b/crates/cli/tests/sample-scripts/random.js
@@ -1,0 +1,2 @@
+const random = Math.random();
+Javy.IO.writeSync(1, new Uint8Array(new TextEncoder().encode(random.toString())));

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = { workspace = true }
 javy = { workspace = true }
-javy-apis = { path = "../apis", features = ["console", "text_encoding", "stream_io"] }
+javy-apis = { path = "../apis", features = ["console", "text_encoding", "random", "stream_io"] }
 once_cell = { workspace = true }
 
 [features]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -265,10 +265,6 @@ criteria = "safe-to-deploy"
 version = "0.2.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.fastrand]]
-version = "1.7.0"
-criteria = "safe-to-run"
-
 [[exemptions.fs-set-times]]
 version = "0.15.0"
 criteria = "safe-to-deploy"
@@ -311,7 +307,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.instant]]
 version = "0.1.12"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
 
 [[exemptions.io-extras]]
 version = "0.13.2"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -716,6 +716,16 @@ criteria = "safe-to-run"
 delta = "0.9.3 -> 0.8.4"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.fastrand]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.9.0"
+notes = """
+`does-not-implement-crypto` is certified because this crate explicitly says
+that the RNG here is not cryptographically secure.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/main/cargo-vet/audits.toml?format=TEXT"
+
 [[audits.google.audits.proc-macro-error-attr]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Fixes #318 and #317. Technically not all of #317 in that the build output is still non-deterministic but the output of `Math.random` will be either deterministic or non-deterministic based on the WASI context used at runtime instead of based on the WASI context used at compile time.