### PR TITLE
Bump javy-cli version to test release pipeline

### DIFF
--- a/npm/javy-cli/CHANGELOG.md
+++ b/npm/javy-cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.9] - 2023-08-17
+
+No changes. This release is to test our automated NPM publishing pipeline.
+
 ## [0.1.8] - 2023-07-28
 
 ### Fixed

--- a/npm/javy-cli/package-lock.json
+++ b/npm/javy-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "javy-cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "javy-cli",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "cachedir": "^2.3.0",

--- a/npm/javy-cli/package.json
+++ b/npm/javy-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javy-cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Unfortunately I can't think of a better way to fully validate that the automated releases work without making a release.