### PR TITLE
Fixes for Rust 1.72

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "crates/core",
   "crates/cli",
 ]
+resolver = "2"
 
 [workspace.package]
 version = "1.1.2"

--- a/crates/cli/src/wasm_generator/static.rs
+++ b/crates/cli/src/wasm_generator/static.rs
@@ -61,9 +61,15 @@ pub fn generate(js: &JS, exports: Vec<Export>) -> Result<Vec<u8>> {
     let invoke_export = invoke.id();
 
     if !exports.is_empty() {
-        let ExportItem::Function(realloc_fn) = realloc.item else { unreachable!() };
-        let ExportItem::Function(invoke_fn) = invoke.item else { unreachable!() };
-        let ExportItem::Memory(memory) = memory.item else { unreachable!() };
+        let ExportItem::Function(realloc_fn) = realloc.item else {
+            unreachable!()
+        };
+        let ExportItem::Function(invoke_fn) = invoke.item else {
+            unreachable!()
+        };
+        let ExportItem::Memory(memory) = memory.item else {
+            unreachable!()
+        };
         export_exported_js_functions(&mut module, realloc_fn, invoke_fn, memory, exports);
     }
 

--- a/crates/quickjs-wasm-rs/src/js_binding/context.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/context.rs
@@ -173,7 +173,7 @@ impl JSContextRef {
                 JS_WRITE_OBJ_BYTECODE as i32,
             );
             Ok(Vec::from_raw_parts(
-                output_buffer as *mut u8,
+                output_buffer,
                 output_size.try_into()?,
                 output_size.try_into()?,
             ))


### PR DESCRIPTION
Got a linting error, a formatting error, and a warning about the resolver not being set. This should get CI passing again.