### PR TITLE
Refactor to use Walrus instead of wasm-encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
- "gimli",
+ "gimli 0.27.2",
 ]
 
 [[package]]
@@ -444,7 +444,7 @@ dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.27.2",
  "hashbrown 0.13.2",
  "log",
  "regalloc2",
@@ -908,6 +908,17 @@ dependencies = [
 
 [[package]]
 name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
@@ -1207,15 +1218,14 @@ dependencies = [
  "brotli",
  "criterion",
  "lazy_static",
- "leb128",
  "num-format",
  "serde",
  "serde_json",
  "structopt",
  "tempfile",
  "uuid",
+ "walrus",
  "wasi-common",
- "wasm-encoder 0.20.0",
  "wasmparser 0.101.0",
  "wasmprinter",
  "wasmtime",
@@ -2363,6 +2373,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "walrus"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc27d837c587f863d99515dc8cae7cef1098bd1d99fa29373e3660c12766265e"
+dependencies = [
+ "anyhow",
+ "gimli 0.26.2",
+ "id-arena",
+ "leb128",
+ "log",
+ "walrus-macro",
+ "wasm-encoder 0.29.0",
+ "wasmparser 0.80.2",
+]
+
+[[package]]
+name = "walrus-macro"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,21 +2522,27 @@ checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05632e0a66a6ed8cca593c24223aabd6262f256c3693ad9822c315285f010614"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eff853c4f09eec94d76af527eddad4e9de13b11d6286a1ef7134bc30135a2b7"
 dependencies = [
  "leb128",
 ]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.80.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449167e2832691a1bff24cde28d2804e90e09586a448c8e76984792c44334a6b"
 
 [[package]]
 name = "wasmparser"
@@ -2644,7 +2688,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli",
+ "gimli 0.27.2",
  "log",
  "object",
  "target-lexicon",
@@ -2663,7 +2707,7 @@ dependencies = [
  "anyhow",
  "cranelift-codegen",
  "cranelift-native",
- "gimli",
+ "gimli 0.27.2",
  "object",
  "target-lexicon",
  "wasmtime-environ",
@@ -2677,7 +2721,7 @@ checksum = "5c2a2c8dcf2c4bacaa5bd29fbbc744769804377747940c6d5fe12b15bdfafe2c"
 dependencies = [
  "anyhow",
  "cranelift-entity",
- "gimli",
+ "gimli 0.27.2",
  "indexmap",
  "log",
  "object",
@@ -2712,7 +2756,7 @@ dependencies = [
  "bincode",
  "cfg-if",
  "cpp_demangle",
- "gimli",
+ "gimli 0.27.2",
  "ittapi",
  "log",
  "object",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,13 +20,11 @@ structopt = "0.3"
 anyhow = { workspace = true }
 binaryen = { git = "https://github.com/pepyakin/binaryen-rs", rev = "00c98174843f957681ba0bc5cdcc9d15f5d0cb23" }
 brotli = "3.3.4"
-wasm-encoder = "0.20"
 wasmprinter = { version = "0.2.45", optional = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasi-common = { workspace = true }
-wasmparser = "0.101.0"
-leb128 = "0.2.5"
+walrus = "0.20.1"
 
 [dev-dependencies]
 serde_json = "1.0"
@@ -36,6 +34,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 criterion = "0.3"
 num-format = "0.4.3"
 tempfile = "3.4.0"
+wasmparser = "0.101.0"
 
 [build-dependencies]
 anyhow = "1.0.71"

--- a/crates/cli/src/module_generator.rs
+++ b/crates/cli/src/module_generator.rs
@@ -1,236 +1,89 @@
 use anyhow::Result;
-use wasm_encoder::{
-    CodeSection, DataCountSection, DataSection, EntityType, ExportKind, ExportSection, Function,
-    FunctionSection, ImportSection, Instruction, MemoryType, Module, TypeSection, ValType,
-};
+use walrus::{DataKind, FunctionBuilder, Module, ValType};
 
-use crate::transform;
+use crate::transform::{self, SourceCodeSection};
 
 // Run the calling code with the `dump_wat` feature enabled to print the WAT to stdout
 //
-// For the example generated WAT, the `bytecode_len` is 145
+// For the example generated WAT, the `bytecode_len` is 90
 // (module
-//     (type (;0;) (func (param i32 i32 i32 i32) (result i32)))
+//     (type (;0;) (func))
 //     (type (;1;) (func (param i32 i32)))
-//     (type (;2;) (func))
-//     (import "javy_quickjs_provider_v1" "canonical_abi_realloc" (func (;0;) (type 0)))
+//     (type (;2;) (func (param i32 i32 i32 i32) (result i32)))
+//     (import "javy_quickjs_provider_v1" "canonical_abi_realloc" (func (;0;) (type 2)))
 //     (import "javy_quickjs_provider_v1" "eval_bytecode" (func (;1;) (type 1)))
 //     (import "javy_quickjs_provider_v1" "memory" (memory (;0;) 0))
-//     (func (;2;) (type 2)
+//     (func (;2;) (type 0)
 //       (local i32)
 //       i32.const 0
 //       i32.const 0
 //       i32.const 1
-//       i32.const 145
+//       i32.const 90
 //       call 0
 //       local.tee 0
 //       i32.const 0
-//       i32.const 145
+//       i32.const 90
 //       memory.init 0
-//       data.drop 0
 //       local.get 0
-//       i32.const 145
+//       i32.const 90
 //       call 1
 //     )
 //     (export "_start" (func 2))
-//     (data (;0;) "\02\08\0econsole\06log\16TextDecoder\0cdecode\16TextEncoder\0cencode\03\00\d8\18function.mjs\0e\00\06\00\a0\01\00\01\00\07\00\006\01\a2\01\00\00\008\de\00\00\00B\df\00\00\008\e0\00\00\00\11!\00\00B\e1\00\00\008\e2\00\00\00\11!\00\00B\e3\00\00\00\04\e4\00\00\00$\01\00$\01\00$\01\00\cd(\ca\03\01\00")
+//     (data (;0;) "\02\04\18function.mjs\0econsole\06log\18Hello world!\0f\bc\03\00\00\00\00\0e\00\06\01\a0\01\00\00\00\03\00\00\17\00\08\ea\02)8\df\00\00\00B\e0\00\00\00\04\e1\00\00\00$\01\00)\bc\03\01\02\01\17")
 // )
 pub fn generate_module(bytecode: Vec<u8>, js_src: &[u8]) -> Result<Vec<u8>> {
-    let mut module = Module::new();
-    let mut indices = Indices::new();
+    let mut module = Module::with_config(transform::module_config());
 
-    add_types(&mut module, &mut indices);
-    add_imports(&mut module, &mut indices);
-    add_functions(&mut module, &mut indices);
-    add_exports(&mut module, &indices);
-    add_data_count(&mut module, 1);
-    add_code(&mut module, &indices, bytecode.len().try_into()?);
-    add_data(&mut module, bytecode);
-    transform::add_source_code_section(&mut module, js_src)?;
-    transform::add_producers_section(&mut module)?;
-
-    let wasm_binary = module.finish();
-    print_wat(&wasm_binary)?;
-    Ok(wasm_binary)
-}
-
-struct Indices {
-    pub realloc_ty: Option<u32>,
-    pub eval_bytecode_ty: Option<u32>,
-    pub start_ty: Option<u32>,
-    pub realloc_fn: Option<u32>,
-    pub eval_bytecode_fn: Option<u32>,
-    pub start_fn: Option<u32>,
-    pub javy_quickjs_provider_memory: Option<u32>,
-    pub bytecode_data: u32,
-    next_ty_index: u32,
-    next_func_index: u32,
-    next_memory_index: u32,
-}
-
-impl Indices {
-    pub fn new() -> Indices {
-        Indices {
-            realloc_ty: None,
-            eval_bytecode_ty: None,
-            start_ty: None,
-            realloc_fn: None,
-            eval_bytecode_fn: None,
-            start_fn: None,
-            javy_quickjs_provider_memory: None,
-            bytecode_data: 0,
-            next_ty_index: 0,
-            next_func_index: 0,
-            next_memory_index: 0,
-        }
-    }
-
-    pub fn assign_realloc_ty(&mut self) {
-        self.realloc_ty = Some(self.next_ty_index);
-        self.next_ty_index += 1;
-    }
-
-    pub fn assign_eval_bytecode_ty(&mut self) {
-        self.eval_bytecode_ty = Some(self.next_ty_index);
-        self.next_ty_index += 1;
-    }
-
-    pub fn assign_start_ty(&mut self) {
-        self.start_ty = Some(self.next_ty_index);
-        self.next_ty_index += 1;
-    }
-
-    pub fn assign_realloc_fn(&mut self) {
-        self.realloc_fn = Some(self.next_func_index);
-        self.next_func_index += 1;
-    }
-
-    pub fn assign_eval_bytecode_fn(&mut self) {
-        self.eval_bytecode_fn = Some(self.next_func_index);
-        self.next_func_index += 1;
-    }
-
-    pub fn assign_start_fn(&mut self) {
-        self.start_fn = Some(self.next_func_index);
-        self.next_func_index += 1;
-    }
-
-    pub fn assign_javy_quickjs_provider_memory(&mut self) {
-        self.javy_quickjs_provider_memory = Some(self.next_memory_index);
-        self.next_memory_index += 1;
-    }
-}
-
-fn add_types(module: &mut Module, indices: &mut Indices) {
-    let mut types = TypeSection::new();
-
-    // canonical_abi_realloc
-    types.function(
-        vec![ValType::I32, ValType::I32, ValType::I32, ValType::I32],
-        vec![ValType::I32],
-    );
-    indices.assign_realloc_ty();
-
-    // eval_bytecode
-    types.function(vec![ValType::I32, ValType::I32], vec![]);
-    indices.assign_eval_bytecode_ty();
-
-    // _start
-    types.function(vec![], vec![]);
-    indices.assign_start_ty();
-
-    module.section(&types);
-}
-
-fn add_imports(module: &mut Module, indices: &mut Indices) {
     const IMPORT_NAMESPACE: &str = "javy_quickjs_provider_v1";
-    let mut imports = ImportSection::new();
 
-    imports.import(
+    let canonical_abi_realloc_type = module.types.add(
+        &[ValType::I32, ValType::I32, ValType::I32, ValType::I32],
+        &[ValType::I32],
+    );
+    let (canonical_abi_realloc_fn, _) = module.add_import_func(
         IMPORT_NAMESPACE,
         "canonical_abi_realloc",
-        EntityType::Function(indices.realloc_ty.unwrap()),
+        canonical_abi_realloc_type,
     );
-    indices.assign_realloc_fn();
 
-    imports.import(
-        IMPORT_NAMESPACE,
-        "eval_bytecode",
-        EntityType::Function(indices.eval_bytecode_ty.unwrap()),
-    );
-    indices.assign_eval_bytecode_fn();
+    let eval_bytecode_type = module.types.add(&[ValType::I32, ValType::I32], &[]);
+    let (eval_bytecode_fn, _) =
+        module.add_import_func(IMPORT_NAMESPACE, "eval_bytecode", eval_bytecode_type);
 
-    imports.import(
-        IMPORT_NAMESPACE,
-        "memory",
-        EntityType::Memory(MemoryType {
-            minimum: 0,
-            maximum: None,
-            memory64: false,
-            shared: false,
-        }),
-    );
-    indices.assign_javy_quickjs_provider_memory();
+    let (memory, _) = module.add_import_memory(IMPORT_NAMESPACE, "memory", false, 0, None);
 
-    module.section(&imports);
-}
+    transform::add_producers_section(&mut module.producers);
+    module.customs.add(SourceCodeSection::new(js_src)?);
 
-fn add_functions(module: &mut Module, indices: &mut Indices) {
-    let mut functions = FunctionSection::new();
-    functions.function(indices.start_ty.unwrap());
-    indices.assign_start_fn();
-    module.section(&functions);
-}
+    let bytecode_len: i32 = bytecode.len().try_into()?;
+    let bytecode_data = module.data.add(DataKind::Passive, bytecode);
 
-fn add_exports(module: &mut Module, indices: &Indices) {
-    let mut exports = ExportSection::new();
-    exports.export("_start", ExportKind::Func, indices.start_fn.unwrap());
-    module.section(&exports);
-}
+    let mut main = FunctionBuilder::new(&mut module.types, &[], &[]);
+    let ptr_local = module.locals.add(ValType::I32);
+    main.func_body()
+        // Allocate memory in javy_quickjs_provider for bytecode array.
+        .i32_const(0) // orig ptr
+        .i32_const(0) // orig size
+        .i32_const(1) // alignment
+        .i32_const(bytecode_len) // new size
+        .call(canonical_abi_realloc_fn)
+        // Copy bytecode array into allocated memory.
+        .local_tee(ptr_local) // save returned address to local and set as dest addr for mem.init
+        .i32_const(0) // offset into data segment for mem.init
+        .i32_const(bytecode_len) // size to copy from data segment
+        // top-2: dest addr, top-1: offset into source, top-0: size of memory region in bytes.
+        .memory_init(memory, bytecode_data)
+        // Evaluate bytecode.
+        .local_get(ptr_local) // ptr to bytecode
+        .i32_const(bytecode_len)
+        .call(eval_bytecode_fn);
+    let main = main.finish(vec![], &mut module.funcs);
 
-fn add_data_count(module: &mut Module, count: u32) {
-    module.section(&DataCountSection { count });
-}
+    module.exports.add("_start", main);
 
-fn add_code(module: &mut Module, indices: &Indices, bytecode_len: i32) {
-    let mut code = CodeSection::new();
-
-    let mut start_function = Function::new_with_locals_types([ValType::I32]);
-    const ALLOCATED_PTR_LOCAL_INDEX: u32 = 0;
-
-    // allocate memory in javy_quickjs_provider for bytecode array
-    start_function.instruction(&Instruction::I32Const(0)); // orig ptr
-    start_function.instruction(&Instruction::I32Const(0)); // orig size
-    start_function.instruction(&Instruction::I32Const(1)); // alignment
-    start_function.instruction(&Instruction::I32Const(bytecode_len)); // new_size
-    start_function.instruction(&Instruction::Call(indices.realloc_fn.unwrap()));
-
-    // copy bytecode array into allocated memory
-    start_function.instruction(&Instruction::LocalTee(ALLOCATED_PTR_LOCAL_INDEX)); // set local to allocated ptr, also sets allocated ptr as dest addr for mem init
-    start_function.instruction(&Instruction::I32Const(0)); // offset into data segment
-    start_function.instruction(&Instruction::I32Const(bytecode_len)); // size to copy from data segment
-
-    // top-2: dest addr, top-1: offset into source, top-0: size of memory region in bytes
-    start_function.instruction(&Instruction::MemoryInit {
-        mem: indices.javy_quickjs_provider_memory.unwrap(),
-        data_index: indices.bytecode_data,
-    });
-    start_function.instruction(&Instruction::DataDrop(indices.bytecode_data)); // no longer need data section so reduce memory pressure
-
-    // evaluate bytecode
-    start_function.instruction(&Instruction::LocalGet(ALLOCATED_PTR_LOCAL_INDEX)); // bytecode_ptr
-    start_function.instruction(&Instruction::I32Const(bytecode_len));
-    start_function.instruction(&Instruction::Call(indices.eval_bytecode_fn.unwrap())); // eval_bytecode
-    start_function.instruction(&Instruction::End);
-
-    code.function(&start_function);
-    module.section(&code);
-}
-
-fn add_data(module: &mut Module, bytecode: Vec<u8>) {
-    let mut data = DataSection::new();
-    data.passive(bytecode);
-    module.section(&data);
+    let wasm = module.emit_wasm();
+    print_wat(&wasm)?;
+    Ok(wasm)
 }
 
 #[cfg(feature = "dump_wat")]

--- a/crates/cli/src/transform.rs
+++ b/crates/cli/src/transform.rs
@@ -1,68 +1,49 @@
-use std::io::{Cursor, Write};
+use std::{borrow::Cow, io::Cursor};
 
 use anyhow::Result;
 use brotli::enc::{self, BrotliEncoderParams};
-use wasm_encoder::{CustomSection, Module};
+use walrus::{CustomSection, IdsToIndices, ModuleConfig, ModuleProducers};
 
-pub const PRODUCERS_SECTION_NAME: &str = "producers";
-
-pub fn add_producers_section(module: &mut Module) -> Result<()> {
-    module.section(&CustomSection {
-        name: PRODUCERS_SECTION_NAME,
-        data: &producers_section_content()?,
-    });
-    Ok(())
+#[derive(Debug)]
+pub struct SourceCodeSection {
+    compressed_source_code: Vec<u8>,
 }
 
-pub fn add_source_code_section(module: &mut Module, source_code: &[u8]) -> Result<()> {
-    let mut compressed_source_code: Vec<u8> = vec![];
-    enc::BrotliCompress(
-        &mut Cursor::new(source_code),
-        &mut compressed_source_code,
-        &BrotliEncoderParams {
-            quality: 11,
-            ..Default::default()
-        },
-    )?;
-
-    module.section(&CustomSection {
-        name: "javy_source",
-        data: &compressed_source_code,
-    });
-    Ok(())
+impl SourceCodeSection {
+    pub fn new(source_code: &[u8]) -> Result<SourceCodeSection> {
+        let mut compressed_source_code: Vec<u8> = vec![];
+        enc::BrotliCompress(
+            &mut Cursor::new(source_code),
+            &mut compressed_source_code,
+            &BrotliEncoderParams {
+                quality: 11,
+                ..Default::default()
+            },
+        )?;
+        Ok(SourceCodeSection {
+            compressed_source_code,
+        })
+    }
 }
 
-fn producers_section_content() -> Result<Vec<u8>> {
-    // see https://github.com/WebAssembly/tool-conventions/blob/main/ProducersSection.md
-    const FIELD_COUNT: u64 = 2;
-    const LANGUAGE_FIELD_NAME: &str = "language";
-    const LANGUAGE_FIELD_VALUE_COUNT: u64 = 1;
-    const LANGUAGE: &str = "JavaScript";
-    const LANGUAGE_VERSION: &str = "ES2020";
-    const PROCESSED_BY_FIELD_NAME: &str = "processed-by";
-    const PROCESSED_BY_FIELD_VALUE_COUNT: u64 = 1;
-    const PROCESSED_BY: &str = "Javy";
-    const PROCESSED_BY_VERSION: &str = env!("CARGO_PKG_VERSION");
+impl CustomSection for SourceCodeSection {
+    fn name(&self) -> &str {
+        "javy_source"
+    }
 
-    let mut producers_section = vec![];
-    leb128::write::unsigned(&mut producers_section, FIELD_COUNT)?;
-    write_wasm_vector(&mut producers_section, LANGUAGE_FIELD_NAME)?;
-    leb128::write::unsigned(&mut producers_section, LANGUAGE_FIELD_VALUE_COUNT)?;
-    write_wasm_vector(&mut producers_section, LANGUAGE)?;
-    write_wasm_vector(&mut producers_section, LANGUAGE_VERSION)?;
-    write_wasm_vector(&mut producers_section, PROCESSED_BY_FIELD_NAME)?;
-    leb128::write::unsigned(&mut producers_section, PROCESSED_BY_FIELD_VALUE_COUNT)?;
-    write_wasm_vector(&mut producers_section, PROCESSED_BY)?;
-    write_wasm_vector(&mut producers_section, PROCESSED_BY_VERSION)?;
-
-    Ok(producers_section)
+    fn data(&self, _ids_to_indices: &IdsToIndices) -> Cow<[u8]> {
+        (&self.compressed_source_code).into()
+    }
 }
 
-fn write_wasm_vector(buffer: &mut Vec<u8>, s: &str) -> Result<()> {
-    // see https://webassembly.github.io/spec/core/binary/conventions.html#binary-vec and
-    // https://webassembly.github.io/spec/core/binary/values.html#binary-int for encoding details
-    let bytes = s.as_bytes();
-    leb128::write::unsigned(buffer, bytes.len().try_into()?)?;
-    buffer.write_all(bytes)?;
-    Ok(())
+pub fn module_config() -> ModuleConfig {
+    let mut config = ModuleConfig::new();
+    config.generate_name_section(false);
+    config
+}
+
+pub fn add_producers_section(producers: &mut ModuleProducers) {
+    producers.clear(); // removes Walrus and Rust
+    producers.add_language("JavaScript", "ES2020");
+    producers.add_processed_by("Javy", env!("CARGO_PKG_VERSION"));
 }

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use std::path::{Path, PathBuf};
+use wasmparser::ProducersSectionReader;
 use wasmtime::{Engine, Module};
 
+#[allow(dead_code)]
 pub fn create_quickjs_provider_module(engine: &Engine) -> Result<Module> {
     let mut lib_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     lib_path.pop();
@@ -13,4 +15,41 @@ pub fn create_quickjs_provider_module(engine: &Engine) -> Result<Module> {
             .join("javy_quickjs_provider_wizened.wasm"),
     );
     Module::from_file(engine, lib_path)
+}
+
+#[allow(dead_code)]
+pub fn assert_producers_section_is_correct(wasm: &[u8]) -> Result<()> {
+    let producers_section = wasmparser::Parser::new(0)
+        .parse_all(wasm)
+        .find_map(|payload| match payload {
+            Ok(wasmparser::Payload::CustomSection(c)) if c.name() == "producers" => {
+                Some(ProducersSectionReader::new(c.data(), c.data_offset()).unwrap())
+            }
+            _ => None,
+        })
+        .unwrap();
+    let fields = producers_section
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    assert_eq!(2, fields.len());
+
+    let language_field = &fields[0];
+    assert_eq!("language", language_field.name);
+    assert_eq!(1, language_field.values.count());
+    let language_value = language_field.values.clone().into_iter().next().unwrap()?;
+    assert_eq!("JavaScript", language_value.name);
+    assert_eq!("ES2020", language_value.version);
+
+    let processed_by_field = &fields[1];
+    assert_eq!("processed-by", processed_by_field.name);
+    assert_eq!(1, processed_by_field.values.count());
+    let processed_by_value = processed_by_field
+        .values
+        .clone()
+        .into_iter()
+        .next()
+        .unwrap()?;
+    assert_eq!("Javy", processed_by_value.name);
+    Ok(())
 }

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 use wasmparser::ProducersSectionReader;
 use wasmtime::{Engine, Module};
 
+// Allows dead code b/c each integration test suite is considered its own
+// application and this function is used by 2 of 3 suites.
 #[allow(dead_code)]
 pub fn create_quickjs_provider_module(engine: &Engine) -> Result<Module> {
     let mut lib_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -17,6 +19,8 @@ pub fn create_quickjs_provider_module(engine: &Engine) -> Result<Module> {
     Module::from_file(engine, lib_path)
 }
 
+// Allows dead code b/c each integration test suite is considered its own
+// application and this function is used by 2 of 3 suites.
 #[allow(dead_code)]
 pub fn assert_producers_section_is_correct(wasm: &[u8]) -> Result<()> {
     let producers_section = wasmparser::Parser::new(0)

--- a/crates/cli/tests/dynamic_linking_test.rs
+++ b/crates/cli/tests/dynamic_linking_test.rs
@@ -42,16 +42,7 @@ pub fn test_dynamic_linking() -> Result<()> {
 #[test]
 fn test_producers_section_present() -> Result<()> {
     let js_wasm = create_dynamically_linked_wasm_module("console.log(42)")?;
-    let producers_section = wasmparser::Parser::new(0)
-        .parse_all(&js_wasm)
-        .find_map(|payload| match payload {
-            Ok(wasmparser::Payload::CustomSection(c)) if c.name() == "producers" => Some(c.data()),
-            _ => None,
-        })
-        .unwrap();
-    let producers_string = str::from_utf8(producers_section)?;
-    assert!(producers_string.contains("JavaScript"));
-    assert!(producers_string.contains("Javy"));
+    common::assert_producers_section_is_correct(&js_wasm)?;
     Ok(())
 }
 

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -1,3 +1,4 @@
+mod common;
 mod runner;
 
 use runner::{Runner, RunnerError};
@@ -103,16 +104,7 @@ fn test_promises() {
 #[test]
 fn test_producers_section_present() {
     let runner = Runner::new("readme.js");
-    let producers_section = wasmparser::Parser::new(0)
-        .parse_all(&runner.wasm)
-        .find_map(|payload| match payload {
-            Ok(wasmparser::Payload::CustomSection(c)) if c.name() == "producers" => Some(c.data()),
-            _ => None,
-        })
-        .unwrap();
-    let producers_string = str::from_utf8(producers_section).unwrap();
-    assert!(producers_string.contains("JavaScript"));
-    assert!(producers_string.contains("Javy"));
+    common::assert_producers_section_is_correct(&runner.wasm).unwrap();
 }
 
 #[test]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -280,6 +280,10 @@ version = "0.2.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.gimli]]
+version = "0.26.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.gimli]]
 version = "0.27.2"
 criteria = "safe-to-deploy"
 
@@ -692,6 +696,14 @@ criteria = "safe-to-run"
 version = "2.3.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.walrus]]
+version = "0.20.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.walrus-macro]]
+version = "0.19.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.wasi]]
 version = "0.10.2+wasi-snapshot-preview1"
 criteria = "safe-to-deploy"
@@ -727,6 +739,14 @@ criteria = "safe-to-run"
 [[exemptions.wasm-bindgen-shared]]
 version = "0.2.81"
 criteria = "safe-to-run"
+
+[[exemptions.wasm-encoder]]
+version = "0.29.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmparser]]
+version = "0.80.2"
+criteria = "safe-to-deploy"
 
 [[exemptions.wasmtime]]
 version = "8.0.0"


### PR DESCRIPTION
Closes #399.

I had to make the tests around the producers custom section more strict because Walrus adds itself to the producers by default and I wanted to detect if Walrus was doing that and fail the test if it was.