### PR TITLE
Javy-cli set exit code when javy fails

### DIFF
--- a/npm/javy-cli/index.js
+++ b/npm/javy-cli/index.js
@@ -20,13 +20,12 @@ async function main() {
 			await downloadBinary(version);
 		}
 	}
-	try {
-		childProcess.spawnSync(binaryPath(version), getArgs(), {
-			stdio: "inherit",
-		});
-	} catch (e) {
-		if (typeof e?.status === "number") return;
-		console.error(e);
+	const result = childProcess.spawnSync(binaryPath(version), getArgs(), {
+		stdio: "inherit",
+	});
+	process.exitCode = result.status || 1;
+	if (result.error?.code === "ENOENT") {
+		console.error("Failed to start Javy. If on Linux, check if glibc is installed.");
 	}
 }
 main();

--- a/npm/javy-cli/index.js
+++ b/npm/javy-cli/index.js
@@ -23,7 +23,7 @@ async function main() {
 	const result = childProcess.spawnSync(binaryPath(version), getArgs(), {
 		stdio: "inherit",
 	});
-	process.exitCode = result.status || 1;
+	process.exitCode = result.status === null ? 1 : result.status;
 	if (result.error?.code === "ENOENT") {
 		console.error("Failed to start Javy. If on Linux, check if glibc is installed.");
 	}

--- a/npm/javy-cli/package-lock.json
+++ b/npm/javy-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "javy-cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "javy-cli",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "cachedir": "^2.3.0",

--- a/npm/javy-cli/package.json
+++ b/npm/javy-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javy-cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
The `javy-cli` NPM package should exit with Javy's exit code after running Javy. If Javy fails to start, it should exit with a non-zero exit code. Other tools may inspect the exit code of `javy-cli` to determine if running it failed and set their exit code appropriately.

I'm also going to include a stderr line about checking if glibc is installed if a `ENOENT` error code is returned. A few things may cause that like if a binary for the wrong architecture is downloaded. But in our case, it's probably because glibc isn't available and there isn't any output if that's the case.