### PR TITLE
Add a PR template including a checklist for commonly missed steps

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Description of the change
+
+## Why am I making this change?
+
+## Checklist
+
+- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
+- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](../docs/contributing.md#versioning-for-library-crates).
+- [ ] I've updated documentation including crate documentation if necessary.


### PR DESCRIPTION
The inclusion of the checklist should make it less likely for updates to changelogs, crate versions, and documentation to be missed.