### PR TITLE
Add --no-source-compression option to reduce compile time

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -34,6 +34,10 @@ pub struct CompileCommandOpts {
     #[structopt(short = "n")]
     /// Optional WIT world name for WIT file. Must be specified if WIT is file path is specified.
     pub wit_world: Option<String>,
+
+    #[structopt(long = "dev")]
+    /// Enables the development mode, which reduces compile time at the expense of generating larger WebAssembly files.
+    pub dev: bool,
 }
 
 #[derive(Debug, StructOpt)]

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -35,9 +35,9 @@ pub struct CompileCommandOpts {
     /// Optional WIT world name for WIT file. Must be specified if WIT is file path is specified.
     pub wit_world: Option<String>,
 
-    #[structopt(long = "dev")]
-    /// Enables the development mode, which reduces compile time at the expense of generating larger WebAssembly files.
-    pub dev: bool,
+    #[structopt(long = "no-source-compression")]
+    /// Disable source code compression, which reduces compile time at the expense of generating larger WebAssembly files.
+    pub no_source_compression: bool,
 }
 
 #[derive(Debug, StructOpt)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -29,9 +29,9 @@ fn main() -> Result<()> {
                 (Some(wit), Some(world)) => exports::process_exports(&js, wit, world),
             }?;
             let wasm = if opts.dynamic {
-                dynamic_generator::generate(&js, exports)?
+                dynamic_generator::generate(&js, exports, !opts.dev)?
             } else {
-                static_generator::generate(&js, exports)?
+                static_generator::generate(&js, exports, !opts.dev)?
             };
             fs::write(&opts.output, wasm)?;
             Ok(())

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -29,9 +29,9 @@ fn main() -> Result<()> {
                 (Some(wit), Some(world)) => exports::process_exports(&js, wit, world),
             }?;
             let wasm = if opts.dynamic {
-                dynamic_generator::generate(&js, exports, !opts.dev)?
+                dynamic_generator::generate(&js, exports, opts.no_source_compression)?
             } else {
-                static_generator::generate(&js, exports, !opts.dev)?
+                static_generator::generate(&js, exports, opts.no_source_compression)?
             };
             fs::write(&opts.output, wasm)?;
             Ok(())

--- a/crates/cli/src/wasm_generator/dynamic.rs
+++ b/crates/cli/src/wasm_generator/dynamic.rs
@@ -64,7 +64,11 @@ use walrus::{DataKind, FunctionBuilder, Module, ValType};
 //    (data (;0;) "\02\05\18function.mjs\06foo\0econsole\06log\06bar\0f\bc\03\00\01\00\00\be\03\00\00\0e\00\06\01\a0\01\00\00\00\03\01\01\1a\00\be\03\00\01\08\ea\05\c0\00\e1)8\e0\00\00\00B\e1\00\00\00\04\e2\00\00\00$\01\00)\bc\03\01\04\01\00\07\0a\0eC\06\01\be\03\00\00\00\03\00\00\13\008\e0\00\00\00B\e1\00\00\00\04\df\00\00\00$\01\00)\bc\03\01\02\03]")
 //    (data (;1;) "foo")
 //  )
