### PR TITLE
Update javy-cli README and fix building from source

### DIFF
--- a/npm/javy-cli/README.md
+++ b/npm/javy-cli/README.md
@@ -8,20 +8,24 @@ parameters given.
 
 ```
 # Install javy globally
-$ npm install -g javy
+$ npm install -g javy-cli
 
 # Directly invoke it via npm
-$ npx javy
+$ npx javy-cli@latest
 ```
 
 ## Updating javy
 
-The npm package won't download Javy again once its downloaded. If a new
-version of the javy npm package has been published, you can use the following
-invocation to update to the latest release:
+The npm package will automatically download the newest version of Javy if a
+newer version is available.
+
+## Using a specific version of javy
+
+To use a specific version of Javy, set the environment variable
+`FORCE_RELEASE` to the version you would like to use.
 
 ```
-REFRESH_JAVY=1 npx javy
+FORCE_RELEASE=v1.1.0 npx javy-cli@latest
 ```
 
 ## Building from source
@@ -31,7 +35,7 @@ don't work for you for some reason, the npm package can also build Javy from
 source.
 
 ```
-BUILD_JAVY=1 npx javy
+FORCE_FROM_SOURCE=1 npx javy-cli@latest
 ```
 
 Please note that for this to work you must have all prerequisites of Javy

--- a/npm/javy-cli/index.js
+++ b/npm/javy-cli/index.js
@@ -15,7 +15,7 @@ async function main() {
 	const version = await getDesiredVersionNumber();
 	if (!(await isBinaryDownloaded(version))) {
 		if (process.env.FORCE_FROM_SOURCE) {
-			await buildBinary();
+			await buildBinary(version);
 		} else {
 			await downloadBinary(version);
 		}
@@ -51,7 +51,7 @@ async function downloadBinary(version) {
 	const targetPath = binaryPath(version);
 	const compressedStream = await new Promise(async (resolve) => {
 		const url = binaryUrl(version);
-		console.log(`Downloading ${NAME} ${version} to ${targetPath}...`);
+		console.log(`Downloading ${NAME} ${version} to ${targetPath}`);
 		const resp = await fetch(url);
 		resolve(resp.body);
 	});
@@ -150,10 +150,11 @@ function getArgs() {
 	return args;
 }
 
-async function buildBinary() {
+async function buildBinary(version) {
 	const repoDir = cacheDir("build", NAME);
 	try {
 		console.log(`Downloading ${NAME}'s source code...`);
+		fs.rmSync(repoDir, { recursive: true });
 		childProcess.execSync(
 			`git clone https://github.com/${REPO} ${repoDir}`
 		);
@@ -172,6 +173,6 @@ async function buildBinary() {
 	}
 	await fs.promises.rename(
 		path.join(repoDir, "target", "release", NAME),
-		binaryPath()
+		binaryPath(version)
 	);
 }

--- a/npm/javy-cli/package-lock.json
+++ b/npm/javy-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "javy-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "javy-cli",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "cachedir": "^2.3.0",

--- a/npm/javy-cli/package.json
+++ b/npm/javy-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javy-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Updating the README so it's in-sync with what's in the code. I also noticed building from source wasn't working so I made a couple small fixes to get that working.