### PR TITLE
Make `JSContextRef::wrap_rust_value` private

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "2.0.2-alpha.1"
+version = "3.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["wasm"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-rs = { version = "2.0.2-alpha.1", path = "../quickjs-wasm-rs" }
+quickjs-wasm-rs = { version = "3.0.0-alpha.1", path = "../quickjs-wasm-rs" }
 serde_json = { version = "1.0", optional = true }
 serde-transcode = { version = "1.1", optional = true }
 rmp-serde = { version = "^1.1", optional = true }

--- a/crates/quickjs-wasm-rs/CHANGELOG.md
+++ b/crates/quickjs-wasm-rs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Make `JSContextRef::wrap_rust_value` private. Similar to
+  `context::get_rust_value` this function is simply an internal detail.
+
 ## [2.0.1] - 2023-09-11
 
 ### Fixed

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-rs"
-version = "2.0.2-alpha.1"
+version = "3.0.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/quickjs-wasm-rs/src/js_binding/context.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/context.rs
@@ -315,7 +315,7 @@ impl JSContextRef {
     }
 
     /// Wrap the specified Rust value in a JS value
-    pub fn wrap_rust_value<T: 'static>(&self, value: T) -> Result<JSValueRef> {
+    fn wrap_rust_value<T: 'static>(&self, value: T) -> Result<JSValueRef> {
         // Note the use of `RefCell` to provide checked unique references.  Since JS values can be arbitrarily
         // aliased, we need `RefCell`'s dynamic borrow checking to prevent unsound access.
         let pointer = Box::into_raw(Box::new(RefCell::new(value)));


### PR DESCRIPTION
## Description of the change
While investigating https://github.com/bytecodealliance/javy/issues/486 I realized that this function is still public, which shouldn't be the case as it's only used for wrapping closure types, which is an internal detail about the crate.


## Why am I making this change?


## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
