### PR TITLE
Change dependabot to a monthly cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     open-pull-requests-limit: 100
     groups:
       nonbreaking:
@@ -14,16 +14,16 @@ updates:
   - package-ecosystem: npm
     directory: "/npm/javy"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 100
 
   - package-ecosystem: npm
     directory: "/npm/javy-cli"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 100
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
## Description of the change

Changing Dependabot's cadence for all ecosystems to monthly.

## Why am I making this change?

We don't need to update our dependencies more frequently unless there's a security concern.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
