### PR TITLE
Test javy-cli on Node versions 16, 18, and 20

### DIFF
--- a/.github/workflows/ci-npm-javy-cli.yml
+++ b/.github/workflows/ci-npm-javy-cli.yml
@@ -8,15 +8,20 @@ on:
 
 jobs:
   test:
-    name: npm_test-${{ matrix.os }}
+    name: npm_test-${{ matrix.os }}-${{ matrix.node }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [16, 18, 20]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
 
       - run: npm install
         working-directory: npm/javy-cli


### PR DESCRIPTION
We want to ensure `javy-cli` works as expected against the last few stable Node versions.