### PR TITLE
Add workflow for dependabot and cargo vet

### DIFF
--- a/.github/workflows/dependabot-cargo-vet.yml
+++ b/.github/workflows/dependabot-cargo-vet.yml
@@ -1,4 +1,4 @@
-# Runs cargo vet and cargo vet regenerate exemptions for Dependabot PRs
+# Runs cargo vet for Dependabot PRs
 name: Dependabot update cargo vet
 on:
   push:
@@ -49,8 +49,6 @@ jobs:
       - run: cargo vet trust --all Amanieu
         continue-on-error: true
 
-      - run: cargo vet regenerate exemptions
-      
       - name: commit and push
         shell: bash
         run: |

--- a/.github/workflows/dependabot-cargo-vet.yml
+++ b/.github/workflows/dependabot-cargo-vet.yml
@@ -1,0 +1,62 @@
+# Runs cargo vet and cargo vet regenerate exemptions for Dependabot PRs
+name: Dependabot update cargo vet
+on:
+  push:
+    branches:
+      - "dependabot/cargo/**"
+
+jobs:
+  vet:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    env:
+      CARGO_VET_VERSION: 0.8.0
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ runner.tool_cache }}/cargo-vet
+          key: cargo-vet-bin-${{ env.CARGO_VET_VERSION }}
+
+      - name: Add the tool cache directory to the search path
+        run: echo "${{ runner.tool_cache }}/cargo-vet/bin" >> $GITHUB_PATH
+
+      - name: Ensure that the tool cache is populated with the cargo-vet binary
+        run: cargo install --root ${{ runner.tool_cache }}/cargo-vet --version ${{ env.CARGO_VET_VERSION }} cargo-vet
+
+      - run: cargo vet
+        continue-on-error: true
+      
+      # These all ask for input on the terminal to select the trusted criteria but take the default of `safe-to-deploy`.
+      
+      - run: cargo vet trust --all BurntSushi
+        continue-on-error: true
+
+      - run: cargo vet trust --all sunfishcode
+        continue-on-error: true
+
+      - run: cargo vet trust --all dtolnay
+        continue-on-error: true
+      
+      - run: cargo vet trust --all cuviper
+        continue-on-error: true
+      
+      - run: cargo vet trust --all Amanieu
+        continue-on-error: true
+
+      - run: cargo vet regenerate exemptions
+      
+      - name: commit and push
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            git commit -am "[dependabot skip] Regenerate cargo vet"
+            git push
+          fi


### PR DESCRIPTION
## Description of the change

Fixes #531. Adds a workflow to run `cargo vet`, trust our trusted publishes, and run `cargo vet regenerate exemptions` on pushes to branches used by Dependabot for `cargo`.

I don't think this introduces a security vulnerability because it should only run on branches in the `javy` repository and branches on forks would have the logic run in the branch on their fork.

## Why am I making this change?

Most of our Dependabot PRs are failing due to `cargo vet --locked` failing and this _should_ address that.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
