### PR TITLE
Support semicolons in WIT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,7 +1040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 dependencies = [
  "fallible-iterator",
- "indexmap",
+ "indexmap 1.9.3",
  "stable_deref_trait",
 ]
 
@@ -1045,7 +1051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 dependencies = [
  "fallible-iterator",
- "indexmap",
+ "indexmap 1.9.3",
  "stable_deref_trait",
 ]
 
@@ -1075,6 +1081,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 
 [[package]]
 name = "heck"
@@ -1209,6 +1221,17 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.1",
  "serde",
 ]
 
@@ -1373,7 +1396,7 @@ dependencies = [
  "wasmprinter",
  "wasmtime",
  "wasmtime-wasi",
- "wit-parser 0.8.0",
+ "wit-parser 0.11.3",
  "wizer",
 ]
 
@@ -1493,9 +1516,9 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memfd"
@@ -1636,7 +1659,7 @@ checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "crc32fast",
  "hashbrown 0.13.2",
- "indexmap",
+ "indexmap 1.9.3",
  "memchr",
 ]
 
@@ -1903,6 +1926,17 @@ name = "pulldown-cmark"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+dependencies = [
+ "bitflags 1.3.2",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
 dependencies = [
  "bitflags 1.3.2",
  "memchr",
@@ -2307,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa 1.0.4",
  "ryu",
@@ -2589,7 +2623,7 @@ checksum = "d7787d3607d628ad0cc2e7173770f6a43229ce46e55136e81e5fdeb0951dd6c9"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.3.3",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "phf",
  "rustc-hash",
@@ -2610,7 +2644,7 @@ version = "0.123.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b6d6b59ebd31b25fe2692ff705c806961e7856de8b7e91fd0942328886cd315"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "num_cpus",
  "once_cell",
  "rustc-hash",
@@ -3248,7 +3282,7 @@ version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adde01ade41ab9a5d10ec8ed0bb954238cf8625b5cd5a13093d6de2ad9c2be1a"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "url",
 ]
 
@@ -3258,7 +3292,7 @@ version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc3222d9e47412382cc95e2f013c6a9f510bcff80af92de5665ae3ec1e4a2f6"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "url",
 ]
 
@@ -3268,7 +3302,7 @@ version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c437373cac5ea84f1113d648d51f71751ffbe3d90c00ae67618cf20d0b5ee7b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "url",
 ]
 
@@ -3278,7 +3312,7 @@ version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d014e33793cab91655fa6349b0bc974984de106b2e0f6b0dfe6f6594b260624d"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "url",
 ]
 
