### PR TITLE
Move alloc functions into a module

### DIFF
--- a/crates/core/src/alloc.rs
+++ b/crates/core/src/alloc.rs
@@ -1,0 +1,35 @@
+use std::alloc::{alloc, dealloc, Layout};
+use std::ptr::copy_nonoverlapping;
+
+// Unlike C's realloc, zero-length allocations need not have
+// unique addresses, so a zero-length allocation may be passed
+// in and also requested, but it's ok to return anything that's
+// non-zero to indicate success.
+const ZERO_SIZE_ALLOCATION_PTR: *mut u8 = 1 as _;
+
+pub unsafe extern "C" fn canonical_abi_realloc(
+    original_ptr: *mut u8,
+    original_size: usize,
+    alignment: usize,
+    new_size: usize,
+) -> *mut std::ffi::c_void {
+    assert!(new_size >= original_size);
+
+    let new_mem = match new_size {
+        0 => ZERO_SIZE_ALLOCATION_PTR,
+        // this call to `alloc` is safe since `new_size` must be > 0
+        _ => alloc(Layout::from_size_align(new_size, alignment).unwrap()),
+    };
+
+    if !original_ptr.is_null() && original_size != 0 {
+        copy_nonoverlapping(original_ptr, new_mem, original_size);
+        canonical_abi_free(original_ptr, original_size, alignment);
+    }
+    new_mem as _
+}
+
+pub unsafe extern "C" fn canonical_abi_free(ptr: *mut u8, size: usize, alignment: usize) {
+    if size > 0 {
+        dealloc(ptr, Layout::from_size_align(size, alignment).unwrap())
+    };
+}


### PR DESCRIPTION
This is a refactoring to cut down on the size of a future code change. As part of implementing support for #405, `main.rs` is also going to need access to an implementation of `canonical_abi_realloc`. Doing this in a separate PR will reduce the size of that future PR and make it easier to review.