### PR TITLE
Bump Rustix versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
  "io-lifetimes 0.5.3",
  "ipnet",
  "maybe-owned",
- "rustix 0.33.3",
+ "rustix 0.33.7",
  "winapi",
  "winapi-util",
  "winx 0.31.0",
@@ -316,7 +316,7 @@ dependencies = [
  "io-lifetimes 1.0.11",
  "ipnet",
  "maybe-owned",
- "rustix 0.37.23",
+ "rustix 0.37.26",
  "windows-sys 0.48.0",
  "winx 0.35.1",
 ]
@@ -341,7 +341,7 @@ dependencies = [
  "io-extras 0.13.2",
  "io-lifetimes 0.5.3",
  "ipnet",
- "rustix 0.33.3",
+ "rustix 0.33.7",
 ]
 
 [[package]]
@@ -353,7 +353,7 @@ dependencies = [
  "cap-primitives 1.0.10",
  "io-extras 0.17.4",
  "io-lifetimes 1.0.11",
- "rustix 0.37.23",
+ "rustix 0.37.26",
 ]
 
 [[package]]
@@ -364,7 +364,7 @@ checksum = "27254eb495abe5deb117c9de424b2bfb74944e29a28ac224b213b13550c2cc4d"
 dependencies = [
  "cap-primitives 1.0.10",
  "once_cell",
- "rustix 0.37.23",
+ "rustix 0.37.26",
  "winx 0.35.1",
 ]
 
@@ -867,7 +867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ae6b3d9530211fb3b12a95374b8b0823be812f53d09e18c5675c0146b09642"
 dependencies = [
  "cfg-if",
- "rustix 0.37.23",
+ "rustix 0.37.26",
  "windows-sys 0.48.0",
 ]
 
@@ -930,7 +930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df62ee66ee2d532ea8d567b5a3f0d03ecd64636b98bad5be1e93dcc918b92aa"
 dependencies = [
  "io-lifetimes 0.5.3",
- "rustix 0.33.3",
+ "rustix 0.33.7",
  "winapi",
 ]
 
@@ -941,7 +941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7833d0f115a013d51c55950a3b09d30e4b057be9961b709acb9b5b17a1108861"
 dependencies = [
  "io-lifetimes 1.0.11",
- "rustix 0.37.23",
+ "rustix 0.37.26",
  "windows-sys 0.48.0",
 ]
 
@@ -1308,7 +1308,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes 1.0.11",
- "rustix 0.37.23",
+ "rustix 0.37.26",
  "windows-sys 0.48.0",
 ]
 
@@ -1526,7 +1526,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
 dependencies = [
- "rustix 0.37.23",
+ "rustix 0.37.26",
 ]
 
 [[package]]
@@ -2161,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.33.3"
+version = "0.33.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9466f25b92a648960ac1042fd3baa6b0bf285e60f754d7e5070770c813a177a"
+checksum = "938a344304321a9da4973b9ff4f9f8db9caf4597dfd9dda6a60b523340a0fff0"
 dependencies = [
  "bitflags 1.3.2",
  "errno 0.2.8",
@@ -2177,12 +2177,12 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.36.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "6da3636faa25820d8648e0e31c5d519bbb01f72fdf57131f0f5f7da5fed36eab"
 dependencies = [
  "bitflags 1.3.2",
- "errno 0.2.8",
+ "errno 0.3.1",
  "io-lifetimes 1.0.11",
  "libc",
  "linux-raw-sys 0.1.4",
@@ -2191,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
+version = "0.37.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+checksum = "84f3f8f960ed3b5a59055428714943298bf3fa2d4a1d53135084e0544829d995"
 dependencies = [
  "bitflags 1.3.2",
  "errno 0.3.1",
@@ -2751,7 +2751,7 @@ dependencies = [
  "cap-std 1.0.10",
  "fd-lock",
  "io-lifetimes 1.0.11",
- "rustix 0.37.23",
+ "rustix 0.37.26",
  "windows-sys 0.48.0",
  "winx 0.35.1",
 ]
@@ -2771,7 +2771,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.2.10",
- "rustix 0.36.8",
+ "rustix 0.36.16",
  "windows-sys 0.42.0",
 ]
 
@@ -3162,7 +3162,7 @@ dependencies = [
  "io-lifetimes 1.0.11",
  "is-terminal",
  "once_cell",
- "rustix 0.37.23",
+ "rustix 0.37.26",
  "system-interface",
  "tracing",
  "wasi-common",
@@ -3181,7 +3181,7 @@ dependencies = [
  "cap-std 1.0.10",
  "io-extras 0.17.4",
  "log",
- "rustix 0.37.23",
+ "rustix 0.37.26",
  "thiserror",
  "tracing",
  "wasmtime",
@@ -3382,7 +3382,7 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix 0.37.23",
+ "rustix 0.37.26",
  "serde",
  "sha2",
  "toml",
@@ -3477,7 +3477,7 @@ checksum = "23c5127908fdf720614891ec741c13dd70c844e102caa393e2faca1ee68e9bfb"
 dependencies = [
  "cc",
  "cfg-if",
- "rustix 0.37.23",
+ "rustix 0.37.26",
  "wasmtime-asm-macros",
  "windows-sys 0.48.0",
 ]
@@ -3515,7 +3515,7 @@ checksum = "65fb78eacf4a6e47260d8ef8cc81ea8ddb91397b2e848b3fb01567adebfe89b5"
 dependencies = [
  "object",
  "once_cell",
- "rustix 0.37.23",
+ "rustix 0.37.26",
 ]
 
 [[package]]
@@ -3546,7 +3546,7 @@ dependencies = [
  "memoffset 0.8.0",
  "paste",
  "rand",
- "rustix 0.37.23",
+ "rustix 0.37.26",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-fiber",

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -349,8 +349,29 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.rustix]]
+version = "0.33.7"
+when = "2022-04-18"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.rustix]]
+version = "0.36.16"
+when = "2023-10-12"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.rustix]]
 version = "0.37.23"
 when = "2023-07-05"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.rustix]]
+version = "0.37.26"
+when = "2023-10-19"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"


### PR DESCRIPTION
## Description of the change

Increments Rustix versions.

## Why am I making this change?

- https://github.com/bytecodealliance/javy/security/dependabot/33
- https://github.com/bytecodealliance/javy/security/dependabot/34

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
