### PR TITLE
Update javy-cli devdep in javy NPM package

### DIFF
--- a/npm/javy/package-lock.json
+++ b/npm/javy/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "javy",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "javy",
-			"version": "0.1.1",
+			"version": "0.1.2",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@rollup/plugin-node-resolve": "^15.0.1",
-				"javy-cli": "^0.1.4",
+				"javy-cli": "^0.2.0",
 				"rollup": "^3.7.4",
 				"rollup-plugin-swc": "^0.2.1",
 				"typescript": "^4.9.4",
@@ -785,9 +785,9 @@
 			}
 		},
 		"node_modules/javy-cli": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/javy-cli/-/javy-cli-0.1.4.tgz",
-			"integrity": "sha512-cSafsb8gXP4BnwjpogfU04ZUnbJ/uxPLzIc2dz6VeG70JB3yqdOhlf1r4cXlK7aloijs5vgz70ty4ogC0YEqpw==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/javy-cli/-/javy-cli-0.2.0.tgz",
+			"integrity": "sha512-kxY6+q+1bhXjfFb5o8ETlfKtxEMajSqNB/0G1l9tVfFU0RMYiDHHRQgs2r8cSAZhkEgs2gSKlpxgopQ4NuL6Ig==",
 			"dev": true,
 			"dependencies": {
 				"cachedir": "^2.3.0",
@@ -1963,9 +1963,9 @@
 			"dev": true
 		},
 		"javy-cli": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/javy-cli/-/javy-cli-0.1.4.tgz",
-			"integrity": "sha512-cSafsb8gXP4BnwjpogfU04ZUnbJ/uxPLzIc2dz6VeG70JB3yqdOhlf1r4cXlK7aloijs5vgz70ty4ogC0YEqpw==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/javy-cli/-/javy-cli-0.2.0.tgz",
+			"integrity": "sha512-kxY6+q+1bhXjfFb5o8ETlfKtxEMajSqNB/0G1l9tVfFU0RMYiDHHRQgs2r8cSAZhkEgs2gSKlpxgopQ4NuL6Ig==",
 			"dev": true,
 			"requires": {
 				"cachedir": "^2.3.0",

--- a/npm/javy/package.json
+++ b/npm/javy/package.json
@@ -23,7 +23,7 @@
 	},
 	"devDependencies": {
 		"@rollup/plugin-node-resolve": "^15.0.1",
-		"javy-cli": "^0.1.4",
+		"javy-cli": "^0.2.0",
 		"rollup": "^3.7.4",
 		"rollup-plugin-swc": "^0.2.1",
 		"typescript": "^4.9.4",


### PR DESCRIPTION
## Description of the change

Updates the version of the `javy-cli` NPM package used by the tests for the `javy` NPM package.

## Why am I making this change?

Our CI started failing after deleting the old Shopify/javy repo that the old version of the `javy-cli` NPM package used.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
