### PR TITLE
v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "binaryen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.2"
+version = "1.2.0"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
## Description of the change

Bumping Javy version to v1.2.0 in preparation of releasing v1.2.0.

## Why am I making this change?

We've added support for reading WIT files that contain semicolons when generating modules with multiple exports and I want to ship that change. I think it counts as a new feature rather than a "bugfix".

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
