### PR TITLE
Fix build assets workflow

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: provider
-          path: target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm
+          path: target/wasm32-wasi/release/javy_quickjs_provider.wasm
 
       - name: Archive wizened quickjs_provider
         run: gzip -k -f target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm && mv target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm.gz javy-quickjs_provider.wasm.gz


### PR DESCRIPTION
Update build-assets workflow to work with changes introduced in #383.

Technically this will result in the Javy QuickJS provider output by the Javy CLI to be slightly different from the version attached to the release since we're now wizening the provider in each Javy CLI binary we're building and the wizening process is non-deterministic. But there shouldn't be any noticeable impacts from that.

I'm also open to making a change to the build file to skip the wizening process if a wizened file is already available as an alternative solution.