### PR TITLE
Disable LTO for CLI in Makefile (CI and local builds)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,9 @@ bench: cli
 check-bench:
 	cargo check --package=javy-cli --release --benches
 
+# Disabling LTO substantially improves compile time
 cli: core
-	cargo build --package=javy-cli --release
+	CARGO_PROFILE_RELEASE_LTO=off cargo build --package=javy-cli --release
 
 core:
 	cargo build --package=javy-core --release --target=wasm32-wasi --features=$(CORE_FEATURES)
@@ -37,8 +38,9 @@ test-core:
 
 # Test in release mode to skip some debug assertions
 # Note: to make this faster, the engine should be optimized beforehand (wasm-strip + wasm-opt).
+# Disabling LTO substantially improves compile time
 test-cli: core
-	cargo test --package=javy-cli --release --features=$(CLI_FEATURES) -- --nocapture
+	CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-cli --release --features=$(CLI_FEATURES) -- --nocapture
 
 # WPT requires a Javy build with the experimental_event_loop feature to pass
 test-wpt: export CORE_FEATURES ?= experimental_event_loop

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ $ cargo build -p javy-core --target=wasm32-wasi -r
 $ cargo install --path crates/cli
 ```
 
+If you are going to recompile frequently, you may want to prepend `CARGO_PROFILE_RELEASE_LTO=off` to cargo build for the CLI to speed up the build.
+
 ## Using Javy
 
 Pre-compiled binaries of the Javy CLI can be found on [the releases page](https://github.com/bytecodealliance/javy/releases).


### PR DESCRIPTION
This reduces build times for the CLI by two minutes. This is super convenient for local development since otherwise it takes 2 minutes on my machine for the CLI to recompile with minimal changes and only a few seconds with this change.

I could not find a `cargo build` flag I could pass to do this. I also couldn't figure out the Makefile syntax to make `CARGO_PROFILE_RELEASE_LTO` overridable.