### PR TITLE
Version crates to 2.0.0 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "quickjs-wasm-rs",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "javy-apis"
-version = "1.1.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "fastrand",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ wasmtime-wasi = "9.0"
 wasi-common = "9.0"
 anyhow = "1.0"
 once_cell = "1.16"
-javy = { path = "crates/javy", version = "1.0.0" }
+javy = { path = "crates/javy", version = "2.0.0" }
 
 [profile.release]
 lto = true

--- a/crates/apis/CHANGELOG.md
+++ b/crates/apis/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-* Added `random` feature to override `Math.random` implementation with one that sets the random seed on first use of `Math.random`
+## 2.0.0 - 2023-08-17
+
+### Added
+- `random` feature to override `Math.random` implementation with one that sets the random seed on first use of `Math.random`.
+
+### Changed
+- `javy` dependency is now at version 2.0.0.
 
 ## 1.0.0 - 2023-05-17
 

--- a/crates/apis/CHANGELOG.md
+++ b/crates/apis/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `javy` dependency is now at version 2.0.0.
+- WASI SDK will be automatically downloaded at build time if `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable is not set.
 
 ## 1.0.0 - 2023-05-17
 

--- a/crates/apis/Cargo.toml
+++ b/crates/apis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-apis"
-version = "1.1.0-alpha.1"
+version = "2.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update of `quickjs` types to use types in `quickjs-wasm-rs` 2.0.0.
+- WASI SDK will be automatically downloaded at build time if `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable is not set.
 
 ## 1.0.0 - 2023-05-16
 

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 2.0.0 - 2023-08-17
+
+### Changed
+
+- Update of `quickjs` types to use types in `quickjs-wasm-rs` 2.0.0.
+
 ## 1.0.0 - 2023-05-16
 
 Initial release

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "1.0.0"
+version = "2.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -11,7 +11,7 @@ categories = ["wasm"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-rs = { version = "2.0.0-alpha.1", path = "../quickjs-wasm-rs" }
+quickjs-wasm-rs = { version = "2.0.0", path = "../quickjs-wasm-rs" }
 serde_json = { version = "1.0", optional = true }
 serde-transcode = { version = "1.1", optional = true }
 rmp-serde = { version = "^1.1", optional = true }

--- a/crates/quickjs-wasm-rs/CHANGELOG.md
+++ b/crates/quickjs-wasm-rs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Callback functions registered with `context.wrap_callback` now pass `JSValueRef` into the closure instead of `CallbackArg`.
 - `from_qjs_value` now takes `JSValueRef` by value.
+- Updated to `quickjs-wasm-sys` version `1.1.0` which will automatically download a WASI SDK if the `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable is not set.
 
 ### Removed
 - `CallbackArg` type.

--- a/crates/quickjs-wasm-rs/CHANGELOG.md
+++ b/crates/quickjs-wasm-rs/CHANGELOG.md
@@ -5,18 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
+
+## [2.0.0] - 2023-08-17
 
 ### Added
-- `JSValueRef` can convert to Rust types with `try_into` (previously this was implemented on `CallbackArg`)
-- Added `eval_module` method on `JSContextRef` that evaluates JS code in a ECMAScript module scope
+- `JSValueRef` can convert to Rust types with `try_into` (previously this was implemented on `CallbackArg`).
+- Added `eval_module` method on `JSContextRef` that evaluates JS code in a ECMAScript module scope.
 
 ### Changed
-- Callback functions registered with `context.wrap_callback` now pass `JSValueRef` into the closure instead of `CallbackArg`
-- `from_qjs_value` now takes `JSValueRef` by value
+- Callback functions registered with `context.wrap_callback` now pass `JSValueRef` into the closure instead of `CallbackArg`.
+- `from_qjs_value` now takes `JSValueRef` by value.
 
 ### Removed
-- `CallbackArg` type
+- `CallbackArg` type.
 
 ## [1.0.0] - 2023-05-05
 
@@ -32,7 +34,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - `json` and `messagepack` features have been moved to the `javy` crate
-
-[unreleased]: https://github.com/bytecodealliance/javy/compare/quickjs-wasm-rs-1.0.0...HEAD
-[1.0.0]: https://github.com/bytecodealliance/javy/tree/quickjs-wasm-rs-1.0.0/crates/quickjs-wasm-rs
-

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-rs"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,6 +8,8 @@ We will only add JS APIs or accept contributions that add JS APIs that are poten
 
 The library crates, `javy`, `javy-apis`, `quickjs-wasm-rs`, and `quickjs-wasm-sys`, use the versioning system described in [Rust for Rustaceans](https://rust-for-rustaceans.com/) in the _Unreleased Versions_ section in the _Project Structure_ chapter. The underlying motivation is that the version in the crate's `Cargo.toml` is important between releases to ensure Cargo does not reuse a stale version if a project relies on a version of the crate that has not yet been published to crates.io and the version required by that project is updated to a version with new additive or breaking changes.
 
+The versions for `javy` and `javy-apis` must always be the same. So a version change in the one crate should result in a version change in the other crate.
+
 ### The system
 
 After publishing a release, immediately update the version number to the next patch version with an `-alpha.1` suffix. The first time an additive change is made, reset the patch version to `0` and increment the minor version and reset the suffix to `-alpha.1`. When making additional additive changes, increment the number in the suffix, for example `-alpha.2`. The first time a breaking change is made, reset the patch version and minor version to `0` and increment the major version and reset the suffix to `-alpha.1`. When making additional breaking changes, increment the number in the suffix, for example `-alpha.2`.


### PR DESCRIPTION
Bumping `quickjs-wasm-rs`, `javy`, and `javy-apis` to 2.0.0 for release.

I realized going through the CHANGELOG that we missed a breaking change in `javy` because it re-exports `quickjs-wasm-rs` so `javy` needs to go to 2.0.0 as well. And we also had an informal policy that was never documented to keep `javy-apis` in sync with `javy` so that also has to go to 2.0.0 as well. I've included an update to the versioning policy in this PR.

I'm also opting to remove the version diffs in the changelog because they're very difficult to properly maintain. We don't use tags for crate releases, we can't know the commit hash on the `main` branch before merging, and branches may not reflect the contents of a crate when merged. I'm open to revisiting if there's a way to do this.

We might need smarter tools or better documentation to consult for ensuring versions are set correctly.