### PR TITLE
Move allocation functions into javy lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "2.0.1-alpha.1"
+version = "2.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "quickjs-wasm-rs",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "javy-apis"
-version = "2.0.1-alpha.1"
+version = "2.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ wasmtime-wasi = "9.0"
 wasi-common = "9.0"
 anyhow = "1.0"
 once_cell = "1.16"
-javy = { path = "crates/javy", version = "2.0.1-alpha.1" }
+javy = { path = "crates/javy", version = "2.1.0-alpha.1" }
 
 [profile.release]
 lto = true

--- a/crates/apis/Cargo.toml
+++ b/crates/apis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-apis"
-version = "2.0.1-alpha.1"
+version = "2.1.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cli/src/wasm_generator/static.rs
+++ b/crates/cli/src/wasm_generator/static.rs
@@ -45,19 +45,21 @@ pub fn generate(js: &JS, exports: Vec<Export>) -> Result<Vec<u8>> {
 
     let mut module = transform::module_config().parse(&wasm)?;
 
-    let (realloc, invoke, memory) = {
+    let (realloc, free, invoke, memory) = {
         let mut exports = HashMap::new();
         for export in module.exports.iter() {
             exports.insert(export.name.as_str(), export);
         }
         (
             *exports.get("canonical_abi_realloc").unwrap(),
+            *exports.get("canonical_abi_free").unwrap(),
             *exports.get("javy.invoke").unwrap(),
             *exports.get("memory").unwrap(),
         )
     };
 
     let realloc_export = realloc.id();
+    let free_export = free.id();
     let invoke_export = invoke.id();
 
     if !exports.is_empty() {
@@ -69,6 +71,7 @@ pub fn generate(js: &JS, exports: Vec<Export>) -> Result<Vec<u8>> {
 
     // We no longer need these exports so remove them.
     module.exports.delete(realloc_export);
+    module.exports.delete(free_export);
     module.exports.delete(invoke_export);
 
     let wasm = module.emit_wasm();

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = { workspace = true }
-javy = { workspace = true }
+javy = { workspace = true, features = ["export_alloc_fns"] }
 javy-apis = { path = "../apis", features = ["console", "text_encoding", "random", "stream_io"] }
 once_cell = { workspace = true }
 

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -5,7 +5,6 @@ use std::slice;
 use std::str;
 use std::string::String;
 
-mod alloc;
 mod execution;
 mod runtime;
 
@@ -35,31 +34,6 @@ fn main() {
     let bytecode = unsafe { BYTECODE.take().unwrap() };
     let runtime = unsafe { RUNTIME.take().unwrap() };
     execution::run_bytecode(&runtime, &bytecode);
-}
-
-// Removed in post_processing.
-/// 1. Allocate memory of new_size with alignment.
-/// 2. If original_ptr != 0
-///   a. copy min(new_size, original_size) bytes from original_ptr to new memory
-///   b. de-allocate original_ptr
-/// 3. return new memory ptr
-///
-/// # Safety
-///
-/// * `original_ptr` must be 0 or a valid pointer
-/// * if `original_ptr` is not 0, it must be valid for reads of `original_size`
-///   bytes
-/// * if `original_ptr` is not 0, it must be properly aligned
-/// * if `original_size` is not 0, it must match the `new_size` value provided
-///   in the original `canonical_abi_realloc` call that returned `original_ptr`
-#[export_name = "canonical_abi_realloc"]
-pub unsafe extern "C" fn canonical_abi_realloc(
-    original_ptr: *mut u8,
-    original_size: usize,
-    alignment: usize,
-    new_size: usize,
-) -> *mut std::ffi::c_void {
-    alloc::canonical_abi_realloc(original_ptr, original_size, alignment, new_size)
 }
 
 // Removed in post-processing.

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `alloc` module containing implementations of a realloc function and a free function.
+- An `export_alloc_fns` crate feature which when enabled, will export `canonical_abi_realloc` and `canonical_abi_free`
+  functions from your Wasm module.
+
 ## 2.0.0 - 2023-08-17
 
 ### Changed

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "2.0.1-alpha.1"
+version = "2.1.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -17,5 +17,6 @@ serde-transcode = { version = "1.1", optional = true }
 rmp-serde = { version = "^1.1", optional = true }
 
 [features]
+export_alloc_fns = []
 messagepack = ["rmp-serde", "serde-transcode"]
 json = ["serde_json", "serde-transcode"]

--- a/crates/javy/src/alloc.rs
+++ b/crates/javy/src/alloc.rs
@@ -11,7 +11,7 @@ const ZERO_SIZE_ALLOCATION_PTR: *mut u8 = 1 as _;
 /// 2. If original_ptr != 0
 ///   a. copy min(new_size, original_size) bytes from original_ptr to new memory
 ///   b. de-allocate original_ptr
-/// 3. return new memory ptr
+/// 3. Return new memory ptr.
 ///
 /// # Safety
 ///

--- a/crates/javy/src/alloc.rs
+++ b/crates/javy/src/alloc.rs
@@ -10,7 +10,7 @@ const ZERO_SIZE_ALLOCATION_PTR: *mut u8 = 1 as _;
 // For canonical_abi_realloc and canonical_abi_free, we want the functions to be available for use
 // by other crates, whether or not the `export_alloc_fns` feature is enabled. When the
 // `export_alloc_fns` feature is enabled, we also want to export the two functions from the Wasm
-// module. To do that, we apply an `export_name` attribute when teh `export_alloc_fns` feature is
+// module. To do that, we apply an `export_name` attribute when the `export_alloc_fns` feature is
 // enabled. The `export_name` attribute is what causes the functions to be exported from the Wasm
 // module as opposed to just exported for use by other crates.
 

--- a/crates/javy/src/alloc.rs
+++ b/crates/javy/src/alloc.rs
@@ -7,6 +7,21 @@ use std::ptr::copy_nonoverlapping;
 // non-zero to indicate success.
 const ZERO_SIZE_ALLOCATION_PTR: *mut u8 = 1 as _;
 
+/// 1. Allocate memory of new_size with alignment.
+/// 2. If original_ptr != 0
+///   a. copy min(new_size, original_size) bytes from original_ptr to new memory
+///   b. de-allocate original_ptr
+/// 3. return new memory ptr
+///
+/// # Safety
+///
+/// * `original_ptr` must be 0 or a valid pointer
+/// * if `original_ptr` is not 0, it must be valid for reads of `original_size`
+///   bytes
+/// * if `original_ptr` is not 0, it must be properly aligned
+/// * if `original_size` is not 0, it must match the `new_size` value provided
+///   in the original `canonical_abi_realloc` call that returned `original_ptr`
+#[cfg_attr(feature = "export_alloc_fns", export_name = "canonical_abi_realloc")]
 pub unsafe extern "C" fn canonical_abi_realloc(
     original_ptr: *mut u8,
     original_size: usize,
@@ -28,6 +43,14 @@ pub unsafe extern "C" fn canonical_abi_realloc(
     new_mem as _
 }
 
+/// Frees memory
+///
+/// # Safety
+///
+/// * `ptr` must denote a block of memory allocated by `canonical_abi_realloc`
+/// * `size` and `alignment` must match the values provided in the original
+///   `canonical_abi_realloc` call that returned `ptr`
+#[cfg_attr(feature = "export_alloc_fns", export_name = "canonical_abi_free")]
 pub unsafe extern "C" fn canonical_abi_free(ptr: *mut u8, size: usize, alignment: usize) {
     if size > 0 {
         dealloc(ptr, Layout::from_size_align(size, alignment).unwrap())

--- a/crates/javy/src/alloc.rs
+++ b/crates/javy/src/alloc.rs
@@ -7,6 +7,13 @@ use std::ptr::copy_nonoverlapping;
 // non-zero to indicate success.
 const ZERO_SIZE_ALLOCATION_PTR: *mut u8 = 1 as _;
 
+// For canonical_abi_realloc and canonical_abi_free, we want the functions to be available for use
+// by other crates, whether or not the `export_alloc_fns` feature is enabled. When the
+// `export_alloc_fns` feature is enabled, we also want to export the two functions from the Wasm
+// module. To do that, we apply an `export_name` attribute when teh `export_alloc_fns` feature is
+// enabled. The `export_name` attribute is what causes the functions to be exported from the Wasm
+// module as opposed to just exported for use by other crates.
+
 /// 1. Allocate memory of new_size with alignment.
 /// 2. If original_ptr != 0
 ///   a. copy min(new_size, original_size) bytes from original_ptr to new memory

--- a/crates/javy/src/lib.rs
+++ b/crates/javy/src/lib.rs
@@ -40,6 +40,7 @@ pub use config::Config;
 pub use quickjs_wasm_rs as quickjs;
 pub use runtime::Runtime;
 
+pub mod alloc;
 mod config;
 mod runtime;
 


### PR DESCRIPTION
This does two things:
1. Moves the realloc and free implementations from the core crate into the `javy` crate under the publicly exported `alloc` module
2. Adds a cargo feature named `export_alloc_fns` which, when enabled, will export the realloc and free functions from the produced Wasm module

This will allow users of the Javy crate to share memory allocation and free functions instead of potentially having to write their own. I opted to put the function exports behind a cargo feature because someone using the Javy crate may want to expose their own allocation and free functions instead with their allocation logic and wouldn't want someone calling our functions or if they want to export them under a different name.