### PR TITLE
Refactor to add abstraction around the JS source

### DIFF
--- a/crates/cli/src/js.rs
+++ b/crates/cli/src/js.rs
@@ -1,3 +1,8 @@
+/// Higher-level representation of JavaScript.
+///
+/// This is intended to be used to derive different representations of source
+/// code. For example, as a byte array, a string, QuickJS bytecode, compressed
+/// bytes, or attributes of the source code like what it exports.
 use anyhow::{Context, Result};
 use brotli::enc::{self, BrotliEncoderParams};
 use std::{

--- a/crates/cli/src/js.rs
+++ b/crates/cli/src/js.rs
@@ -1,0 +1,46 @@
+use anyhow::{Context, Result};
+use brotli::enc::{self, BrotliEncoderParams};
+use std::{
+    fs::File,
+    io::{Cursor, Read},
+    path::Path,
+};
+
+use crate::bytecode;
+
+pub struct JS {
+    source_code: Vec<u8>,
+}
+
+impl JS {
+    pub fn from_file(path: &Path) -> Result<JS> {
+        let mut input_file = File::open(path)
+            .with_context(|| format!("Failed to open input file {}", path.display()))?;
+        let mut contents: Vec<u8> = vec![];
+        input_file.read_to_end(&mut contents)?;
+        Ok(JS {
+            source_code: contents,
+        })
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.source_code
+    }
+
+    pub fn compile(&self) -> Result<Vec<u8>> {
+        bytecode::compile_source(&self.source_code)
+    }
+
+    pub fn compress(&self) -> Result<Vec<u8>> {
+        let mut compressed_source_code: Vec<u8> = vec![];
+        enc::BrotliCompress(
+            &mut Cursor::new(&self.source_code),
+            &mut compressed_source_code,
+            &BrotliEncoderParams {
+                quality: 11,
+                ..Default::default()
+            },
+        )?;
+        Ok(compressed_source_code)
+    }
+}

--- a/crates/cli/src/transform.rs
+++ b/crates/cli/src/transform.rs
@@ -1,8 +1,9 @@
-use std::{borrow::Cow, io::Cursor};
+use std::borrow::Cow;
 
 use anyhow::Result;
-use brotli::enc::{self, BrotliEncoderParams};
 use walrus::{CustomSection, IdsToIndices, ModuleConfig, ModuleProducers};
+
+use crate::js::JS;
 
 #[derive(Debug)]
 pub struct SourceCodeSection {
@@ -10,18 +11,9 @@ pub struct SourceCodeSection {
 }
 
 impl SourceCodeSection {
-    pub fn new(source_code: &[u8]) -> Result<SourceCodeSection> {
-        let mut compressed_source_code: Vec<u8> = vec![];
-        enc::BrotliCompress(
-            &mut Cursor::new(source_code),
-            &mut compressed_source_code,
-            &BrotliEncoderParams {
-                quality: 11,
-                ..Default::default()
-            },
-        )?;
+    pub fn new(js: &JS) -> Result<SourceCodeSection> {
         Ok(SourceCodeSection {
-            compressed_source_code,
+            compressed_source_code: js.compress()?,
         })
     }
 }


### PR DESCRIPTION
We do a number of operations on JavaScript source code. We compress it, we compile it to QuickJS bytecode, we load it from a file. Soon we're going to be deriving a list of exported functions from it. Based on the work I'm doing for multiple exports, I think now is a good time to treat the JavaScript as its own type which exposes various representations we can derive from it.

I'm open to suggestions if there's a better name than `JS` for the module or struct.