### PR TITLE
Update javy NPM package changelog for 0.1.2 version

### DIFF
--- a/npm/javy/CHANGELOG.md
+++ b/npm/javy/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.1.2] - 2023-07-28
+
+### Added
+
+- New README content providing a description of the APIs exposed by the package.


### PR DESCRIPTION
I realized I should've waited to merge #441 and updated the changelog after merging #440. Better late than never.