@@ -3304,7 +3338,7 @@ dependencies = [
  "bumpalo",
  "cfg-if",
  "fxprof-processed-profile",
- "indexmap",
+ "indexmap 1.9.3",
  "libc",
  "log",
  "object",
@@ -3425,7 +3459,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli 0.27.2",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
  "object",
  "serde",
@@ -3504,7 +3538,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if",
- "indexmap",
+ "indexmap 1.9.3",
  "libc",
  "log",
  "mach",
@@ -3858,25 +3892,27 @@ checksum = "5ca2581061573ef6d1754983d7a9b3ed5871ef859d52708ea9a0f5af32919172"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
- "pulldown-cmark",
+ "pulldown-cmark 0.8.0",
  "unicode-xid",
  "url",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.8.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6daec9f093dbaea0e94043eeb92ece327bbbe70c86b1f41aca9bbfefd7f050f0"
+checksum = "a39edca9abb16309def3843af73b58d47d243fe33a9ceee572446bcc57556b9a"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.0.2",
  "log",
- "pulldown-cmark",
+ "pulldown-cmark 0.9.3",
  "semver 1.0.17",
+ "serde",
+ "serde_json",
  "unicode-xid",
  "url",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -26,7 +26,7 @@ wasmtime-wasi = { workspace = true }
 wasi-common = { workspace = true }
 walrus = "0.20.1"
 swc_core = { version = "0.83.0", features = ["common_sourcemap", "ecma_ast", "ecma_parser"] }
-wit-parser = "0.8.0"
+wit-parser = "0.11.3"
 convert_case = "0.4.0"
 
 [dev-dependencies]

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -134,6 +134,16 @@ fn test_exported_functions_without_flag() {
 }
 
 #[test]
+fn test_exported_function_without_semicolons() {
+    let mut runner = Runner::new_with_exports(
+        "exported-fn-no-semicolon.js",
+        "exported-fn-no-semicolon.wit",
+        "exported-fn",
+    );
+    run_fn(&mut runner, "foo", &[]);
+}
+
+#[test]
 fn test_producers_section_present() {
     let runner = Runner::new("readme.js");
     common::assert_producers_section_is_correct(&runner.wasm).unwrap();

--- a/crates/cli/tests/sample-scripts/exported-default-arrow-fn.wit
+++ b/crates/cli/tests/sample-scripts/exported-default-arrow-fn.wit
@@ -1,5 +1,5 @@
-package local:test
+package local:test;
 
 world exported-arrow {
-  export default: func()
+  export default: func();
 }

--- a/crates/cli/tests/sample-scripts/exported-default-fn.wit
+++ b/crates/cli/tests/sample-scripts/exported-default-fn.wit
@@ -1,5 +1,5 @@
-package local:test
+package local:test;
 
 world exported-default {
-  export default: func()
+  export default: func();
 }

--- a/crates/cli/tests/sample-scripts/exported-fn-no-semicolon.js
+++ b/crates/cli/tests/sample-scripts/exported-fn-no-semicolon.js
@@ -1,0 +1,3 @@
+export function foo() {
+    console.log("Hello from bar!");
+}

--- a/crates/cli/tests/sample-scripts/exported-fn-no-semicolon.wit
+++ b/crates/cli/tests/sample-scripts/exported-fn-no-semicolon.wit
@@ -1,0 +1,5 @@
+package local:test
+
+world exported-fn {
+  export foo: func()
+}

--- a/crates/cli/tests/sample-scripts/exported-fn.wit
+++ b/crates/cli/tests/sample-scripts/exported-fn.wit
@@ -1,7 +1,7 @@
-package local:test
+package local:test;
 
 world exported-fn {
-  export foo: func()
-  export bar: func()
-  export foo-bar: func()
+  export foo: func();
+  export bar: func();
+  export foo-bar: func();
 }

--- a/crates/cli/tests/sample-scripts/exported-promise-fn.wit
+++ b/crates/cli/tests/sample-scripts/exported-promise-fn.wit
@@ -1,5 +1,5 @@
-package local:test
+package local:test;
 
 world exported-promise-fn {
-  export foo: func()
+  export foo: func();
 }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -21,6 +21,12 @@ who = "Jeff Charles <jeff.charles@shopify.com>"
 criteria = "safe-to-deploy"
 version = "1.0.0"
 
+[[trusted.aho-corasick]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-03-28"
+end = "2024-10-03"
+
 [[trusted.ambient-authority]]
 criteria = "safe-to-deploy"
 user-id = 6825 # Dan Gohman (sunfishcode)
@@ -32,6 +38,18 @@ criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-07-23"
 end = "2024-07-12"
+
+[[trusted.bstr]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-04-02"
+end = "2024-10-03"
+
+[[trusted.byteorder]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-06-09"
+end = "2024-10-03"
 
 [[trusted.cap-fs-ext]]
 criteria = "safe-to-deploy"
@@ -57,11 +75,35 @@ user-id = 6825 # Dan Gohman (sunfishcode)
 start = "2020-09-21"
 end = "2024-07-25"
 
+[[trusted.csv]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-04-05"
+end = "2024-10-03"
+
+[[trusted.csv-core]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-06-26"
+end = "2024-10-03"
+
+[[trusted.equivalent]]
+criteria = "safe-to-deploy"
+user-id = 539 # Josh Stone (cuviper)
+start = "2023-02-05"
+end = "2024-10-03"
+
 [[trusted.fs-set-times]]
 criteria = "safe-to-deploy"
 user-id = 6825 # Dan Gohman (sunfishcode)
 start = "2020-09-15"
 end = "2024-07-25"
+
+[[trusted.hashbrown]]
+criteria = "safe-to-deploy"
+user-id = 2915 # Amanieu d'Antras (Amanieu)
+start = "2019-04-02"
+end = "2024-10-03"
 
 [[trusted.io-extras]]
 criteria = "safe-to-deploy"
@@ -93,6 +135,12 @@ user-id = 6825 # Dan Gohman (sunfishcode)
 start = "2021-06-12"
 end = "2024-07-25"
 
+[[trusted.memchr]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-07-07"
+end = "2024-10-03"
+
 [[trusted.num-traits]]
 criteria = "safe-to-deploy"
 user-id = 539 # Josh Stone (cuviper)
@@ -111,6 +159,12 @@ user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-04-16"
 end = "2024-07-12"
 
+[[trusted.quickcheck]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-05-13"
+end = "2024-10-03"
+
 [[trusted.rayon]]
 criteria = "safe-to-deploy"
 user-id = 539 # Josh Stone (cuviper)
@@ -122,6 +176,24 @@ criteria = "safe-to-deploy"
 user-id = 539 # Josh Stone (cuviper)
 start = "2019-06-13"
 end = "2024-07-12"
+
+[[trusted.regex]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-02-27"
+end = "2024-10-03"
+
+[[trusted.regex-automata]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-02-25"
+end = "2024-10-03"
+
+[[trusted.regex-syntax]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-03-30"
+end = "2024-10-03"
 
 [[trusted.rustix]]
 criteria = "safe-to-deploy"
@@ -140,6 +212,12 @@ criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-05-02"
 end = "2024-07-12"
+
+[[trusted.same-file]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-07-16"
+end = "2024-10-03"
 
 [[trusted.scopeguard]]
 criteria = "safe-to-deploy"
@@ -183,8 +261,26 @@ user-id = 6825 # Dan Gohman (sunfishcode)
 start = "2019-03-06"
 end = "2024-07-25"
 
+[[trusted.termcolor]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-06-04"
+end = "2024-10-03"
+
 [[trusted.unicode-ident]]
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2021-10-02"
 end = "2024-07-12"
+
+[[trusted.walkdir]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-06-09"
+end = "2024-10-03"
+
+[[trusted.winapi-util]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2020-01-11"
+end = "2024-10-03"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -52,10 +52,6 @@ criteria = "safe-to-deploy"
 version = "0.8.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.aho-corasick]]
-version = "0.7.18"
-criteria = "safe-to-deploy"
-
 [[exemptions.alloc-no-stdlib]]
 version = "2.0.4"
 criteria = "safe-to-deploy"
@@ -102,14 +98,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.brotli-decompressor]]
 version = "2.3.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.bstr]]
-version = "0.2.17"
-criteria = "safe-to-run"
-
-[[exemptions.byteorder]]
-version = "1.4.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.bytes]]
@@ -167,14 +155,6 @@ criteria = "safe-to-deploy"
 [[exemptions.crossbeam-utils]]
 version = "0.8.7"
 criteria = "safe-to-deploy"
-
-[[exemptions.csv]]
-version = "1.1.6"
-criteria = "safe-to-run"
-
-[[exemptions.csv-core]]
-version = "0.1.10"
-criteria = "safe-to-run"
 
 [[exemptions.data-encoding]]
 version = "2.4.0"
@@ -293,6 +273,10 @@ criteria = "safe-to-deploy"
 version = "1.9.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.indexmap]]
+version = "2.0.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.instant]]
 version = "0.1.12"
 criteria = "safe-to-deploy"
@@ -335,10 +319,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.maybe-owned]]
 version = "0.3.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.memchr]]
-version = "2.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.memoffset]]
@@ -446,10 +426,6 @@ criteria = "safe-to-deploy"
 version = "0.1.17"
 criteria = "safe-to-deploy"
 
-[[exemptions.quickcheck]]
-version = "1.0.3"
-criteria = "safe-to-run"
-
 [[exemptions.rand]]
 version = "0.8.5"
 criteria = "safe-to-deploy"
@@ -466,18 +442,6 @@ criteria = "safe-to-deploy"
 version = "0.4.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.regex]]
-version = "1.5.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.regex-automata]]
-version = "0.1.10"
-criteria = "safe-to-run"
-
-[[exemptions.regex-syntax]]
-version = "0.6.26"
-criteria = "safe-to-deploy"
-
 [[exemptions.rmp]]
 version = "0.8.11"
 criteria = "safe-to-deploy"
@@ -488,10 +452,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rustc_version]]
 version = "0.2.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.same-file]]
-version = "1.0.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.schannel]]
@@ -642,10 +602,6 @@ criteria = "safe-to-deploy"
 version = "3.4.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.termcolor]]
-version = "1.1.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.textwrap]]
 version = "0.11.0"
 criteria = "safe-to-deploy"
@@ -719,10 +675,6 @@ criteria = "safe-to-deploy"
 version = "7.5.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.walkdir]]
-version = "2.3.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.walrus]]
 version = "0.20.1"
 criteria = "safe-to-deploy"
@@ -773,10 +725,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.winapi-i686-pc-windows-gnu]]
 version = "0.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.winapi-util]]
-version = "0.1.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.winapi-x86_64-pc-windows-gnu]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,13 @@
 
 # cargo-vet imports lock
 
+[[publisher.aho-corasick]]
+version = "0.7.18"
+when = "2021-04-30"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
 [[publisher.ambient-authority]]
 version = "0.0.1"
 when = "2021-07-13"
@@ -21,6 +28,20 @@ when = "2021-12-09"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
+
+[[publisher.bstr]]
+version = "0.2.17"
+when = "2021-09-20"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.byteorder]]
+version = "1.4.3"
+when = "2021-03-10"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
 
 [[publisher.cap-fs-ext]]
 version = "1.0.10"
@@ -145,12 +166,40 @@ when = "2023-06-13"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.csv]]
+version = "1.1.6"
+when = "2021-03-07"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.csv-core]]
+version = "0.1.10"
+when = "2020-02-14"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.equivalent]]
+version = "1.0.1"
+when = "2023-07-10"
+user-id = 539
+user-login = "cuviper"
+user-name = "Josh Stone"
+
 [[publisher.fs-set-times]]
 version = "0.15.0"
 when = "2022-01-31"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
