### PR TITLE
Use absolute link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,5 +5,5 @@
 ## Checklist
 
 - [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
-- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](blob/main/docs/contributing.md#versioning-for-library-crates)
+- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
 - [ ] I've updated documentation including crate documentation if necessary.


### PR DESCRIPTION
## Description of the change

Making the link to the contributing documentation in the PR template an absolute link.

## Why am I making this change?

The previous link was broken. I can't figure out how to make this work with a non-absolute link so I'll just use an absolute link.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
