### PR TITLE
Add alpha suffixes to crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "2.2.0"
+version = "2.2.1-alpha.1"
 dependencies = [
  "anyhow",
  "quickjs-wasm-rs",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "javy-apis"
-version = "2.2.0"
+version = "2.2.1-alpha.1"
 dependencies = [
  "anyhow",
  "fastrand",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "3.0.0"
+version = "3.0.1-alpha.1"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-sys"
-version = "1.2.0"
+version = "1.2.1-alpha.1"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ wasmtime-wasi = "16"
 wasi-common = "16"
 anyhow = "1.0"
 once_cell = "1.19"
-javy = { path = "crates/javy", version = "2.2.0" }
+javy = { path = "crates/javy", version = "2.2.1-alpha.1" }
 
 [profile.release]
 lto = true

--- a/crates/apis/Cargo.toml
+++ b/crates/apis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-apis"
-version = "2.2.0"
+version = "2.2.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "2.2.0"
+version = "2.2.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -11,7 +11,7 @@ categories = ["wasm"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-rs = { version = "3.0.0", path = "../quickjs-wasm-rs" }
+quickjs-wasm-rs = { version = "3.0.1-alpha.1", path = "../quickjs-wasm-rs" }
 serde_json = { version = "1.0", optional = true }
 serde-transcode = { version = "1.1", optional = true }
 rmp-serde = { version = "^1.1", optional = true }

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-rs"
-version = "3.0.0"
+version = "3.0.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-sys = { version = "1.2.0", path = "../quickjs-wasm-sys" }
+quickjs-wasm-sys = { version = "1.2.1-alpha.1", path = "../quickjs-wasm-sys" }
 serde = { version = "1.0", features = ["derive"] }
 once_cell = "1.19"
 

--- a/crates/quickjs-wasm-sys/Cargo.toml
+++ b/crates/quickjs-wasm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-sys"
-version = "1.2.0"
+version = "1.2.1-alpha.1"
 authors.workspace = true
 edition.workspace = true 
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Bumping all patch versions with an alpha suffix.

## Why am I making this change?

See https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#the-system for our versioning strategy.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
