### PR TITLE
Group nonbreaking changes and use daily interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,18 +3,26 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 100
+    groups:
+      nonbreaking:
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: npm
     directory: "/npm/javy"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 100
+
   - package-ecosystem: npm
     directory: "/npm/javy-cli"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 100
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description of the change

This groups minor and patch updates to cargo dependencies. It also temporarily changes to using a daily interval before changing it to monthly on another day.

## Why am I making this change?

We want to group non-breaking updates because we need to manually run `cargo vet` and clean up any issues it finds for each Dependabot PR. Having more of them grouped together should save time.

I'm also temporarily changing the interval to daily to see if we can get a rolled up update tomorrow. The plan is to change it to monthly after.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
