### PR TITLE
Fixed no-source-compression to compress at level 0 instead of no-compression

### DIFF
--- a/crates/cli/src/js.rs
+++ b/crates/cli/src/js.rs
@@ -54,13 +54,13 @@ impl JS {
         bytecode::compile_source(self.source_code.as_bytes())
     }
 
-    pub fn compress(&self) -> Result<Vec<u8>> {
+    pub fn compress(&self, quality: i32) -> Result<Vec<u8>> {
         let mut compressed_source_code: Vec<u8> = vec![];
         enc::BrotliCompress(
             &mut Cursor::new(&self.source_code.as_bytes()),
             &mut compressed_source_code,
             &BrotliEncoderParams {
-                quality: 11,
+                quality,
                 ..Default::default()
             },
         )?;

--- a/crates/cli/src/wasm_generator/transform.rs
+++ b/crates/cli/src/wasm_generator/transform.rs
@@ -13,13 +13,13 @@ pub struct SourceCodeSection {
 impl SourceCodeSection {
     pub fn compressed(js: &JS) -> Result<SourceCodeSection> {
         Ok(SourceCodeSection {
-            source_code: js.compress()?,
+            source_code: js.compress(11)?,
         })
     }
 
     pub fn uncompressed(js: &JS) -> Result<SourceCodeSection> {
         Ok(SourceCodeSection {
-            source_code: js.as_bytes().to_vec(),
+            source_code: js.compress(0)?,
         })
     }
 }


### PR DESCRIPTION
rel: #581
## Description of the change
Fixed no-source-compression to compress at level 0 instead of no-compression

## Why am I making this change?
https://github.com/bytecodealliance/javy/pull/581#issuecomment-1878925292

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
