### PR TITLE
Fix missing HTTP status check in javy-cli

### DIFF
--- a/npm/javy-cli/CHANGELOG.md
+++ b/npm/javy-cli/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [2023-07-28] - 0.1.8
+## [0.1.8] - 2023-07-28
 
 ### Fixed
 

--- a/npm/javy-cli/CHANGELOG.md
+++ b/npm/javy-cli/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [2023-07-28] - 0.1.8
+
+### Fixed
+
+- HTTP response status codes other than 200 when downloading Javy binary now throws an error

--- a/npm/javy-cli/package-lock.json
+++ b/npm/javy-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "javy-cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "javy-cli",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "cachedir": "^2.3.0",

--- a/npm/javy-cli/package.json
+++ b/npm/javy-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javy-cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
We aren't checking the status code on the response when fetching the Javy binary which would result in the response bodies from non-200 requests being forwarded to the gunzip step. This step would fail but an empty `javy-v${version}` file would still be created. This empty file would not have the execute bit set because the function would throw as a result of the failed gunzip error. On future runs, the binary wouldn't be redownloaded because `javy-cli` would see there's a file present in the location it's expecting. But running this file would always fail with an `EACCES` error code because the execute bit isn't set.

This PR adds a status code check on the response from GitHub and throws if it's not 200. That should prevent the empty `javy-v${version}` file from being created. I also added an additional check on the possible error code after trying to run Javy so we can delete any invalid cached `javy` binaries since they'll never work and they stop Javy from redownloading the file in the future. There's probably an implementation where I could retry the download and rerun but that would be a more complicated change and should probably be left for a future PR if we're going to do it.

I'm also adding a try/catch around the main implementation where we write the error to stderr and set a non-zero exit code. Node has handling for uncaught promise reject but it adds a lot noise to the stderr output. I think having a cleaner output is a better dev experience.