### PR TITLE
v1.1.0 for quickjs-wasm-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-sys"
-version = "1.1.0-alpha.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-sys = { version = "1.1.0-alpha.1", path = "../quickjs-wasm-sys" }
+quickjs-wasm-sys = { version = "1.1.0", path = "../quickjs-wasm-sys" }
 serde = { version = "1.0", features = ["derive"] }
 once_cell = "1.16"
 

--- a/crates/quickjs-wasm-sys/CHANGELOG.md
+++ b/crates/quickjs-wasm-sys/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.1.0 - 2023-07-24
+
 - Added: `QUICKJS_WASM_SYS_WASI_SDK_MAJOR_VERSION` and `QUICKJS_WASM_SYS_WASI_SDK_MINOR_VERSION` build-time environment variables to control which version of the WASI SDK to use.
 - Fixed: Changing the `QUICKJS_WASM_SYS_WASI_SDK_PATH` build time environment variable will trigger a rebuild of the crate.
+- Changed: Crate now automatically downloads WASI SDK if `QUICKJS_WASM_SYS_WASI_SDK_PATH` is not set at build time
 
 ## 1.0.0 - 2023-05-16
 

--- a/crates/quickjs-wasm-sys/Cargo.toml
+++ b/crates/quickjs-wasm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-sys"
-version = "1.1.0-alpha.1"
+version = "1.1.0"
 authors.workspace = true
 edition.workspace = true 
 license.workspace = true


### PR DESCRIPTION
Publishing a new version of `quickjs-wasm-sys` will allow us to test if docs.rs can build the crate or not. We should also publish a new version of the crate anyway given the steps to build it have been simplified with the built-in logic to download the WASI SDK automatically.