### PR TITLE
Better error when attempting to export default arrow function

### DIFF
--- a/crates/cli/src/js.rs
+++ b/crates/cli/src/js.rs
@@ -105,6 +105,9 @@ impl JS {
                         }
                     }
                 }
+                ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(e)) if e.expr.is_arrow() => {
+                    bail!("Exported default arrow functions are not supported");
+                }
                 ModuleItem::Stmt(Stmt::Decl(Decl::Fn(f))) => {
                     functions.insert(
                         f.ident.sym,

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -2,7 +2,7 @@ mod common;
 mod runner;
 
 use runner::{Runner, RunnerError};
-use std::str;
+use std::{path::Path, str};
 
 #[test]
 fn test_identity() {
@@ -129,6 +129,19 @@ fn test_exported_functions_without_flag() {
         "failed to find function export `foo`",
         res.err().unwrap().to_string()
     );
+}
+
+#[test]
+fn test_exported_default_arrow_function() {
+    let res = Runner::compile(
+        "exported-default.js",
+        Some(Path::new("exported-default.wit")),
+        Some("exported-default"),
+    );
+    assert_eq!(
+        "Error: Exported default arrow functions are not supported\n",
+        str::from_utf8(&res.unwrap_err().stderr).unwrap()
+    )
 }
 
 #[test]

--- a/crates/cli/tests/sample-scripts/exported-default.js
+++ b/crates/cli/tests/sample-scripts/exported-default.js
@@ -1,0 +1,1 @@
+export default () => { console.log(42); }

--- a/crates/cli/tests/sample-scripts/exported-default.wit
+++ b/crates/cli/tests/sample-scripts/exported-default.wit
@@ -1,0 +1,5 @@
+package local:main
+
+world exported-default {
+    export default: func()
+}


### PR DESCRIPTION
Fixes #422. The error message will now clearly indicate that exporting default arrow functions is not supported.