### PR TITLE
v1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "binaryen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.3.0"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
## Description of the change

Preparing for a new release to add the `--no-source-compression` flag by incrementing the minor version.

## Why am I making this change?

There's no reason to not release support for the new flag.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
