### PR TITLE
Increment version on all library crates to next alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "2.1.0"
+version = "2.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "quickjs-wasm-rs",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "javy-apis"
-version = "2.1.0"
+version = "2.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "fastrand",
@@ -1922,7 +1922,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "2.0.1"
+version = "2.0.2-alpha.1"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-sys"
-version = "1.1.1"
+version = "1.1.2-alpha.1"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ wasmtime-wasi = "9.0"
 wasi-common = "9.0"
 anyhow = "1.0"
 once_cell = "1.16"
-javy = { path = "crates/javy", version = "2.1.0" }
+javy = { path = "crates/javy", version = "2.1.1-alpha.1" }
 
 [profile.release]
 lto = true

--- a/crates/apis/Cargo.toml
+++ b/crates/apis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-apis"
-version = "2.1.0"
+version = "2.1.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "2.1.0"
+version = "2.1.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -11,7 +11,7 @@ categories = ["wasm"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-rs = { version = "2.0.1", path = "../quickjs-wasm-rs" }
+quickjs-wasm-rs = { version = "2.0.2-alpha.1", path = "../quickjs-wasm-rs" }
 serde_json = { version = "1.0", optional = true }
 serde-transcode = { version = "1.1", optional = true }
 rmp-serde = { version = "^1.1", optional = true }

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-rs"
-version = "2.0.1"
+version = "2.0.2-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-sys = { version = "1.1.1", path = "../quickjs-wasm-sys" }
+quickjs-wasm-sys = { version = "1.1.2-alpha.1", path = "../quickjs-wasm-sys" }
 serde = { version = "1.0", features = ["derive"] }
 once_cell = "1.16"
 

--- a/crates/quickjs-wasm-sys/Cargo.toml
+++ b/crates/quickjs-wasm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-sys"
-version = "1.1.1"
+version = "1.1.2-alpha.1"
 authors.workspace = true
 edition.workspace = true 
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Increment all library crates to next patch alpha version.

## Why am I making this change?

Following our versioning policy.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
