### PR TITLE
Fix `cargo install` for the CLI crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 [[package]]
 name = "binaryen"
 version = "0.12.1"
-source = "git+https://github.com/pepyakin/binaryen-rs#00c98174843f957681ba0bc5cdcc9d15f5d0cb23"
+source = "git+https://github.com/pepyakin/binaryen-rs?rev=00c98174843f957681ba0bc5cdcc9d15f5d0cb23#00c98174843f957681ba0bc5cdcc9d15f5d0cb23"
 dependencies = [
  "binaryen-sys",
 ]
@@ -124,7 +124,7 @@ dependencies = [
 [[package]]
 name = "binaryen-sys"
 version = "0.12.1"
-source = "git+https://github.com/pepyakin/binaryen-rs#00c98174843f957681ba0bc5cdcc9d15f5d0cb23"
+source = "git+https://github.com/pepyakin/binaryen-rs?rev=00c98174843f957681ba0bc5cdcc9d15f5d0cb23#00c98174843f957681ba0bc5cdcc9d15f5d0cb23"
 dependencies = [
  "cc",
  "cmake",
@@ -2791,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "wizer"
 version = "1.6.1-beta.4"
-source = "git+https://github.com/bytecodealliance/wizer#3acc39cc561e7f985f163a2c8e89259a0dfc2f2f"
+source = "git+https://github.com/bytecodealliance/wizer?rev=3acc39cc561e7f985f163a2c8e89259a0dfc2f2f#3acc39cc561e7f985f163a2c8e89259a0dfc2f2f"
 dependencies = [
  "anyhow",
  "cap-std 0.24.4",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,10 +15,10 @@ dump_wat = ["dep:wasmprinter"]
 experimental_event_loop = []
 
 [dependencies]
-wizer = { git = "https://github.com/bytecodealliance/wizer" }
+wizer = { git = "https://github.com/bytecodealliance/wizer", rev = "3acc39cc561e7f985f163a2c8e89259a0dfc2f2f" }
 structopt = "0.3"
 anyhow = { workspace = true }
-binaryen = { git = "https://github.com/pepyakin/binaryen-rs" }
+binaryen = { git = "https://github.com/pepyakin/binaryen-rs", rev = "00c98174843f957681ba0bc5cdcc9d15f5d0cb23" }
 brotli = "3.3.4"
 wasm-encoder = "0.20"
 wasmprinter = { version = "0.2.45", optional = true }


### PR DESCRIPTION
When running `cargo install --path crates/cli`, I see the following error:

```
error: failed to compile `javy-cli v1.0.1 (/Users/jeffcharles/src/github.com/Shopify/javy/crates/cli)`, intermediate artifacts can be found at `/Users/jeffcharles/src/github.com/Shopify/javy/target`

Caused by:
  failed to select a version for `wasi-common`.
      ... required by package `wasi-cap-std-sync v9.0.0`
      ... which satisfies dependency `wasi-cap-std-sync = "^9.0.0"` of package `wizer v3.0.0 (https://github.com/bytecodealliance/wizer#8956f12d)`
      ... which satisfies git dependency `wizer` of package `javy-cli v1.0.1 (/Users/jeffcharles/src/github.com/Shopify/javy/crates/cli)`
  versions that meet the requirements `=9.0.0` are: 9.0.0

  the package `wasi-common` links to the native library `wasi-common-19`, but it conflicts with a previous package which links to `wasi-common-19` as well:
  package `wasi-common v8.0.0`
      ... which satisfies dependency `wasi-common = "^8.0"` of package `javy-cli v1.0.1 (/Users/jeffcharles/src/github.com/Shopify/javy/crates/cli)`
  Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the links ='wasi-common' value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

  failed to select a version for `wasi-common` which could resolve this conflict
```

This is caused by `cargo install` ignoring the lockfile for the project and picking the latest commit on the main branch for our Git dependencies. This PR specifies the revisions we're depending on so `cargo install` knows which versions to use.