### PR TITLE
Reduce usage of wizer CLI since we no longer need it

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -28,7 +28,13 @@ jobs:
         run: make download-wasi-sdk
 
       - name: Install wizer
-        run: cargo install wizer --all-features
+        env:
+          WIZER_VERSION: 3.0.1
+        run: |
+          wget -nv https://github.com/bytecodealliance/wizer/releases/download/v${{ env.WIZER_VERSION }}/wizer-v${{ env.WIZER_VERSION }}-x86_64-macos.tar.xz -O /tmp/wizer.tar.xz
+          mkdir /tmp/wizer
+          tar xvf /tmp/wizer.tar.xz --strip-components=1 -C /tmp/wizer
+          echo "/tmp/wizer" >> $GITHUB_PATH
 
       - name: Make core
         run: make core
@@ -45,8 +51,10 @@ jobs:
           name: provider
           path: target/wasm32-wasi/release/javy_quickjs_provider.wasm
 
-      - name: Archive wizened quickjs_provider
-        run: gzip -k -f target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm && mv target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm.gz javy-quickjs_provider.wasm.gz
+      - name: Wizen and archive wizened quickjs_provider
+        run: |
+          wizer target/wasm32-wasi/release/javy_quickjs_provider.wasm --allow-wasi --wasm-bulk-memory true -o target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm
+          gzip -k -f target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm && mv target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm.gz javy-quickjs_provider.wasm.gz
 
       - name: Upload archived quickjs_provider to artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,6 @@ jobs:
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
-      - name: Install wizer
-        env:
-          WIZER_VERSION: 3.0.1
-        run: |
-          wget -nv https://github.com/bytecodealliance/wizer/releases/download/v${{ env.WIZER_VERSION }}/wizer-v${{ env.WIZER_VERSION }}-x86_64-macos.tar.xz -O /tmp/wizer.tar.xz
-          mkdir /tmp/wizer
-          tar xvf /tmp/wizer.tar.xz --strip-components=1 -C /tmp/wizer
-          echo "/tmp/wizer" >> $GITHUB_PATH
-
       - name: Install wasi-sdk
         run: make download-wasi-sdk
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ cli: core
 
 core:
 	cargo build --package=javy-core --release --target=wasm32-wasi --features=$(CORE_FEATURES)
-	wizer target/wasm32-wasi/release/javy_quickjs_provider.wasm --allow-wasi --wasm-bulk-memory true -o target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm
 
 docs:
 	cargo doc --package=javy-cli --open

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Read our [contribution documentation](docs/contributing.md) for additional infor
 - wasmtime-cli, can be installed via `cargo install wasmtime-cli` (required for
   `cargo-wasi`)
 - cargo-wasi, can be installed via `cargo install cargo-wasi`
-- wizer, can be installed via `cargo install wizer --all-features`
 - cargo-hack, can be installed via `cargo +stable install cargo-hack --locked`
 
 ## How to build


### PR DESCRIPTION
This stops using the Wizer CLI everywhere except for the build assets workflow. https://github.com/bytecodealliance/javy/blob/main/crates/cli/build.rs wizens the QuickJS provider Wasm module. The build assets workflow still needs the Wizer CLI since the unwizened version is unusable without wizening so it's best if we upload a wizened version. This also cleans up the CI pipeline a little.