### PR TITLE
Only link wasi preview1 to slightly reduce build times

### DIFF
--- a/crates/cli/src/bytecode.rs
+++ b/crates/cli/src/bytecode.rs
@@ -18,7 +18,7 @@ fn create_wasm_env() -> Result<(Store<WasiCtx>, Instance, Memory)> {
     let engine = Engine::default();
     let module = Module::new(&engine, QUICKJS_PROVIDER_MODULE)?;
     let mut linker = Linker::new(&engine);
-    wasmtime_wasi::add_to_linker(&mut linker, |s| s)?;
+    wasmtime_wasi::snapshots::preview_1::add_wasi_snapshot_preview1_to_linker(&mut linker, |s| s)?;
     let wasi = WasiCtxBuilder::new().inherit_stderr().build();
     let mut store = Store::new(&engine, wasi);
     let instance = linker.instantiate(&mut store, &module)?;


### PR DESCRIPTION
Part of #324. I ran an analysis of what's producing the most LLVM lines in the CLI and it looks like `wasmtime_wasi::sync::snapshots::preview_1::add_wasi_snapshot_preview1_to_linker` and `wasmtime_wasi::sync::snapshots::preview_0::add_wasi_unstable_to_linker` were adding about 5% each.

```
➜  javy git:(main) ✗ cargo llvm-lines -p javy-cli | head -20
   Compiling javy-cli v1.1.1 (/Users/jeffcharles/src/github.com/Shopify/javy/crates/cli)
    Finished dev [unoptimized + debuginfo] target(s) in 5.22s
  Lines                 Copies              Function name
  -----                 ------              -------------
  293637                5121                (TOTAL)
   14296 (4.9%,  4.9%)    46 (0.9%,  0.9%)  wasmtime_wasi::sync::snapshots::preview_1::add_wasi_snapshot_preview1_to_linker::{{closure}}::{{closure}}
   13988 (4.8%,  9.6%)    45 (0.9%,  1.8%)  wasmtime_wasi::sync::snapshots::preview_0::add_wasi_unstable_to_linker::{{closure}}::{{closure}}
   10776 (3.7%, 13.3%)   109 (2.1%,  3.9%)  alloc::alloc::box_free
    9828 (3.3%, 16.6%)    91 (1.8%,  5.7%)  wasmtime::linker::Linker<T>::func_wrap
    6481 (2.2%, 18.9%)    91 (1.8%,  7.5%)  wiggle::run_in_dummy_executor
    5921 (2.0%, 20.9%)    91 (1.8%,  9.2%)  wasmtime::func::Caller<T>::with
    5320 (1.8%, 22.7%)    28 (0.5%,  9.8%)  <F as wasmtime::func::IntoFunc<T,(wasmtime::func::Caller<T>,A1,A2),R>>::into_func::wasm_to_host_shim::{{closure}}
    5005 (1.7%, 24.4%)    91 (1.8%, 11.6%)  wasmtime::func::HostFunc::wrap
    4648 (1.6%, 26.0%)    28 (0.5%, 12.1%)  <F as wasmtime::func::IntoFunc<T,(wasmtime::func::Caller<T>,A1,A2),R>>::into_func::wasm_to_host_shim::{{closure}}::{{closure}}
    4419 (1.5%, 27.5%)     9 (0.2%, 12.3%)  brotli::enc::backward_references::CreateBackwardReferences
    4290 (1.5%, 28.9%)     3 (0.1%, 12.3%)  brotli::enc::block_splitter::ClusterBlocks
    4266 (1.5%, 30.4%)   193 (3.8%, 16.1%)  alloc::boxed::Box<T>::new
    4186 (1.4%, 31.8%)    91 (1.8%, 17.9%)  std::panicking::try::do_catch
    3937 (1.3%, 33.2%)    91 (1.8%, 19.7%)  std::panicking::try
    3804 (1.3%, 34.5%)     4 (0.1%, 19.7%)  brotli::enc::brotli_bit_stream::process_command_queue
    3797 (1.3%, 35.7%)    46 (0.9%, 20.6%)  core::ptr::drop_in_place<wasmtime_wasi::sync::snapshots::preview_1::add_wasi_snapshot_preview1_to_linker<wasi_common::ctx::WasiCtx,wasi_common::ctx::WasiCtx,javy::bytecode::create_wasm_env::{{closure}}>::{{closure}}::{{closure}}>
    3715 (1.3%, 37.0%)    45 (0.9%, 21.5%)  core::ptr::drop_in_place<wasmtime_wasi::sync::snapshots::preview_0::add_wasi_unstable_to_linker<wasi_common::ctx::WasiCtx,wasi_common::ctx::WasiCtx,javy::bytecode::create_wasm_env::{{closure}}>::{{closure}}::{{closure}}>
```

We can safely remove the call to add WASI unstable since the provider module doesn't import any of those. This is a very small decrease in build times but seemed like an easy reduction given it's a one line code change.