### PR TITLE
Add CHANGELOGs to NPM packages

### DIFF
--- a/npm/javy-cli/CHANGELOG.md
+++ b/npm/javy-cli/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased

--- a/npm/javy/CHANGELOG.md
+++ b/npm/javy/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased


### PR DESCRIPTION
We should track changes to the NPM packages in a CHANGELOG file similar to how we do so for the Rust crates.