### PR TITLE
Fix multiword exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,6 +439,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,6 +1340,7 @@ dependencies = [
  "anyhow",
  "binaryen",
  "brotli",
+ "convert_case",
  "criterion",
  "lazy_static",
  "num-format",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -27,6 +27,7 @@ wasi-common = { workspace = true }
 walrus = "0.20.1"
 swc_core = { version = "0.78.15", features = ["common_sourcemap", "ecma_ast", "ecma_parser"] }
 wit-parser = "0.8.0"
+convert_case = "0.4.0"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/cli/src/exports.rs
+++ b/crates/cli/src/exports.rs
@@ -9,7 +9,7 @@ pub struct Export {
     pub js: String,
 }
 
-pub fn determine_js_exports(js: &JS, wit: &Path, wit_world: &str) -> Result<Vec<Export>> {
+pub fn process_exports(js: &JS, wit: &Path, wit_world: &str) -> Result<Vec<Export>> {
     let js_exports = js.exports()?;
     wit::parse_exports(wit, wit_world)?
         .into_iter()

--- a/crates/cli/src/exports.rs
+++ b/crates/cli/src/exports.rs
@@ -1,0 +1,28 @@
+use anyhow::{anyhow, Result};
+use convert_case::{Case, Casing};
+use std::path::Path;
+
+use crate::{js::JS, wit};
+
+pub struct Export {
+    pub wit: String,
+    pub js: String,
+}
+
+pub fn determine_js_exports(js: &JS, wit: &Path, wit_world: &str) -> Result<Vec<Export>> {
+    let js_exports = js.exports()?;
+    wit::parse_exports(wit, wit_world)?
+        .into_iter()
+        .map(|wit_export| {
+            let export = wit_export.from_case(Case::Kebab).to_case(Case::Camel);
+            if !js_exports.contains(&export) {
+                Err(anyhow!("JS module does not export {export}"))
+            } else {
+                Ok(Export {
+                    wit: wit_export,
+                    js: export,
+                })
+            }
+        })
+        .collect::<Result<Vec<Export>>>()
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
                 (None, None) => Ok(vec![]),
                 (None, Some(_)) => Ok(vec![]),
                 (Some(_), None) => bail!("Must provide WIT world when providing WIT file"),
-                (Some(wit), Some(world)) => exports::determine_js_exports(&js, wit, world),
+                (Some(wit), Some(world)) => exports::process_exports(&js, wit, world),
             }?;
             if opts.dynamic {
                 let wasm = dynamic_generator::generate(&js, exports)?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,12 +1,14 @@
 mod bytecode;
 mod commands;
+mod exports;
 mod js;
 mod wasm_generator;
 mod wit;
 
 use crate::commands::{Command, CompileCommandOpts, EmitProviderCommandOpts};
 use crate::wasm_generator::r#static as static_generator;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
+use exports::Export;
 use js::JS;
 use std::env;
 use std::fs::File;
@@ -23,7 +25,12 @@ fn main() -> Result<()> {
         Command::EmitProvider(opts) => emit_provider(opts),
         Command::Compile(opts) => {
             let js = JS::from_file(&opts.input)?;
-            let exports = determine_js_exports(&js, opts)?;
+            let exports = match (&opts.wit, &opts.wit_world) {
+                (None, None) => Ok(vec![]),
+                (None, Some(_)) => Ok(vec![]),
+                (Some(_), None) => bail!("Must provide WIT world when providing WIT file"),
+                (Some(wit), Some(world)) => exports::determine_js_exports(&js, wit, world),
+            }?;
             if opts.dynamic {
                 let wasm = dynamic_generator::generate(&js, exports)?;
                 fs::write(&opts.output, wasm)?;
@@ -44,7 +51,7 @@ fn emit_provider(opts: &EmitProviderCommandOpts) -> Result<()> {
     Ok(())
 }
 
-fn create_statically_linked_module(opts: &CompileCommandOpts, exports: Vec<String>) -> Result<()> {
+fn create_statically_linked_module(opts: &CompileCommandOpts, exports: Vec<Export>) -> Result<()> {
     // The javy-core `main.rs` pre-initializer uses WASI to read the JS source
     // code from stdin. Wizer doesn't let us customize its WASI context so we
     // don't have a better option right now. Since we can't set the content of
@@ -82,23 +89,4 @@ fn create_statically_linked_module(opts: &CompileCommandOpts, exports: Vec<Strin
 
     fs::write(&opts.output, wasm)?;
     Ok(())
-}
-
-fn determine_js_exports(js: &JS, opts: &CompileCommandOpts) -> Result<Vec<String>> {
-    let js_exports = js.exports()?;
-    match (&opts.wit, &opts.wit_world) {
-        (None, None) => Ok(vec![]),
-        (None, Some(_)) => Ok(vec![]),
-        (Some(_), None) => bail!("Must provide WIT world when providing WIT file"),
-        (Some(path), Some(world)) => wit::parse_exports(path, world)?
-            .into_iter()
-            .map(|wit_export| {
-                if !js_exports.contains(&wit_export) {
-                    Err(anyhow!("JS module does not export {wit_export}"))
-                } else {
-                    Ok(wit_export)
-                }
-            })
-            .collect::<Result<Vec<String>>>(),
-    }
 }

--- a/crates/cli/tests/dynamic_linking_test.rs
+++ b/crates/cli/tests/dynamic_linking_test.rs
@@ -20,15 +20,15 @@ pub fn test_dynamic_linking() -> Result<()> {
 
 #[test]
 pub fn test_dynamic_linking_with_func() -> Result<()> {
-    let js_src = "export function foo() { console.log('In foo'); }; console.log('Toplevel');";
+    let js_src = "export function fooBar() { console.log('In foo'); }; console.log('Toplevel');";
     let wit = "
         package local:main
 
         world foo-test {
-            export foo: func()
+            export foo-bar: func()
         }
     ";
-    let log_output = invoke_fn_on_generated_module(js_src, "foo", Some((wit, "foo-test")))?;
+    let log_output = invoke_fn_on_generated_module(js_src, "foo-bar", Some((wit, "foo-test")))?;
     assert_eq!("Toplevel\nIn foo\n", &log_output);
     Ok(())
 }

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -107,6 +107,8 @@ fn test_exported_functions() {
     let (_, logs, fuel_consumed) = run_fn(&mut runner, "foo", &[]);
     assert_eq!("Hello from top-level\nHello from foo\n", logs);
     assert_fuel_consumed_within_threshold(54610, fuel_consumed);
+    let (_, logs, _) = run_fn(&mut runner, "foo-bar", &[]);
+    assert_eq!("Hello from top-level\nHello from fooBar\n", logs);
 }
 
 #[cfg(feature = "experimental_event_loop")]

--- a/crates/cli/tests/sample-scripts/exported-fn.js
+++ b/crates/cli/tests/sample-scripts/exported-fn.js
@@ -6,4 +6,8 @@ export function foo() {
     console.log("Hello from foo");
 }
 
+export function fooBar() {
+    console.log("Hello from fooBar");
+}
+
 console.log("Hello from top-level");

--- a/crates/cli/tests/sample-scripts/exported-fn.wit
+++ b/crates/cli/tests/sample-scripts/exported-fn.wit
@@ -3,4 +3,5 @@ package local:test
 world exported-fn {
   export foo: func()
   export bar: func()
+  export foo-bar: func()
 }

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1130,6 +1130,12 @@ who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
 version = "1.0.58"
 
+[[audits.embark-studios.audits.convert_case]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+notes = "No unsafe usage or ambient capabilities"
+
 [[audits.embark-studios.audits.epaint]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Fixes #420.

We translate the kebab-cased identifiers in the WIT file to camel-cased identifiers in the JavaScript and retain the kebab-cased identifiers for the name of the Wasm function exports since the WIT describes the export names for the Wasm.