-pub fn generate(js: &JS, exported_functions: Vec<Export>, no_source_compression: bool) -> Result<Vec<u8>> {
+pub fn generate(
+    js: &JS,
+    exported_functions: Vec<Export>,
+    no_source_compression: bool,
+) -> Result<Vec<u8>> {
     let mut module = Module::with_config(transform::module_config());
 
     const IMPORT_NAMESPACE: &str = "javy_quickjs_provider_v1";

--- a/crates/cli/src/wasm_generator/dynamic.rs
+++ b/crates/cli/src/wasm_generator/dynamic.rs
@@ -64,7 +64,7 @@ use walrus::{DataKind, FunctionBuilder, Module, ValType};
 //    (data (;0;) "\02\05\18function.mjs\06foo\0econsole\06log\06bar\0f\bc\03\00\01\00\00\be\03\00\00\0e\00\06\01\a0\01\00\00\00\03\01\01\1a\00\be\03\00\01\08\ea\05\c0\00\e1)8\e0\00\00\00B\e1\00\00\00\04\e2\00\00\00$\01\00)\bc\03\01\04\01\00\07\0a\0eC\06\01\be\03\00\00\00\03\00\00\13\008\e0\00\00\00B\e1\00\00\00\04\df\00\00\00$\01\00)\bc\03\01\02\03]")
 //    (data (;1;) "foo")
 //  )
-pub fn generate(js: &JS, exported_functions: Vec<Export>) -> Result<Vec<u8>> {
+pub fn generate(js: &JS, exported_functions: Vec<Export>, compress_source: bool) -> Result<Vec<u8>> {
     let mut module = Module::with_config(transform::module_config());
 
     const IMPORT_NAMESPACE: &str = "javy_quickjs_provider_v1";
@@ -86,7 +86,11 @@ pub fn generate(js: &JS, exported_functions: Vec<Export>) -> Result<Vec<u8>> {
     let (memory, _) = module.add_import_memory(IMPORT_NAMESPACE, "memory", false, 0, None);
 
     transform::add_producers_section(&mut module.producers);
-    module.customs.add(SourceCodeSection::new(js)?);
+    if compress_source {
+        module.customs.add(SourceCodeSection::new(js)?);
+    } else {
+        module.customs.add(SourceCodeSection::uncompressed(js)?);
+    }
 
     let bytecode = js.compile()?;
     let bytecode_len: i32 = bytecode.len().try_into()?;

--- a/crates/cli/src/wasm_generator/dynamic.rs
+++ b/crates/cli/src/wasm_generator/dynamic.rs
@@ -64,7 +64,7 @@ use walrus::{DataKind, FunctionBuilder, Module, ValType};
 //    (data (;0;) "\02\05\18function.mjs\06foo\0econsole\06log\06bar\0f\bc\03\00\01\00\00\be\03\00\00\0e\00\06\01\a0\01\00\00\00\03\01\01\1a\00\be\03\00\01\08\ea\05\c0\00\e1)8\e0\00\00\00B\e1\00\00\00\04\e2\00\00\00$\01\00)\bc\03\01\04\01\00\07\0a\0eC\06\01\be\03\00\00\00\03\00\00\13\008\e0\00\00\00B\e1\00\00\00\04\df\00\00\00$\01\00)\bc\03\01\02\03]")
 //    (data (;1;) "foo")
 //  )
-pub fn generate(js: &JS, exported_functions: Vec<Export>, compress_source: bool) -> Result<Vec<u8>> {
+pub fn generate(js: &JS, exported_functions: Vec<Export>, no_source_compression: bool) -> Result<Vec<u8>> {
     let mut module = Module::with_config(transform::module_config());
 
     const IMPORT_NAMESPACE: &str = "javy_quickjs_provider_v1";
@@ -86,10 +86,10 @@ pub fn generate(js: &JS, exported_functions: Vec<Export>, compress_source: bool)
     let (memory, _) = module.add_import_memory(IMPORT_NAMESPACE, "memory", false, 0, None);
 
     transform::add_producers_section(&mut module.producers);
-    if compress_source {
-        module.customs.add(SourceCodeSection::new(js)?);
-    } else {
+    if no_source_compression {
         module.customs.add(SourceCodeSection::uncompressed(js)?);
+    } else {
+        module.customs.add(SourceCodeSection::compressed(js)?);
     }
 
     let bytecode = js.compile()?;

--- a/crates/cli/src/wasm_generator/static.rs
+++ b/crates/cli/src/wasm_generator/static.rs
@@ -14,7 +14,7 @@ use super::transform::{self, SourceCodeSection};
 
 static mut WASI: OnceLock<WasiCtx> = OnceLock::new();
 
-pub fn generate(js: &JS, exports: Vec<Export>, compress_source: bool) -> Result<Vec<u8>> {
+pub fn generate(js: &JS, exports: Vec<Export>, no_source_compression: bool) -> Result<Vec<u8>> {
     let wasm = include_bytes!(concat!(env!("OUT_DIR"), "/engine.wasm"));
 
     let wasi = WasiCtxBuilder::new()
@@ -97,10 +97,10 @@ pub fn generate(js: &JS, exports: Vec<Export>, compress_source: bool) -> Result<
     let wasm = module.write();
 
     let mut module = transform::module_config().parse(&wasm)?;
-    if compress_source {
-        module.customs.add(SourceCodeSection::new(js)?);
-    } else {
+    if no_source_compression {
         module.customs.add(SourceCodeSection::uncompressed(js)?);
+    } else {
+        module.customs.add(SourceCodeSection::compressed(js)?);
     }
     transform::add_producers_section(&mut module.producers);
     Ok(module.emit_wasm())

--- a/crates/cli/src/wasm_generator/transform.rs
+++ b/crates/cli/src/wasm_generator/transform.rs
@@ -7,19 +7,19 @@ use crate::js::JS;
 
 #[derive(Debug)]
 pub struct SourceCodeSection {
-    compressed_source_code: Vec<u8>,
+    source_code: Vec<u8>,
 }
 
 impl SourceCodeSection {
-    pub fn new(js: &JS) -> Result<SourceCodeSection> {
+    pub fn compressed(js: &JS) -> Result<SourceCodeSection> {
         Ok(SourceCodeSection {
-            compressed_source_code: js.compress()?,
+            source_code: js.compress()?,
         })
     }
 
     pub fn uncompressed(js: &JS) -> Result<SourceCodeSection> {
         Ok(SourceCodeSection {
-            compressed_source_code: js.as_bytes().to_vec(),
+            source_code: js.as_bytes().to_vec(),
         })
     }
 }
@@ -30,7 +30,7 @@ impl CustomSection for SourceCodeSection {
     }
 
     fn data(&self, _ids_to_indices: &IdsToIndices) -> Cow<[u8]> {
-        (&self.compressed_source_code).into()
+        (&self.source_code).into()
     }
 }
 

--- a/crates/cli/src/wasm_generator/transform.rs
+++ b/crates/cli/src/wasm_generator/transform.rs
@@ -16,6 +16,12 @@ impl SourceCodeSection {
             compressed_source_code: js.compress()?,
         })
     }
+
+    pub fn uncompressed(js: &JS) -> Result<SourceCodeSection> {
+        Ok(SourceCodeSection {
+            compressed_source_code: js.as_bytes().to_vec(),
+        })
+    }
 }
 
 impl CustomSection for SourceCodeSection {


### PR DESCRIPTION
close #579

## Description of the change
Add --no-source-compression option to reduce compile time

## Why am I making this change?
ref: #579

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
