### PR TITLE
Run WPT in separate workflow from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,8 @@ jobs:
         run: make download-wasi-sdk
 
       - name: Tests
-        run: make tests
+        # Everything but WPT
+        run: make test-quickjs-wasm-rs test-javy test-apis test-core test-cli
 
       - name: Check benchmarks
         run: make check-bench

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -1,0 +1,46 @@
+name: WPT CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  wpt:
+    name: wpt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Cargo Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo
+
+      - name: Cargo Target Cache
+        uses: actions/cache@v3
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}
+            ${{ runner.os }}-cargo-target
+
+      - name: Install wasmtime-cli
+        env:
+          WASMTIME_VERSION: 8.0.0
+        run: |
+          wget -nv 'https://github.com/bytecodealliance/wasmtime/releases/download/v${{ env.WASMTIME_VERSION }}/wasmtime-v${{ env.WASMTIME_VERSION }}-x86_64-linux.tar.xz' -O /tmp/wasmtime.tar.xz
+          mkdir /tmp/wasmtime
+          tar xvf /tmp/wasmtime.tar.xz --strip-components=1 -C /tmp/wasmtime
+          echo "/tmp/wasmtime" >> $GITHUB_PATH
+
+      - name: WPT
+        run: make test-wpt

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ cli: core
 
 core:
 	cargo build --package=javy-core --release --target=wasm32-wasi --features=$(CORE_FEATURES)
-	wizer target/wasm32-wasi/release/javy_quickjs_provider.wasm --allow-wasi --wasm-bulk-memory true -o target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm
 
 docs:
 	cargo doc --package=javy-cli --open


### PR DESCRIPTION
Part of #324. Splitting WPT off into its own workflow substantially reduces the time for CI to complete (see [WPT run on my fork](https://github.com/jeffcharles/javy/actions/runs/5524241631) and [CI run on my fork](https://github.com/jeffcharles/javy/actions/runs/5524241626)).

A big part of the explanation for why it reduces CI time is WPT forces a recompilation of `javy-core` since we need to enable promise support and that also forces a recompilation of `javy-cli`. Since we're already using a different `javy-core` with promises enabled, I think we can safely run this on Linux which has faster compile times. We might be able to get this to run even faster in the future by using `lld` or `mold` for linking the CLI but I'll save that for a future PR.

This also pulls in part of #430 since I don't want to just have to remove Wizer later.