+
+[[publisher.hashbrown]]
+version = "0.14.1"
+when = "2023-09-29"
+user-id = 2915
+user-login = "Amanieu"
+user-name = "Amanieu d'Antras"
 
 [[publisher.io-extras]]
 version = "0.13.2"
@@ -215,6 +264,13 @@ user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
+[[publisher.memchr]]
+version = "2.6.4"
+when = "2023-10-01"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
 [[publisher.num-traits]]
 version = "0.2.16"
 when = "2023-07-20"
@@ -236,6 +292,13 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.quickcheck]]
+version = "1.0.3"
+when = "2021-01-15"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
 [[publisher.rayon]]
 version = "1.5.1"
 when = "2021-05-18"
@@ -256,6 +319,27 @@ when = "2023-05-01"
 user-id = 3726
 user-login = "cfallin"
 user-name = "Chris Fallin"
+
+[[publisher.regex]]
+version = "1.5.6"
+when = "2022-05-20"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.regex-automata]]
+version = "0.1.10"
+when = "2021-06-01"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.regex-syntax]]
+version = "0.6.26"
+when = "2022-05-20"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
 
 [[publisher.rustix]]
 version = "0.33.3"
@@ -284,6 +368,13 @@ when = "2021-12-12"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
+
+[[publisher.same-file]]
+version = "1.0.6"
+when = "2020-01-11"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
 
 [[publisher.scopeguard]]
 version = "1.1.0"
