### PR TITLE
Remove references to WASI SDK env var from READMEs and publish

### DIFF
--- a/crates/apis/README.md
+++ b/crates/apis/README.md
@@ -27,16 +27,6 @@ If you want to customize the runtime or the APIs, you can use the `Runtime::new_
 * `random` - Overrides the implementation of `Math.random` to one that seeds the RNG on first call to `Math.random`. This is helpful to enable when using Wizer to snapshot a Javy Runtime so that the output of `Math.random` relies on the WASI context used at runtime and not the WASI context used when Wizening. Enabling this feature will increase the size of the Wasm module that includes the Javy Runtime and will introduce an additional hostcall invocation when `Math.random` is invoked for the first time.
 * `stream_io` - Registers implementations of `Javy.IO.readSync` and `Javy.IO.writeSync`.
 
-## Building a project using this crate
-
-- Install the [wasi-sdk](https://github.com/WebAssembly/wasi-sdk#install) for your platform
-- Set the `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable to the absolute path where you installed the `wasi-sdk`
-
-For example, if you install the `wasi-sdk` in `/opt/wasi-sdk`, you can run:
-```bash
-export QUICKJS_WASM_SYS_WASI_SDK_PATH=/opt/wasi-sdk
-```
-
 ## Publishing to crates.io
 
 To publish this crate to crates.io, run `./publish.sh`.

--- a/crates/apis/README.md
+++ b/crates/apis/README.md
@@ -30,3 +30,7 @@ If you want to customize the runtime or the APIs, you can use the `Runtime::new_
 ## Publishing to crates.io
 
 To publish this crate to crates.io, run `./publish.sh`.
+
+## Using a custom WASI SDK
+
+This crate can be compiled using a custom [WASI SDK](https://github.com/WebAssembly/wasi-sdk). When building this crate, set the `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable to the absolute path where you installed the SDK.

--- a/crates/apis/publish.sh
+++ b/crates/apis/publish.sh
@@ -2,9 +2,4 @@
 
 set -e
 
-if [[ -z $QUICKJS_WASM_SYS_WASI_SDK_PATH ]]; then
-    echo "QUICKJS_WASM_SYS_WASI_SDK_PATH must be set to a path with a downloaded wasi-sdk" 1>&2
-    exit 1
-fi
-
 cargo publish --target=wasm32-wasi

--- a/crates/javy/README.md
+++ b/crates/javy/README.md
@@ -38,3 +38,7 @@ Create a `Runtime` and use the reference returned by `context()` to add function
 ## Publishing to crates.io
 
 To publish this crate to crates.io, run `./publish.sh`.
