### PR TITLE
Stop using subprocess when generating Wasm

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,16 +5,13 @@ mod js;
 mod wasm_generator;
 mod wit;
 
-use crate::commands::{Command, CompileCommandOpts, EmitProviderCommandOpts};
+use crate::commands::{Command, EmitProviderCommandOpts};
 use crate::wasm_generator::r#static as static_generator;
 use anyhow::{bail, Result};
-use exports::Export;
 use js::JS;
-use std::env;
+use std::fs;
 use std::fs::File;
 use std::io::Write;
-use std::process::Stdio;
-use std::{fs, process::Command as OsCommand};
 use structopt::StructOpt;
 use wasm_generator::dynamic as dynamic_generator;
 
@@ -31,12 +28,12 @@ fn main() -> Result<()> {
                 (Some(_), None) => bail!("Must provide WIT world when providing WIT file"),
                 (Some(wit), Some(world)) => exports::process_exports(&js, wit, world),
             }?;
-            if opts.dynamic {
-                let wasm = dynamic_generator::generate(&js, exports)?;
-                fs::write(&opts.output, wasm)?;
+            let wasm = if opts.dynamic {
+                dynamic_generator::generate(&js, exports)?
             } else {
-                create_statically_linked_module(opts, exports)?;
-            }
+                static_generator::generate(&js, exports)?
+            };
+            fs::write(&opts.output, wasm)?;
             Ok(())
         }
     }
@@ -48,45 +45,5 @@ fn emit_provider(opts: &EmitProviderCommandOpts) -> Result<()> {
         _ => Box::new(std::io::stdout()),
     };
     file.write_all(bytecode::QUICKJS_PROVIDER_MODULE)?;
-    Ok(())
-}
-
-fn create_statically_linked_module(opts: &CompileCommandOpts, exports: Vec<Export>) -> Result<()> {
-    // The javy-core `main.rs` pre-initializer uses WASI to read the JS source
-    // code from stdin. Wizer doesn't let us customize its WASI context so we
-    // don't have a better option right now. Since we can't set the content of
-    // the stdin stream for the main Javy process, we create a subprocess and
-    // set the content of the subprocess's stdin stream, and we run Wizer
-    // within that subprocess. The subprocess runs the same Javy command but
-    // with an env var set, in both cases we end up in this method, and we
-    // can use the env var to tell if we're not in the subprocess and we need
-    // to start the subprocess or we are in the subprocess and we can run Wizer.
-    const IN_SUBPROCESS_KEY: &str = "JAVY_WIZEN";
-    const IN_SUBPROCESS_VAL: &str = "1";
-    let in_subprocess = env::var(IN_SUBPROCESS_KEY).is_ok_and(|v| v == IN_SUBPROCESS_VAL);
-    let wasm = if !in_subprocess {
-        let js = JS::from_file(&opts.input)?;
-
-        let mut args = env::args();
-        let self_cmd = args.next().unwrap();
-        let mut command = OsCommand::new(self_cmd)
-            .args(args)
-            .env(IN_SUBPROCESS_KEY, IN_SUBPROCESS_VAL)
-            .stdin(Stdio::piped())
-            .spawn()?;
-        command.stdin.take().unwrap().write_all(js.as_bytes())?;
-        let status = command.wait()?;
-        if !status.success() {
-            bail!("Couldn't create wasm from input");
-        }
-
-        // The subprocess should have written some Wasm so we can refine it now.
-        let wizened_wasm = fs::read(&opts.output)?;
-        static_generator::refine(wizened_wasm, &js, exports)?
-    } else {
-        static_generator::generate()?
-    };
-
-    fs::write(&opts.output, wasm)?;
     Ok(())
 }

--- a/crates/cli/src/wasm_generator/static.rs
+++ b/crates/cli/src/wasm_generator/static.rs
@@ -33,8 +33,8 @@ pub fn generate(js: &JS, exports: Vec<Export>) -> Result<Vec<u8>> {
     let wasm = Wizer::new()
         .make_linker(Some(Rc::new(|engine| {
             let mut linker = Linker::new(engine);
-            wasmtime_wasi::add_to_linker(&mut linker, |ctx: &mut Option<WasiCtx>| {
-                ctx.as_mut().or_else(|| unsafe { WASI.get_mut() }).unwrap()
+            wasmtime_wasi::add_to_linker(&mut linker, |_ctx: &mut Option<WasiCtx>| {
+                unsafe { WASI.get_mut() }.unwrap()
             })?;
             Ok(linker)
         })))?

--- a/crates/cli/src/wasm_generator/static.rs
+++ b/crates/cli/src/wasm_generator/static.rs
@@ -25,7 +25,8 @@ pub fn generate(js: &JS, exports: Vec<Export>) -> Result<Vec<u8>> {
     // We can't move the WasiCtx into `make_linker` since WasiCtx doesn't implement the `Copy` trait.
     // So we move the WasiCtx into a mutable static OnceLock instead.
     // Setting the value in the `OnceLock` and getting the reference back from it should be safe given
-    // we're never executing this code concurrently.
+    // we're never executing this code concurrently. This code will also fail if `generate` is invoked
+    // more than once per execution.
     if unsafe { WASI.set(wasi) }.is_err() {
         panic!("Failed to set WASI static variable")
     }


### PR DESCRIPTION
I was looking at something earlier today and got inspired. We can use the `make_linker` method on Wizer to pass a custom WASI context with the stdin set to the JS source code. This means we don't need to create a subprocess to set the stdin to the JS source code for Wizer. I think not using a subprocess reduces the complexity involved with generating a statically linked Wasm module. It also opens the door for potentially switching to using a deterministic WASI context when creating JS modules in the future.

The one additional piece of complexity that gets pulled in is we now have to use a mutable static `OnceLock` in the static generator code which means we would not be able to run that code concurrently. I don't know when or why we would want to do that so this seems like an acceptable tradeoff to me.