### PR TITLE
Handle JS errors gracefully

### DIFF
--- a/crates/cli/tests/dylib_test.rs
+++ b/crates/cli/tests/dylib_test.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use std::boxed::Box;
 use std::str;
-use wasi_common::pipe::WritePipe;
+use wasi_common::{pipe::WritePipe, WasiFile};
 use wasmtime::{Engine, Instance, Linker, Store};
 use wasmtime_wasi::{sync::WasiCtxBuilder, WasiCtx};
 
@@ -9,39 +9,35 @@ mod common;
 
 #[test]
 fn test_dylib() -> Result<()> {
-    let engine = Engine::default();
-    let mut linker = Linker::new(&engine);
-    wasmtime_wasi::add_to_linker(&mut linker, |s| s)?;
+    let js_src = "console.log(42);";
     let stderr = WritePipe::new_in_memory();
-    let wasi = WasiCtxBuilder::new()
-        .stderr(Box::new(stderr.clone()))
-        .build();
-    let module = common::create_quickjs_provider_module(&engine)?;
+    run_js_src(js_src, &stderr)?;
 
-    // scope is needed to ensure `store` is dropped before trying to read from `stderr` below
-    {
-        let mut store = Store::new(&engine, wasi);
-        let instance = linker.instantiate(&mut store, &module)?;
-        let eval_bytecode_func =
-            instance.get_typed_func::<(u32, u32), ()>(&mut store, "eval_bytecode")?;
-
-        let js_src = "console.log(42);";
-        let (bytecode_ptr, bytecode_len) = compile_src(js_src.as_bytes(), &instance, &mut store)?;
-        eval_bytecode_func.call(&mut store, (bytecode_ptr, bytecode_len))?;
-    }
-
-    let log_output = stderr.try_into_inner().unwrap().into_inner();
-    assert_eq!("42\n", str::from_utf8(&log_output)?);
+    let output = stderr.try_into_inner().unwrap().into_inner();
+    assert_eq!("42\n", str::from_utf8(&output)?);
 
     Ok(())
 }
 
 #[test]
 fn test_dylib_with_error() -> Result<()> {
+    let js_src = "function foo() { throw new Error('foo error'); } foo();";
+    let stderr = WritePipe::new_in_memory();
+    let result = run_js_src(js_src, &stderr);
+
+    assert!(result.is_err());
+    let output = stderr.try_into_inner().unwrap().into_inner();
+
+    let expected_log_output = "Error while running JS: Uncaught Error: foo error\n    at foo (function.mjs)\n    at <anonymous> (function.mjs:1)\n\n";
+    assert_eq!(expected_log_output, str::from_utf8(&output)?);
+
+    Ok(())
+}
+
+fn run_js_src<T: WasiFile + Clone + 'static>(js_src: &str, stderr: &T) -> Result<()> {
     let engine = Engine::default();
     let mut linker = Linker::new(&engine);
     wasmtime_wasi::add_to_linker(&mut linker, |s| s)?;
-    let stderr = WritePipe::new_in_memory();
     let wasi = WasiCtxBuilder::new()
         .stderr(Box::new(stderr.clone()))
         .build();
@@ -54,14 +50,9 @@ fn test_dylib_with_error() -> Result<()> {
         let eval_bytecode_func =
             instance.get_typed_func::<(u32, u32), ()>(&mut store, "eval_bytecode")?;
 
-        let js_src = "function foo() { throw new Error('foo error'); } foo();";
         let (bytecode_ptr, bytecode_len) = compile_src(js_src.as_bytes(), &instance, &mut store)?;
         eval_bytecode_func.call(&mut store, (bytecode_ptr, bytecode_len))?;
     }
-
-    let log_output = stderr.try_into_inner().unwrap().into_inner();
-    let expected_log_output = "Error while running JS: Uncaught Error: foo error\n    at foo (function.mjs)\n    at <anonymous> (function.mjs:1)\n\n";
-    assert_eq!(expected_log_output, str::from_utf8(&log_output)?);
 
     Ok(())
 }

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -1,6 +1,6 @@
 mod runner;
 
-use runner::Runner;
+use runner::{Runner, RunnerError};
 use std::str;
 
 #[test]
