### PR TITLE
Remove make from GH workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,16 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
 
       - name: Tests
-        # Everything but WPT
-        run: make test-quickjs-wasm-rs test-javy test-apis test-core test-cli
+        run: |
+          cargo hack wasi test --workspace --exclude=javy-cli --each-feature -- --nocapture
+          cargo build --package=javy-core --release --target=wasm32-wasi
+          CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-cli --release -- --nocapture
 
       - name: Check benchmarks
-        run: make check-bench
+        run: CARGO_PROFILE_RELEASE_LTO=off cargo check --package=javy-cli --release --benches
 
       - name: Lint
-        run: make fmt
+        run: |
+          cargo fmt -- --check
+          cargo clippy --workspace --exclude=javy-cli --target=wasm32-wasi --all-targets -- -D warnings
+          CARGO_PROFILE_RELEASE_LTO=off cargo clippy --package=javy-cli --release --all-targets -- -D warnings

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -43,4 +43,8 @@ jobs:
           echo "/tmp/wasmtime" >> $GITHUB_PATH
 
       - name: WPT
-        run: make test-wpt
+        run: |
+          cargo build --package=javy-core --release --target=wasm32-wasi --features=experimental_event_loop
+          CARGO_PROFILE_RELEASE_LTO=off cargo build --package=javy-cli --release
+          npm install --prefix wpt
+          npm test --prefix wpt


### PR DESCRIPTION
Stop using `make` in GitHub workflows. This could make it easier to switch to using MacOS to build javy-core and Ubuntu for CLI builds and testing in CI to speed up CI. This would be because we would no longer be depending on the Makefile to handle the dependency resolution for running the javy-core crate before building or testing javy-cli and we're instead making that explicit in the CI workflow. The reason for continuing to build javy-core in MacOS is we see different fuel usage for the same JS but using javy-core built on different operating systems and MacOS has the lowest fuel usage. But I've measured that Ubuntu seems to compile the CLI faster. I have branch where I tried using Ubuntu for CLI builds and testing and MacOS for `javy-core` but the changes look messy when using `make` for some things and not for others.

Also we should probably move away from using `make` where possible anyway since it's not idiomatic in Rust projects.