### PR TITLE
Prepare crate versions for publishing to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "2.2.0-alpha.1"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "quickjs-wasm-rs",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "javy-apis"
-version = "2.2.0-alpha.1"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "fastrand",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-sys"
-version = "1.2.0-alpha.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ wasmtime-wasi = "16"
 wasi-common = "16"
 anyhow = "1.0"
 once_cell = "1.19"
-javy = { path = "crates/javy", version = "2.2.0-alpha.1" }
+javy = { path = "crates/javy", version = "2.2.0" }
 
 [profile.release]
 lto = true

--- a/crates/apis/CHANGELOG.md
+++ b/crates/apis/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2024-01-31
+
 ### Changed
 
 - Updated to 2023-12-09 release of QuickJS.

--- a/crates/apis/Cargo.toml
+++ b/crates/apis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-apis"
-version = "2.2.0-alpha.1"
+version = "2.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2024-01-31
+
 ### Fixed
 
 - Missing documentation for `export_alloc_fns` feature and `alloc` functions.

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "2.2.0-alpha.1"
+version = "2.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -11,7 +11,7 @@ categories = ["wasm"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-rs = { version = "3.0.0-alpha.1", path = "../quickjs-wasm-rs" }
+quickjs-wasm-rs = { version = "3.0.0", path = "../quickjs-wasm-rs" }
 serde_json = { version = "1.0", optional = true }
 serde-transcode = { version = "1.1", optional = true }
 rmp-serde = { version = "^1.1", optional = true }

--- a/crates/quickjs-wasm-rs/CHANGELOG.md
+++ b/crates/quickjs-wasm-rs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.0.0] - 2024-01-31
+
 ### Changed
 
 - Make `JSContextRef::wrap_rust_value` private. Similar to

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-rs"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-sys = { version = "1.2.0-alpha.1", path = "../quickjs-wasm-sys" }
+quickjs-wasm-sys = { version = "1.2.0", path = "../quickjs-wasm-sys" }
 serde = { version = "1.0", features = ["derive"] }
 once_cell = "1.19"
 

--- a/crates/quickjs-wasm-sys/CHANGELOG.md
+++ b/crates/quickjs-wasm-sys/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased changes
+
+## [1.2.0] - 2024-01-31
 
 - Changed: Updated to 2023-12-09 release of QuickJS.
 

--- a/crates/quickjs-wasm-sys/Cargo.toml
+++ b/crates/quickjs-wasm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-sys"
-version = "1.2.0-alpha.1"
+version = "1.2.0"
 authors.workspace = true
 edition.workspace = true 
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Removing the suffixes from `quickjs-wasm-sys`, `quickjs-wasm-rs`, `javy`, and `javy-apis` and marking them as published in CHANGELOG files.

## Why am I making this change?

I want to publish new versions of these crates to crates.io so other people can take advantage of the QuickJS update we performed.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
