### PR TITLE
Use precompiled Wizer in CI to speed it up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,13 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
 
       - name: Install wizer
-        run: cargo install wizer --all-features
+        env:
+          WIZER_VERSION: 3.0.1
+        run: |
+          wget -nv https://github.com/bytecodealliance/wizer/releases/download/v${{ env.WIZER_VERSION }}/wizer-v${{ env.WIZER_VERSION }}-x86_64-macos.tar.xz -O /tmp/wizer.tar.xz
+          mkdir /tmp/wizer
+          tar xvf /tmp/wizer.tar.xz --strip-components=1 -C /tmp/wizer
+          echo "/tmp/wizer" >> $GITHUB_PATH
 
       - name: Install wasi-sdk
         run: make download-wasi-sdk


### PR DESCRIPTION
This step seems to be adding a little over 10 minutes to CI. Installing the precompiled binary seems to work and is much, much faster.