### PR TITLE
Change CI to compile CLI on Linux to speed it up

### DIFF
--- a/.github/actions/ci-shared-setup/action.yml
+++ b/.github/actions/ci-shared-setup/action.yml
@@ -1,0 +1,36 @@
+name: "Shared CI setup"
+description: "Common setup for CI pipeline workflow jobs"
+inputs:
+  os:
+    description: "The operating system for downloading binaries"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Cargo Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo
+        key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+          ${{ runner.os }}-cargo
+
+    - name: Cargo Target Cache
+      uses: actions/cache@v3
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}
+          ${{ runner.os }}-cargo-target
+
+    - name: Install wasmtime-cli
+      env:
+        WASMTIME_VERSION: 8.0.0
+      shell: bash
+      run: |
+        wget -nv 'https://github.com/bytecodealliance/wasmtime/releases/download/v${{ env.WASMTIME_VERSION }}/wasmtime-v${{ env.WASMTIME_VERSION }}-x86_64-${{ inputs.os }}.tar.xz' -O /tmp/wasmtime.tar.xz
+        mkdir /tmp/wasmtime
+        tar xvf /tmp/wasmtime.tar.xz --strip-components=1 -C /tmp/wasmtime
+        echo "/tmp/wasmtime" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 jobs:
-  checks:
-    name: tests_and_lint
+  core:
+    name: test_core
     # We test on `macos-latest` to accurately reflect
     # the core Wasm binary that we attach to the releases,
     # which is built on the latest macOS too.
@@ -17,35 +17,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
 
-      - name: Cargo Cache
-        uses: actions/cache@v3
+      - uses: ./.github/actions/ci-shared-setup
         with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo
-
-      - name: Cargo Target Cache
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-target
-
-      - name: Install wasmtime-cli
-        env:
-          WASMTIME_VERSION: 8.0.0
-        run: |
-          wget -nv 'https://github.com/bytecodealliance/wasmtime/releases/download/v${{ env.WASMTIME_VERSION }}/wasmtime-v${{ env.WASMTIME_VERSION }}-x86_64-macos.tar.xz' -O /tmp/wasmtime.tar.xz
-          mkdir /tmp/wasmtime
-          tar xvf /tmp/wasmtime.tar.xz --strip-components=1 -C /tmp/wasmtime
-          echo "/tmp/wasmtime" >> $GITHUB_PATH
+          os: macos
 
       - name: Install cargo-wasi
         run: cargo install cargo-wasi
@@ -53,11 +28,50 @@ jobs:
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
-      - name: Tests
-        run: |
-          cargo hack wasi test --workspace --exclude=javy-cli --each-feature -- --nocapture
-          cargo build --package=javy-core --release --target=wasm32-wasi
-          CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-cli --release -- --nocapture
+      - name: Compile core
+        run: cargo build -p javy-core --release --target=wasm32-wasi
+
+      - name: Test
+        run: cargo hack wasi test --workspace --exclude=javy-cli --each-feature -- --nocapture
+
+      - name: Lint
+        run: cargo clippy --workspace --exclude=javy-cli --target=wasm32-wasi --all-targets -- -D warnings
+
+      - name: Upload core binary to artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: engine
+          path: target/wasm32-wasi/release/javy_core.wasm
+
+      - name: Upload quickjs_provider to artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: provider
+          path: target/wasm32-wasi/release/javy_quickjs_provider.wasm
+
+  cli:
+    name: test_cli
+    runs-on: ubuntu-latest
+    needs: core
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/ci-shared-setup
+        with:
+          os: linux
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: engine
+          path: target/wasm32-wasi/release/
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: provider
+          path: target/wasm32-wasi/release/
+
+      - name: Test CLI
+        run: CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-cli --release -- --nocapture
 
       - name: Check benchmarks
         run: CARGO_PROFILE_RELEASE_LTO=off cargo check --package=javy-cli --release --benches
@@ -65,5 +79,4 @@ jobs:
       - name: Lint
         run: |
           cargo fmt -- --check
-          cargo clippy --workspace --exclude=javy-cli --target=wasm32-wasi --all-targets -- -D warnings
           CARGO_PROFILE_RELEASE_LTO=off cargo clippy --package=javy-cli --release --all-targets -- -D warnings

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -15,32 +15,9 @@ jobs:
         with:
           submodules: true
 
-      - name: Cargo Cache
-        uses: actions/cache@v3
+      - uses: ./.github/actions/ci-shared-setup
         with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo
-
-      - name: Cargo Target Cache
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}
-            ${{ runner.os }}-cargo-target
-
-      - name: Install wasmtime-cli
-        env:
-          WASMTIME_VERSION: 8.0.0
-        run: |
-          wget -nv 'https://github.com/bytecodealliance/wasmtime/releases/download/v${{ env.WASMTIME_VERSION }}/wasmtime-v${{ env.WASMTIME_VERSION }}-x86_64-linux.tar.xz' -O /tmp/wasmtime.tar.xz
-          mkdir /tmp/wasmtime
-          tar xvf /tmp/wasmtime.tar.xz --strip-components=1 -C /tmp/wasmtime
-          echo "/tmp/wasmtime" >> $GITHUB_PATH
+          os: linux
 
       - name: WPT
         run: |


### PR DESCRIPTION
This change splits the CI into a job that builds and tests all the Wasm crates on MacOS and a job that builds and tests the CLI on Linux. It also introduces a shared setup action because the shared setup was being repeated three times.

Testing this on my personal fork with no cache, I'm seeing [main](https://github.com/jeffcharles/javy/actions/runs/5895970977) take 34 minutes and 32 seconds and [this branch](https://github.com/jeffcharles/javy/actions/runs/5904072888) take 28 minutes and 21 seconds. The difference is smaller when there is a cache hit depending on what exactly needs to be recompiled.