### PR TITLE
Remove javy-cli FORCE_FROM_SOURCE and cut a 0.2.0 release

### DIFF
--- a/npm/javy-cli/CHANGELOG.md
+++ b/npm/javy-cli/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.2.0] - 2023-08-17
+
+### Removed
+
+- Building Javy from source code by using the `FORCE_FROM_SOURCE` environment variable is no longer supported.
+
 ## [0.1.8] - 2023-07-28
 
 ### Fixed
 
-- HTTP response status codes other than 200 when downloading Javy binary now throws an error
+- HTTP response status codes other than 200 when downloading Javy binary now throws an error.

--- a/npm/javy-cli/README.md
+++ b/npm/javy-cli/README.md
@@ -27,21 +27,3 @@ To use a specific version of Javy, set the environment variable
 ```
 FORCE_RELEASE=v1.1.0 npx javy-cli@latest
 ```
-
-## Building from source
-
-If there are no binaries available for your platform or the available binaries
-don't work for you for some reason, the npm package can also build Javy from 
-source.
-
-```
-FORCE_FROM_SOURCE=1 npx javy-cli@latest
-```
-
-Please note that for this to work you must have all prerequisites of Javy
-(listed in the [README]) installed. (That is CMake, Rust, Rust for wasm32-wasi
-target, cargo wasi, wasmtime-cli and Rosetta on Mac M1).
-
-[README]: https://github.com/bytecodealliance/javy/blob/main/README.md
-
-

--- a/npm/javy-cli/index.js
+++ b/npm/javy-cli/index.js
@@ -15,11 +15,7 @@ async function main() {
 	try {
 		const version = await getDesiredVersionNumber();
 		if (!(await isBinaryDownloaded(version))) {
-			if (process.env.FORCE_FROM_SOURCE) {
-				await buildBinary(version);
-			} else {
-				await downloadBinary(version);
-			}
+			await downloadBinary(version);
 		}
 		const result = childProcess.spawnSync(binaryPath(version), getArgs(), {
 			stdio: "inherit",
@@ -164,29 +160,4 @@ function platarch() {
 function getArgs() {
 	const args = process.argv.slice(2);
 	return args;
-}
-
-async function buildBinary(version) {
-	const repoDir = cacheDir("build", NAME);
-	try {
-		console.log(`Downloading ${NAME}'s source code...`);
-		fs.rmSync(repoDir, { recursive: true });
-		childProcess.execSync(
-			`git clone https://github.com/${REPO} ${repoDir}`
-		);
-		console.log(`Building ${NAME}...`);
-		childProcess.execSync("make", { cwd: repoDir });
-	} catch (e) {
-		console.error(e);
-		console.error("");
-		console.error(`BUILDING ${NAME} FAILED`);
-		console.error(
-			"Please make sure you have cmake, Rust with the wasm32-wasi target, wasmtime-cli and cargo-wasi installed"
-		);
-		console.error("See the README for more details.");
-	}
-	await fs.promises.rename(
-		path.join(repoDir, "target", "release", NAME),
-		binaryPath(version)
-	);
 }

--- a/npm/javy-cli/package-lock.json
+++ b/npm/javy-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "javy-cli",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "javy-cli",
-      "version": "0.1.8",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "cachedir": "^2.3.0",

--- a/npm/javy-cli/package.json
+++ b/npm/javy-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javy-cli",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Removing support for building from source because it's become a maintenance burden due to extra testing and needing to keep help messages up to date.