@@ -113,6 +113,17 @@ fn test_producers_section_present() {
     let producers_string = str::from_utf8(producers_section).unwrap();
     assert!(producers_string.contains("JavaScript"));
     assert!(producers_string.contains("Javy"));
+}
+
+#[test]
+fn test_error_handling() {
+    let mut runner = Runner::new("error.js");
+    let result = runner.exec(&[]);
+    let err = result.err().unwrap().downcast::<RunnerError>().unwrap();
+
+    let expected_log_output = "Error while running JS: Uncaught Error: error\n    at error (function.mjs:2)\n    at <anonymous> (function.mjs:5)\n\n";
+
+    assert_eq!(expected_log_output, str::from_utf8(&err.stderr).unwrap());
 }
 
 fn run_with_u8s(r: &mut Runner, stdin: u8) -> (u8, String, u64) {

--- a/crates/cli/tests/sample-scripts/error.js
+++ b/crates/cli/tests/sample-scripts/error.js
@@ -1,0 +1,5 @@
+function error() {
+  throw new Error("error");
+}
+
+error();

--- a/crates/core/src/execution.rs
+++ b/crates/core/src/execution.rs
@@ -1,7 +1,14 @@
 use anyhow::{bail, Result};
 use javy::Runtime;
 
-pub fn run_bytecode(runtime: &Runtime, bytecode: &[u8]) -> Result<()> {
+pub fn run_bytecode(runtime: &Runtime, bytecode: &[u8]) {
+    run_bytecode_inner(runtime, bytecode).unwrap_or_else(|e| {
+        eprintln!("Error while running JS: {}", e);
+        std::process::abort();
+    });
+}
+
+fn run_bytecode_inner(runtime: &Runtime, bytecode: &[u8]) -> Result<()> {
     let context = runtime.context();
     context.eval_binary(bytecode)?;
     if cfg!(feature = "experimental_event_loop") {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -64,12 +64,7 @@ pub unsafe extern "C" fn compile_src(js_src_ptr: *const u8, js_src_len: usize) -
 pub unsafe extern "C" fn eval_bytecode(bytecode_ptr: *const u8, bytecode_len: usize) {
     let runtime = RUNTIME.get().unwrap();
     let bytecode = slice::from_raw_parts(bytecode_ptr, bytecode_len);
-    match execution::run_bytecode(runtime, bytecode) {
-        Ok(_) => {}
-        Err(e) => {
-            eprintln!("Error while running JS: {}", e);
-        }
-    }
+    execution::run_bytecode(runtime, bytecode)
 }
 
 /// 1. Allocate memory of new_size with alignment.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -64,7 +64,12 @@ pub unsafe extern "C" fn compile_src(js_src_ptr: *const u8, js_src_len: usize) -
 pub unsafe extern "C" fn eval_bytecode(bytecode_ptr: *const u8, bytecode_len: usize) {
     let runtime = RUNTIME.get().unwrap();
     let bytecode = slice::from_raw_parts(bytecode_ptr, bytecode_len);
-    execution::run_bytecode(runtime, bytecode).unwrap();
+    match execution::run_bytecode(runtime, bytecode) {
+        Ok(_) => {}
+        Err(e) => {
+            eprintln!("Error while running JS: {}", e);
+        }
+    }
 }
 
 /// 1. Allocate memory of new_size with alignment.

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -29,5 +29,10 @@ pub extern "C" fn init() {
 fn main() {
     let bytecode = unsafe { BYTECODE.take().unwrap() };
     let runtime = unsafe { RUNTIME.take().unwrap() };
-    execution::run_bytecode(&runtime, &bytecode).unwrap();
+    match execution::run_bytecode(&runtime, &bytecode) {
+        Ok(_) => {}
+        Err(e) => {
+            eprintln!("Error while running JS: {}", e);
+        }
+    }
 }

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -29,10 +29,5 @@ pub extern "C" fn init() {
 fn main() {
     let bytecode = unsafe { BYTECODE.take().unwrap() };
     let runtime = unsafe { RUNTIME.take().unwrap() };
-    match execution::run_bytecode(&runtime, &bytecode) {
-        Ok(_) => {}
-        Err(e) => {
-            eprintln!("Error while running JS: {}", e);
-        }
-    }
+    execution::run_bytecode(&runtime, &bytecode)
 }


### PR DESCRIPTION
# why? 

should fix https://github.com/bytecodealliance/javy/issues/360

# how? 

instead of plain unwrapping, handle the errors on both call sites for `run_bytecode` and print out the error if it's there. This prints also the stacktrace from JS, which was already been captured by existing code. 

# question for the reviewers

should we still panic after we have handled the error? 