@@ -314,8 +405,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.serde_json]]
-version = "1.0.103"
-when = "2023-07-15"
+version = "1.0.107"
+when = "2023-09-13"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -340,6 +431,13 @@ when = "2022-02-01"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
+
+[[publisher.termcolor]]
+version = "1.1.2"
+when = "2020-11-19"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
 
 [[publisher.unicode-ident]]
 version = "1.0.6"
@@ -368,6 +466,13 @@ when = "2022-09-15"
 user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
+
+[[publisher.walkdir]]
+version = "2.3.2"
+when = "2021-03-22"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
 
 [[publisher.wasi-cap-std-sync]]
 version = "9.0.4"
@@ -551,6 +656,13 @@ when = "2023-06-13"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.winapi-util]]
+version = "0.1.5"
+when = "2020-04-20"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
 [[publisher.wit-parser]]
 version = "0.7.1"
 when = "2023-04-27"
@@ -559,8 +671,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wit-parser]]
-version = "0.8.0"
-when = "2023-05-26"
+version = "0.11.3"
+when = "2023-09-27"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1255,6 +1367,18 @@ notes = """
 This crate has `unsafe` blocks and they're all related to SIMD-acceleration and
 are otherwise not doing other `unsafe` operations. Additionally the crate does
 not do anything other than markdown rendering as is expected.
+"""
+
+[[audits.bytecode-alliance.audits.pulldown-cmark]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.0 -> 0.9.3"
+notes = """
+This is a large change to the `pulldown-cmark` crate but it tightens
+restrictions on `unsafe` code to forbid it in non-SIMD mode and additionally
+many changes look to be related to refactoring, improving, and restructuring.
+This crate is not fundamentally different from before, which was trusted, but
+looks to be receiving new assistance for maintainership as well.
 """
 
 [[audits.bytecode-alliance.audits.quote]]


### PR DESCRIPTION
## Description of the change

Supports parsing WIT with semicolons at the end of lines. Also adds a test to verify that WIT that does not have semicolons at the end of lines continues to be parsed.

## Why am I making this change?

WIT added a requirement for semicolons at the end of lines in https://github.com/WebAssembly/component-model/pull/249. We should support WIT that has semicolons at the end of lines without requiring semicolons at the end of lines for backwards compatibility.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
