### PR TITLE
Try fixing link to in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,5 +5,5 @@
 ## Checklist
 
 - [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
-- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](../docs/contributing.md#versioning-for-library-crates).
+- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](/blob/main/docs/contributing.md#versioning-for-library-crates)
 - [ ] I've updated documentation including crate documentation if necessary.


### PR DESCRIPTION
## Description of the change

Changing the hyperlink to the contributing doc to include blob and the branch name to see if it'll resolve. I'm not entirely sure if this will work. If it doesn't I can try using the full URL. GitHub discourages using the full URL to make cloning work better so I thought I'd try this first.

## Why am I making this change?

The current link 404's.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](../docs/contributing.md#versioning-for-library-crates).
- [x] I've updated documentation including crate documentation if necessary.
