### PR TITLE
Update GitHub Actions artifact actions to v4

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -37,13 +37,13 @@ jobs:
         run: make core
 
       - name: Upload core binary to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: engine
           path: target/wasm32-wasi/release/javy_core.wasm
 
       - name: Upload quickjs_provider to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: provider
           path: target/wasm32-wasi/release/javy_quickjs_provider.wasm
@@ -54,7 +54,7 @@ jobs:
           gzip -k -f target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm && mv target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm.gz javy-quickjs_provider.wasm.gz
 
       - name: Upload archived quickjs_provider to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: javy-quickjs_provider.wasm.gz
           path: javy-quickjs_provider.wasm.gz
@@ -69,7 +69,7 @@ jobs:
         run: shasum -a 256 javy-quickjs_provider.wasm.gz | awk '{ print $1 }' > javy-quickjs_provider.wasm.gz.sha256
 
       - name: Upload asset hash to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: javy-quickjs_provider.wasm.gz.sha256
           path: javy-quickjs_provider.wasm.gz.sha256
@@ -130,12 +130,12 @@ jobs:
         run: sudo apt-get update && sudo apt-get --assume-yes install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
         if: matrix.target == 'aarch64-unknown-linux-gnu'
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: engine
           path: target/wasm32-wasi/release/
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: provider
           path: target/wasm32-wasi/release/
@@ -149,7 +149,7 @@ jobs:
         run: gzip -k -f ${{ matrix.path }} && mv ${{ matrix.path }}.gz ${{ matrix.asset_name }}.gz
 
       - name: Upload assets to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset_name }}.gz
           path: ${{ matrix.asset_name }}.gz
@@ -164,7 +164,7 @@ jobs:
         run: ${{ matrix.shasum_cmd }} ${{ matrix.asset_name }}.gz | awk '{ print $1 }' > ${{ matrix.asset_name }}.gz.sha256
 
       - name: Upload asset hash to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset_name }}.gz.sha256
           path: ${{ matrix.asset_name }}.gz.sha256

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,13 @@ jobs:
         run: cargo clippy --workspace --exclude=javy-cli --target=wasm32-wasi --all-targets -- -D warnings
 
       - name: Upload core binary to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: engine
           path: target/wasm32-wasi/release/javy_core.wasm
 
       - name: Upload quickjs_provider to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: provider
           path: target/wasm32-wasi/release/javy_quickjs_provider.wasm
@@ -60,12 +60,12 @@ jobs:
         with:
           os: linux
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: engine
           path: target/wasm32-wasi/release/
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: provider
           path: target/wasm32-wasi/release/


### PR DESCRIPTION
## Description of the change

Updates _both_ `actions/upload-artifact` and `actions/download-artifact` from v3 to v4.

## Why am I making this change?

Dependabot tried updating both actions individually and that didn't work. I'm guessing they both need to be using v4 to work.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
