### PR TITLE
Automatically publish new versions of NPM packages

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,40 @@
+name: NPM package publishing
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish_npm:
+    name: Publish ${{ matrix.package }} NPM package
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [javy, javy-cli]
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install package dependencies
+        run: npm install
+        working-directory: npm/${{ matrix.package }}
+
+      - name: Build NPM package
+        if: matrix.package == 'javy'
+        run: npm run build
+        working-directory: npm/${{ matrix.package }}
+
+      - name: Publish NPM package if new version
+        run: |
+          if [[ $(cat package.json | jq -r .version) == $(npm view ${{ matrix.package }} version) ]]; then
+            echo "Skipping publish because the version is already published"
+          else
+            npm publish
+          fi
+        working-directory: npm/${{ matrix.package }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This change should result in automatically building the javy NPM package and publishing both javy and javy-cli NPM packages to NPM when there is a commit that increments the NPM package version.

I'm thinking I'll follow this up with a PR to bump the patch version on `javy-cli` to verify this works as expected unless someone has an objection.

I've set up an NPM automation token on my Shopify NPM account as a `NPM_TOKEN` secret for GitHub runs. This is similar to how [Wizer](https://github.com/bytecodealliance/wizer/blob/c7e07054d04c27e7f1bfe72e16dae6d73b3f3023/.github/workflows/release.yml#L130) publishes their NPM packages. Since we don't use tags for NPM releases, I have to check if the version has already been published before attempting to publish since already published versions will result in the publish step returning a non-zero exit code.

The logic in here does not account for decrementing the version in an NPM package and will still attempt to publish and fail if the NPM package version is decremented. I think this is okay since I don't expect us to have a legitimate use case for doing that and if were to have one, we could ignore the failure until changing the version back to either the latest version or an unpublished version. If we do find we need to accommodate this use case, we can invest in a more complex solution at that point.