### PR TITLE
Bump all crate versions for docs.rs fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "2.1.0-alpha.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "quickjs-wasm-rs",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "javy-apis"
-version = "2.1.0-alpha.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "fastrand",
@@ -1922,7 +1922,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "2.0.1-alpha.1"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-sys"
-version = "1.1.1-alpha.1"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ wasmtime-wasi = "9.0"
 wasi-common = "9.0"
 anyhow = "1.0"
 once_cell = "1.16"
-javy = { path = "crates/javy", version = "2.1.0-alpha.1" }
+javy = { path = "crates/javy", version = "2.1.0" }
 
 [profile.release]
 lto = true

--- a/crates/apis/CHANGELOG.md
+++ b/crates/apis/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0] - 2023-09-08
+## [2.1.0] - 2023-09-11
 
 ### Fixed
 

--- a/crates/apis/CHANGELOG.md
+++ b/crates/apis/CHANGELOG.md
@@ -5,17 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
-## 2.0.0 - 2023-08-17
+## [2.1.0] - 2023-09-08
+
+### Fixed
+
+- Documentation builds on docs.rs.
+
+## [2.0.0] - 2023-08-17
 
 ### Added
+
 - `random` feature to override `Math.random` implementation with one that sets the random seed on first use of `Math.random`.
 
 ### Changed
+
 - `javy` dependency is now at version 2.0.0.
 - WASI SDK will be automatically downloaded at build time if `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable is not set.
 
-## 1.0.0 - 2023-05-17
+## [1.0.0] - 2023-05-17
 
 Initial release

--- a/crates/apis/Cargo.toml
+++ b/crates/apis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-apis"
-version = "2.1.0-alpha.1"
+version = "2.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
+
+## [2.1.0] - 2023-09-08
 
 ### Added
 
@@ -13,13 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An `export_alloc_fns` crate feature which when enabled, will export `canonical_abi_realloc` and `canonical_abi_free`
   functions from your Wasm module.
 
-## 2.0.0 - 2023-08-17
+### Fixed
+
+- Documentation now builds on docs.rs.
+
+## [2.0.0] - 2023-08-17
 
 ### Changed
 
 - Update of `quickjs` types to use types in `quickjs-wasm-rs` 2.0.0.
 - WASI SDK will be automatically downloaded at build time if `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable is not set.
 
-## 1.0.0 - 2023-05-16
+## [1.0.0] - 2023-05-16
 
 Initial release

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0] - 2023-09-08
+## [2.1.0] - 2023-09-11
 
 ### Added
 

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "2.1.0-alpha.1"
+version = "2.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -11,7 +11,7 @@ categories = ["wasm"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-rs = { version = "2.0.1-alpha.1", path = "../quickjs-wasm-rs" }
+quickjs-wasm-rs = { version = "2.0.1", path = "../quickjs-wasm-rs" }
 serde_json = { version = "1.0", optional = true }
 serde-transcode = { version = "1.1", optional = true }
 rmp-serde = { version = "^1.1", optional = true }

--- a/crates/quickjs-wasm-rs/CHANGELOG.md
+++ b/crates/quickjs-wasm-rs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [2.0.1] - 2023-09-08
+## [2.0.1] - 2023-09-11
 
 ### Fixed
 

--- a/crates/quickjs-wasm-rs/CHANGELOG.md
+++ b/crates/quickjs-wasm-rs/CHANGELOG.md
@@ -7,31 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.0.1] - 2023-09-08
+
+### Fixed
+
+- Documentation now builds on docs.rs
+
 ## [2.0.0] - 2023-08-17
 
 ### Added
+
 - `JSValueRef` can convert to Rust types with `try_into` (previously this was implemented on `CallbackArg`).
 - Added `eval_module` method on `JSContextRef` that evaluates JS code in a ECMAScript module scope.
 
 ### Changed
+
 - Callback functions registered with `context.wrap_callback` now pass `JSValueRef` into the closure instead of `CallbackArg`.
 - `from_qjs_value` now takes `JSValueRef` by value.
 - Updated to `quickjs-wasm-sys` version `1.1.0` which will automatically download a WASI SDK if the `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable is not set.
 
 ### Removed
+
 - `CallbackArg` type.
 
 ## [1.0.0] - 2023-05-05
 
 ### Added
+
 - Documentation across the crate.
 - Added an enum `JSValue` that represents a JavaScript value that can convert to and from Rust types with `try_into`.
 
 ### Changed
+
 - Renamed `Value` to `JSValueRef`.
 - Renamed `Context` to `JSContextRef`.
 - Callback functions now work with `CallbackArg` instead of `JSValueRef` directly. `CallbackArg` can easily convert to Rust types with `try_into`.
 - Relationship of `JSValueRef` and `JSContextRef` is now safer with `JSValueRef` containing a reference to `JSContextRef` instead of a raw pointer to the quickjs `JSContext`.
 
 ### Removed
+
 - `json` and `messagepack` features have been moved to the `javy` crate

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-rs"
-version = "2.0.1-alpha.1"
+version = "2.0.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-sys = { version = "1.1.1-alpha.1", path = "../quickjs-wasm-sys" }
+quickjs-wasm-sys = { version = "1.1.1", path = "../quickjs-wasm-sys" }
 serde = { version = "1.0", features = ["derive"] }
 once_cell = "1.16"
 

--- a/crates/quickjs-wasm-sys/CHANGELOG.md
+++ b/crates/quickjs-wasm-sys/CHANGELOG.md
@@ -5,18 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
-## 1.1.1 - 2023-09-08
+## [1.1.1] - 2023-09-11
 
 - Fixed: Documentation now builds on docs.rs.
 
-## 1.1.0 - 2023-07-24
+## [1.1.0] - 2023-07-24
 
 - Added: `QUICKJS_WASM_SYS_WASI_SDK_MAJOR_VERSION` and `QUICKJS_WASM_SYS_WASI_SDK_MINOR_VERSION` build-time environment variables to control which version of the WASI SDK to use.
 - Fixed: Changing the `QUICKJS_WASM_SYS_WASI_SDK_PATH` build time environment variable will trigger a rebuild of the crate.
 - Changed: Crate now automatically downloads WASI SDK if `QUICKJS_WASM_SYS_WASI_SDK_PATH` is not set at build time
 
-## 1.0.0 - 2023-05-16
+## [1.0.0] - 2023-05-16
 
 No changes from 0.1.2. Just updating version to show we're confident in the existing bindings.

--- a/crates/quickjs-wasm-sys/CHANGELOG.md
+++ b/crates/quickjs-wasm-sys/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.1.1 - 2023-09-08
+
+- Fixed: Documentation now builds on docs.rs.
+
 ## 1.1.0 - 2023-07-24
 
 - Added: `QUICKJS_WASM_SYS_WASI_SDK_MAJOR_VERSION` and `QUICKJS_WASM_SYS_WASI_SDK_MINOR_VERSION` build-time environment variables to control which version of the WASI SDK to use.

--- a/crates/quickjs-wasm-sys/Cargo.toml
+++ b/crates/quickjs-wasm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-sys"
-version = "1.1.1-alpha.1"
+version = "1.1.1"
 authors.workspace = true
 edition.workspace = true 
 license.workspace = true


### PR DESCRIPTION
## Description of the change

This cuts new releases for all of our library crates.

## Why am I making this change?

I want to publish new versions of all of our library crates so docs.rs can build documentation for each of our crates.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
