### PR TITLE
Another try at fixing the PR template link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,5 +5,5 @@
 ## Checklist
 
 - [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
-- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](/blob/main/docs/contributing.md#versioning-for-library-crates)
+- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](blob/main/docs/contributing.md#versioning-for-library-crates)
 - [ ] I've updated documentation including crate documentation if necessary.


### PR DESCRIPTION
## Description of the change

Remove the leading `/` on the link to get a different URL to render.

## Why am I making this change?

The attempt at a fix didn't work. Instead it's linking to `https://github.com/blob/main/...`. I'm guessing based on the previous relative link behaviour that removing the leading `/` will get the link to render correctly.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
