### PR TITLE
Fix default exports

### DIFF
--- a/crates/cli/src/js.rs
+++ b/crates/cli/src/js.rs
@@ -105,6 +105,12 @@ impl JS {
                         }
                     }
                 }
+                ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(e)) if e.decl.is_fn_expr() => {
+                    exported_functions.push("default".into())
+                }
+                ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(e)) if e.expr.is_arrow() => {
+                    exported_functions.push("default".into())
+                }
                 ModuleItem::Stmt(Stmt::Decl(Decl::Fn(f))) => {
                     functions.insert(
                         f.ident.sym,
@@ -288,6 +294,20 @@ mod tests {
     fn parse_hoisted_exports_with_func_and_const() -> Result<()> {
         let exports = parse("export { foo, bar }; function foo() {}; const bar = 1;")?;
         assert_eq!(vec!["foo"], exports);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_default_arrow_export() -> Result<()> {
+        let exports = parse("export default () => {}")?;
+        assert_eq!(vec!["default"], exports);
+        Ok(())
+    }
+
+    #[test]
+    fn parse_default_function_export() -> Result<()> {
+        let exports = parse("export default function() {}")?;
+        assert_eq!(vec!["default"], exports);
         Ok(())
     }
 

--- a/crates/cli/tests/dynamic_linking_test.rs
+++ b/crates/cli/tests/dynamic_linking_test.rs
@@ -56,6 +56,22 @@ pub fn test_dynamic_linking_with_no_exports_does_not_import_invoke() -> Result<(
 }
 
 #[test]
+pub fn test_dynamic_linking_with_arrow_fn() -> Result<()> {
+    let js_src = "export default () => console.log(42)";
+    let wit = "
+        package local:test
+
+        world exported-arrow {
+            export default: func()
+        }
+    ";
+    let log_output =
+        invoke_fn_on_generated_module(js_src, "default", Some((wit, "exported-arrow")))?;
+    assert_eq!("42\n", log_output);
+    Ok(())
+}
+
+#[test]
 fn test_producers_section_present() -> Result<()> {
     let js_wasm = create_dynamically_linked_wasm_module("console.log(42)", None)?;
     common::assert_producers_section_is_correct(&js_wasm)?;

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -159,6 +159,30 @@ fn test_same_module_outputs_different_random_result() {
     // https://github.com/bytecodealliance/javy/issues/401 for investigating the cause.
 }
 
+#[test]
+fn test_exported_default_arrow_fn() {
+    let mut runner = Runner::new_with_exports(
+        "exported-default-arrow-fn.js",
+        "exported-default-arrow-fn.wit",
+        "exported-arrow",
+    );
+    let (_, logs, fuel_consumed) = run_fn(&mut runner, "default", &[]);
+    assert_eq!(logs, "42\n");
+    assert_fuel_consumed_within_threshold(48_628, fuel_consumed);
+}
+
+#[test]
+fn test_exported_default_fn() {
+    let mut runner = Runner::new_with_exports(
+        "exported-default-fn.js",
+        "exported-default-fn.wit",
+        "exported-default",
+    );
+    let (_, logs, fuel_consumed) = run_fn(&mut runner, "default", &[]);
+    assert_eq!(logs, "42\n");
+    assert_fuel_consumed_within_threshold(49_748, fuel_consumed);
+}
+
 fn run_with_u8s(r: &mut Runner, stdin: u8) -> (u8, String, u64) {
     let (output, logs, fuel_consumed) = run(r, &stdin.to_le_bytes());
     assert_eq!(1, output.len());

--- a/crates/cli/tests/sample-scripts/exported-default-arrow-fn.js
+++ b/crates/cli/tests/sample-scripts/exported-default-arrow-fn.js
@@ -1,0 +1,1 @@
+export default () => console.log(42)

--- a/crates/cli/tests/sample-scripts/exported-default-arrow-fn.wit
+++ b/crates/cli/tests/sample-scripts/exported-default-arrow-fn.wit
@@ -1,0 +1,5 @@
+package local:test
+
+world exported-arrow {
+  export default: func()
+}

--- a/crates/cli/tests/sample-scripts/exported-default-fn.js
+++ b/crates/cli/tests/sample-scripts/exported-default-fn.js
@@ -1,0 +1,3 @@
+export default function () {
+    console.log(42);
+}

--- a/crates/cli/tests/sample-scripts/exported-default-fn.wit
+++ b/crates/cli/tests/sample-scripts/exported-default-fn.wit
@@ -1,0 +1,5 @@
+package local:test
+
+world exported-default {
+  export default: func()
+}

--- a/crates/core/src/execution.rs
+++ b/crates/core/src/execution.rs
@@ -13,11 +13,13 @@ pub fn run_bytecode(runtime: &Runtime, bytecode: &[u8]) {
 
 pub fn invoke_function(runtime: &Runtime, fn_module: &str, fn_name: &str) {
     let context = runtime.context();
+    let js = if fn_name == "default" {
+        format!("import {{ default as defaultFn }} from '{fn_module}'; defaultFn();")
+    } else {
+        format!("import {{ {fn_name} }} from '{fn_module}'; {fn_name}();")
+    };
     context
-        .eval_module(
-            "runtime.mjs",
-            &format!("import {{ {fn_name} }} from '{fn_module}'; {fn_name}();"),
-        )
+        .eval_module("runtime.mjs", &js)
         .and_then(|_| process_event_loop(context))
         .unwrap_or_else(handle_error);
 }


### PR DESCRIPTION
Fixes #422.

We use the export name `default` as the Wasm function export name. This is similar to how you can import a default exported function in JS with:

```js
import { default as foo } from './bar.mjs'
```

This does require a change to the QuickJS provider but it's backwards compatible since the change only affects trying to run a default named `export` which wasn't previously possible to export.