### PR TITLE
Add an apt-get update to get apt-get install working

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -122,7 +122,7 @@ jobs:
 
       # wasmtime-fiber and binaryen fail to compile without this
       - name: Install Aarch64 GCC toolchain
-        run: sudo apt-get --assume-yes install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+        run: sudo apt-get update && sudo apt-get --assume-yes install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
         if: matrix.target == 'aarch64-unknown-linux-gnu'
 
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
I noticed our build assets job [started failing](https://github.com/bytecodealliance/javy/actions/runs/5084703574/jobs/9137584479) with it complaining about a package repository 404'ing. Adding a `sudo apt-get update` first should fix it.