### PR TITLE
Update WIT examples in README to use semicolons

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ console.log("Hello world!");
 
 `index.wit`:
 ```
-package local:main
+package local:main;
 
 world index-world {
-  export foo: func() 
+  export foo: func(); 
 }
 ```
 
@@ -191,10 +191,10 @@ export function fooBar() {
 
 `index.wit`:
 ```
-package local:main
+package local:main;
 
 world index {
-  export foo-bar: func() 
+  export foo-bar: func(); 
 }
 ```
 
@@ -218,10 +218,10 @@ export default function () {
 
 `index.wit`:
 ```
-package local:main
+package local:main;
 
 world index {
-  export default: func() 
+  export default: func(); 
 }
 ```
 


### PR DESCRIPTION
## Description of the change

Adding semicolons to WIT examples in the README.

## Why am I making this change?

Semicolons are now part of the WIT standard and are supported by Javy. Given semicolons will not be supported by future versions of WIT parsers, it probably makes sense to use WIT with semicolons in our README examples.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
