### PR TITLE
Update wit-parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,7 +1476,7 @@ dependencies = [
  "wasmprinter",
  "wasmtime",
  "wasmtime-wasi",
- "wit-parser 0.12.2",
+ "wit-parser 0.13.0",
  "wizer",
 ]
 
@@ -3989,9 +3989,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43771ee863a16ec4ecf9da0fc65c3bbd4a1235c8e3da5f094b562894843dfa76"
+checksum = "15df6b7b28ce94b8be39d8df5cb21a08a4f3b9f33b631aedb4aa5776f785ead3"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -26,7 +26,7 @@ wasmtime-wasi = { workspace = true }
 wasi-common = { workspace = true }
 walrus = "0.20.1"
 swc_core = { version = "0.86.29", features = ["common_sourcemap", "ecma_ast", "ecma_parser"] }
-wit-parser = "0.12.2"
+wit-parser = "0.13.0"
 convert_case = "0.6.0"
 
 [dev-dependencies]

--- a/crates/cli/src/exports.rs
+++ b/crates/cli/src/exports.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use convert_case::{Case, Casing};
-use std::path::Path;
+use std::{env, path::Path};
 
 use crate::{js::JS, wit};
 
@@ -11,7 +11,7 @@ pub struct Export {
 
 pub fn process_exports(js: &JS, wit: &Path, wit_world: &str) -> Result<Vec<Export>> {
     let js_exports = js.exports()?;
-    wit::parse_exports(wit, wit_world)?
+    parse_wit_exports(wit, wit_world)?
         .into_iter()
         .map(|wit_export| {
             let export = wit_export.from_case(Case::Kebab).to_case(Case::Camel);
@@ -25,4 +25,24 @@ pub fn process_exports(js: &JS, wit: &Path, wit_world: &str) -> Result<Vec<Expor
             }
         })
         .collect::<Result<Vec<Export>>>()
+}
+
+fn parse_wit_exports(wit: &Path, wit_world: &str) -> Result<Vec<String>> {
+    // Configure wit-parser to not require semicolons but only if the relevant
+    // environment variable is not already set.
+    const SEMICOLONS_OPTIONAL_ENV_VAR: &str = "WIT_REQUIRE_SEMICOLONS";
+    let semicolons_env_var_already_set = env::var(SEMICOLONS_OPTIONAL_ENV_VAR).is_ok();
+    if !semicolons_env_var_already_set {
+        env::set_var(SEMICOLONS_OPTIONAL_ENV_VAR, "0");
+    }
+
+    let exports = wit::parse_exports(wit, wit_world);
+
+    // If we set the environment variable to not require semicolons, remove
+    // that environment variable now that we no longer need it set.
+    if !semicolons_env_var_already_set {
+        env::remove_var(SEMICOLONS_OPTIONAL_ENV_VAR);
+    }
+
+    exports
 }

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -734,8 +734,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wit-parser]]
-version = "0.12.2"
-when = "2023-10-30"
+version = "0.13.0"
+when = "2023-11-06"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"


### PR DESCRIPTION
## Description of the change

Updates `wit-parser` to 0.13.

## Why am I making this change?

Dependabot tried making this update but failed due to wit-parser requiring semicolons in WIT files out of the box. Fortunately there is an environment variable we can set to override this behaviour.

I've opted to set and remove that environment variable only if that environment variable has not been set externally since someone setting it externally presumably knows what they're doing and wants the behaviour they set it to.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