+
+## Using a custom WASI SDK
+
+This crate can be compiled using a custom [WASI SDK](https://github.com/WebAssembly/wasi-sdk). When building this crate, set the `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable to the absolute path where you installed the SDK.

--- a/crates/javy/README.md
+++ b/crates/javy/README.md
@@ -35,16 +35,6 @@ Create a `Runtime` and use the reference returned by `context()` to add function
 - `json` - transcoding functions for converting between `JSValueRef` and JSON
 - `messagepack` - transcoding functions for converting between `JSValueRef` and MessagePack
 
-## Building a project using this crate
-
-- Install the [wasi-sdk](https://github.com/WebAssembly/wasi-sdk#install) for your platform
-- Set the `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable to the absolute path where you installed the `wasi-sdk`
-
-For example, if you install the `wasi-sdk` in `/opt/wasi-sdk`, you can run:
-```bash
-export QUICKJS_WASM_SYS_WASI_SDK_PATH=/opt/wasi-sdk
-```
-
 ## Publishing to crates.io
 
 To publish this crate to crates.io, run `./publish.sh`.

--- a/crates/javy/publish.sh
+++ b/crates/javy/publish.sh
@@ -2,9 +2,4 @@
 
 set -e
 
-if [[ -z $QUICKJS_WASM_SYS_WASI_SDK_PATH ]]; then
-    echo "QUICKJS_WASM_SYS_WASI_SDK_PATH must be set to a path with a downloaded wasi-sdk" 1>&2
-    exit 1
-fi
-
 cargo publish --target=wasm32-wasi

--- a/crates/quickjs-wasm-rs/README.md
+++ b/crates/quickjs-wasm-rs/README.md
@@ -33,16 +33,6 @@ let output_value: JSValueRef = ...;
 let output = messagepack::transcode_output(output_value).unwrap();
 ```
 
-## Building a project using this crate
-
-- Install the [wasi-sdk](https://github.com/WebAssembly/wasi-sdk#install) for your platform
-- Set the `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable to the absolute path where you installed the `wasi-sdk`
-
-For example, if you install the `wasi-sdk` in `/opt/wasi-sdk`, you can run:
-```bash
-export QUICKJS_WASM_SYS_WASI_SDK_PATH=/opt/wasi-sdk
-```
-
 ## Publishing to crates.io
 
 To publish this crate to crates.io, run `./publish.sh`.

--- a/crates/quickjs-wasm-rs/README.md
+++ b/crates/quickjs-wasm-rs/README.md
@@ -36,3 +36,7 @@ let output = messagepack::transcode_output(output_value).unwrap();
 ## Publishing to crates.io
 
 To publish this crate to crates.io, run `./publish.sh`.
+
+## Using a custom WASI SDK
+
+This crate can be compiled using a custom [WASI SDK](https://github.com/WebAssembly/wasi-sdk). When building this crate, set the `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable to the absolute path where you installed the SDK.

--- a/crates/quickjs-wasm-rs/publish.sh
+++ b/crates/quickjs-wasm-rs/publish.sh
@@ -2,9 +2,4 @@
 
 set -e
 
-if [[ -z $QUICKJS_WASM_SYS_WASI_SDK_PATH ]]; then
-    echo "QUICKJS_WASM_SYS_WASI_SDK_PATH must be set to a path with a downloaded wasi-sdk" 1>&2
-    exit 1
-fi
-
 cargo publish --target=wasm32-wasi

--- a/crates/quickjs-wasm-sys/README.md
+++ b/crates/quickjs-wasm-sys/README.md
@@ -5,3 +5,7 @@ FFI bindings for a Wasm build of the QuickJS Javascript engine.
 ## Publishing to crates.io
 
 To publish this crate to crates.io, run `./publish.sh`.
+
+## Using a custom WASI SDK
+
+This crate can be compiled using a custom [WASI SDK](https://github.com/WebAssembly/wasi-sdk). When building this crate, set the `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable to the absolute path where you installed the SDK.

--- a/crates/quickjs-wasm-sys/README.md
+++ b/crates/quickjs-wasm-sys/README.md
@@ -2,16 +2,6 @@
 
 FFI bindings for a Wasm build of the QuickJS Javascript engine.
 
-## Building this crate
-
-- Install the [wasi-sdk](https://github.com/WebAssembly/wasi-sdk#install) for your platform
-- Set the `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable to the absolute path where you installed the `wasi-sdk`
-
-For example, if you install the `wasi-sdk` in `/opt/wasi-sdk`, you can run:
-```bash
-export QUICKJS_WASM_SYS_WASI_SDK_PATH=/opt/wasi-sdk
-```
-
 ## Publishing to crates.io
 
 To publish this crate to crates.io, run `./publish.sh`.

--- a/crates/quickjs-wasm-sys/publish.sh
+++ b/crates/quickjs-wasm-sys/publish.sh
@@ -2,9 +2,4 @@
 
 set -e
 
-if [[ -z $QUICKJS_WASM_SYS_WASI_SDK_PATH ]]; then
-    echo "QUICKJS_WASM_SYS_WASI_SDK_PATH must be set to a path with a downloaded wasi-sdk" 1>&2
-    exit 1
-fi
-
 cargo publish --target=wasm32-wasi


### PR DESCRIPTION
Setting `QUICKJS_WASM_SYS_WASI_SDK_PATH` is no longer necessary so let's remove that from the READMEs and publish shell scripts.