### PR TITLE
Simplify TLS in quickjs-wasm-sys WASI SDK download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,24 +1208,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0-rc.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951dfc2e32ac02d67c90c0d65bd27009a635dc9b381a2cc7d284ab01e3a0150d"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
  "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ef12f041acdd397010e5fb6433270c147d3b8b2d0a840cd7fff8e531dca5c8"
-dependencies = [
- "bytes",
- "futures-util",
- "http",
- "http-body",
  "pin-project-lite",
 ]
 
@@ -1249,9 +1237,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.0.0-rc.3"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75264b2003a3913f118d35c586e535293b3e22e41f074930762929d071e092"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1263,9 +1251,24 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "socket2 0.4.10",
  "tokio",
+ "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1640,7 +1643,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -2060,19 +2062,10 @@ version = "1.1.2-alpha.1"
 dependencies = [
  "anyhow",
  "bindgen",
- "bytes",
  "cc",
- "futures-core",
- "futures-task",
- "futures-util",
- "http-body-util",
  "hyper",
- "mio",
- "native-tls",
- "openssl-macros",
+ "hyper-tls",
  "tokio",
- "tokio-macros 1.7.0",
- "tokio-native-tls",
  "walkdir",
 ]
 
@@ -2474,6 +2467,16 @@ dependencies = [
  "autocfg",
  "static_assertions",
  "version_check",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2946,20 +2949,9 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
- "tokio-macros 2.1.0",
+ "socket2 0.5.5",
+ "tokio-macros",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2991,6 +2983,12 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"

--- a/crates/quickjs-wasm-sys/Cargo.toml
+++ b/crates/quickjs-wasm-sys/Cargo.toml
@@ -14,18 +14,6 @@ cc = "1.0"
 bindgen = "0.68.1"
 walkdir = "2"
 anyhow.workspace = true
-
-# The dependencies below are pinned so they map exactly to the exemptions
-# we copied from the wasmtime team to our supply-chain config
-tokio = { version = "=1.33.0", default-features = false, features = ["rt", "macros", "net"] }
-hyper = { version = "=1.0.0-rc.3", features = ["client", "http1"], default-features = false }
-bytes = "=1.5.0"
-futures-task = "=0.3.29"
-futures-util = { version = "=0.3.27", default-features = false }
-tokio-macros = "=1.7.0"
-futures-core = "=0.3.29"
-mio = "=0.8.9"
-http-body-util = "=0.1.0-rc.3"
-tokio-native-tls = "=0.3.1"
-native-tls = "0.2.11"
-openssl-macros = "=0.1.1"
+tokio = { version = "1.33", default-features = false, features = ["rt", "macros"] }
+hyper = { version = "0.14.27", features = ["client", "http1"] }
+hyper-tls = "0.5.0"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -153,6 +153,12 @@ user-id = 359 # Sean McArthur (seanmonstar)
 start = "2019-03-01"
 end = "2024-10-26"
 
+[[trusted.hyper-tls]]
+criteria = "safe-to-deploy"
+user-id = 359 # Sean McArthur (seanmonstar)
+start = "2019-03-19"
+end = "2024-10-27"
+
 [[trusted.io-extras]]
 criteria = "safe-to-deploy"
 user-id = 6825 # Dan Gohman (sunfishcode)

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -281,6 +281,10 @@ criteria = "safe-to-deploy"
 version = "0.3.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.http-body]]
+version = "0.4.5"
+criteria = "safe-to-deploy"
+
 [[exemptions.humantime]]
 version = "2.1.0"
 criteria = "safe-to-deploy"
@@ -526,6 +530,10 @@ version = "1.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.socket2]]
+version = "0.4.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.socket2]]
 version = "0.5.5"
 criteria = "safe-to-deploy"
 
@@ -651,6 +659,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.toml]]
 version = "0.5.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.tower-service]]
+version = "0.3.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.tracing]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -215,13 +215,6 @@ user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
-[[publisher.http-body-util]]
-version = "0.1.0-rc.3"
-when = "2023-07-10"
-user-id = 359
-user-login = "seanmonstar"
-user-name = "Sean McArthur"
-
 [[publisher.httparse]]
 version = "1.8.0"
 when = "2022-08-30"
@@ -230,8 +223,15 @@ user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
 [[publisher.hyper]]
-version = "1.0.0-rc.3"
-when = "2023-02-23"
+version = "0.14.27"
+when = "2023-06-26"
+user-id = 359
+user-login = "seanmonstar"
+user-name = "Sean McArthur"
+
+[[publisher.hyper-tls]]
+version = "0.5.0"
+when = "2020-12-29"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
@@ -1334,17 +1334,6 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 version = "0.4.0"
 notes = "Contains `forbid_unsafe` and only uses `std::fmt` from the standard library. Otherwise only contains string manipulation."
-
-[[audits.bytecode-alliance.audits.http-body]]
-who = "Pat Hickey <phickey@fastly.com>"
-criteria = "safe-to-deploy"
-version = "1.0.0-rc.2"
-
-[[audits.bytecode-alliance.audits.http-body-util]]
-who = "Pat Hickey <phickey@fastly.com>"
-criteria = "safe-to-deploy"
-version = "0.1.0-rc.2"
-notes = "only one use of unsafe related to pin projection. unclear to me why pin_project! is used in many modules of the project, but the expanded output of that macro is inlined in either.rs"
 
 [[audits.bytecode-alliance.audits.httpdate]]
 who = "Pat Hickey <phickey@fastly.com>"


### PR DESCRIPTION
## Description of the change

Simplify TLS in `quickjs-wasm-sys` build script by using `hyper-tls`. Also stop pinning dependencies since Dependabot will update them anyway.

I'm opting not to add a CHANGELOG entry since this doesn't affect any users of the crate in any way.

## Why am I making this change?

This simplifies keeping dependencies up to date by reducing the number of top-level dependencies we need to use and reduces the amount we need to interact with the `hyper` and `tokio` APIs. Specifically trying to get https://github.com/bytecodealliance/javy/pull/520 working was more time consuming than necessary IMO.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
