### PR TITLE
Add escape hatches to and from `quickjs_wasm_sys`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "3.0.1-alpha.1"
+version = "3.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["wasm"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-rs = { version = "3.0.1-alpha.1", path = "../quickjs-wasm-rs" }
+quickjs-wasm-rs = { version = "3.1.0-alpha.1", path = "../quickjs-wasm-rs" }
 serde_json = { version = "1.0", optional = true }
 serde-transcode = { version = "1.1", optional = true }
 rmp-serde = { version = "^1.1", optional = true }

--- a/crates/quickjs-wasm-rs/CHANGELOG.md
+++ b/crates/quickjs-wasm-rs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add a new `expose-sys` feature that exposes unstable escape hatch functions to the underlying `quickjs_wasm_sys` crate.
+
 ## [3.0.0] - 2024-01-31
 
 ### Changed

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-rs"
-version = "3.0.1-alpha.1"
+version = "3.1.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -18,3 +18,7 @@ once_cell = "1.19"
 [dev-dependencies]
 quickcheck = "1"
 serde_bytes = "0.11.14"
+
+[features]
+# Re-exports the quickjs-wasm-sys module and exposes additional, unstable APIs.
+export-sys = []

--- a/crates/quickjs-wasm-rs/src/js_binding/context.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/context.rs
@@ -146,6 +146,9 @@ impl JSContextRef {
     /// # Safety
     /// While calling this function is safe, using it’s return value has to be
     /// done with a sufficitenly deep understanding of QuickJS and [quickjs_wasm_sys].
+    ///
+    /// This function is not part of the crate’s semver API contract.
+    #[cfg(feature = "export-sys")]
     pub unsafe fn as_raw(&self) -> *mut JSContext {
         self.inner
     }
@@ -155,6 +158,9 @@ impl JSContextRef {
     /// # Safety
     /// The caller has to ensure that the returned `JSContextRef` is the only one
     /// used throughout its lifetime.
+    ///
+    /// This function is not part of the crate’s semver API contract.
+    #[cfg(feature = "export-sys")]
     pub unsafe fn from_raw(inner: *mut JSContext) -> JSContextRef {
         JSContextRef { inner }
     }

--- a/crates/quickjs-wasm-rs/src/js_binding/context.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/context.rs
@@ -141,6 +141,15 @@ impl JSContextRef {
         JSValueRef::new(self, raw)
     }
 
+    /// Returns the raw pointer to the underlying [quickjs_wasm_sys::JSContext].
+    pub unsafe fn as_raw(&self) -> *mut JSContext {
+        self.inner
+    }
+
+    pub unsafe fn from_raw(inner: *mut JSContext) -> JSContextRef {
+        JSContextRef { inner }
+    }
+
     /// Compiles JavaScript to QuickJS bytecode with an ECMAScript module scope.
     ///
     /// # Arguments

--- a/crates/quickjs-wasm-rs/src/js_binding/context.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/context.rs
@@ -142,10 +142,19 @@ impl JSContextRef {
     }
 
     /// Returns the raw pointer to the underlying [quickjs_wasm_sys::JSContext].
+    ///
+    /// # Safety
+    /// While calling this function is safe, using it’s return value has to be
+    /// done with a sufficitenly deep understanding of QuickJS and [quickjs_wasm_sys].
     pub unsafe fn as_raw(&self) -> *mut JSContext {
         self.inner
     }
 
+    /// Creates a `JSContextRef` from a pointer to a [quickjs_wasm_sys::JSContext].
+    ///
+    /// # Safety
+    /// The caller has to ensure that the returned `JSContextRef` is the only one
+    /// used throughout its lifetime.
     pub unsafe fn from_raw(inner: *mut JSContext) -> JSContextRef {
         JSContextRef { inner }
     }

--- a/crates/quickjs-wasm-rs/src/js_binding/value.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/value.rs
@@ -58,6 +58,10 @@ impl<'a> JSValueRef<'a> {
         Self { context, value }
     }
 
+    /// Creates a new `JSValueRef` from a `u64`, which is QuickJS’s internal representation.
+    ///
+    /// # Safety
+    /// The caller has to ensure that the given value is valid and belongs to the context.
     pub unsafe fn from_raw(context: &'a JSContextRef, value: JSValueRaw) -> Self {
         JSValueRef::new_unchecked(context, value)
     }

--- a/crates/quickjs-wasm-rs/src/js_binding/value.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/value.rs
@@ -206,12 +206,8 @@ impl<'a> JSValueRef<'a> {
 
     /// Converts the JavaScript value to a string if it is a string.
     pub fn as_str(&self) -> Result<&str> {
-        if self.is_str() {
-            let buffer = self.as_wtf8_str_buffer();
-            str::from_utf8(buffer).map_err(Into::into)
-        } else {
-            Err(anyhow!("Value {:?} is not a str", self.value))
-        }
+        let buffer = self.as_wtf8_str_buffer();
+        str::from_utf8(buffer).map_err(Into::into)
     }
 
     /// Converts the JavaScript value to a string, replacing any invalid UTF-8 sequences with the

--- a/crates/quickjs-wasm-rs/src/js_binding/value.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/value.rs
@@ -62,10 +62,21 @@ impl<'a> JSValueRef<'a> {
     ///
     /// # Safety
     /// The caller has to ensure that the given value is valid and belongs to the context.
+    ///
+    /// This function is not part of the crate’s semver API contract.
+    #[cfg(feature = "export-sys")]
     pub unsafe fn from_raw(context: &'a JSContextRef, value: JSValueRaw) -> Self {
         JSValueRef::new_unchecked(context, value)
     }
 
+    /// Returns QuickJS’s internal representation. Note that the value is implicitly tied to the context it came from.
+    ///
+    /// # Safety
+    /// The function is safe to call, but not part of the crate’s semver API contract.
+    #[cfg(feature = "export-sys")]
+    pub unsafe fn as_raw(&self) -> JSValueRaw {
+        self.value
+    }
     pub(super) fn eval_function(&self) -> Result<Self> {
         Self::new(self.context, unsafe {
             JS_EvalFunction(self.context.inner, self.value)

--- a/crates/quickjs-wasm-rs/src/js_binding/value.rs
+++ b/crates/quickjs-wasm-rs/src/js_binding/value.rs
@@ -210,7 +210,7 @@ impl<'a> JSValueRef<'a> {
             let buffer = self.as_wtf8_str_buffer();
             str::from_utf8(buffer).map_err(Into::into)
         } else {
-            Err(anyhow!("Can’t represent {:?} as str", self.value))
+            Err(anyhow!("Value {:?} is not a str", self.value))
         }
     }
 

--- a/crates/quickjs-wasm-rs/src/lib.rs
+++ b/crates/quickjs-wasm-rs/src/lib.rs
@@ -66,6 +66,8 @@ mod js_binding;
 mod js_value;
 mod serialize;
 
+pub use quickjs_wasm_sys;
+
 pub use crate::js_binding::context::JSContextRef;
 pub use crate::js_binding::error::JSError;
 pub use crate::js_binding::exception::Exception;

--- a/crates/quickjs-wasm-rs/src/lib.rs
+++ b/crates/quickjs-wasm-rs/src/lib.rs
@@ -66,6 +66,7 @@ mod js_binding;
 mod js_value;
 mod serialize;
 
+#[cfg(feature = "export-sys")]
 pub use quickjs_wasm_sys;
 
 pub use crate::js_binding::context::JSContextRef;


### PR DESCRIPTION
While `quickjs_wasm_rs` provides a much more ergonomic API, there are some features of QuickJS that are not exposed. For example, exotic object behaviors or QuickJS’s execution timeout.

In the long-run, it would be great to have those in `quickjs_wasm_rs`, but in the meantime, it seems like a good idea regardless to me expose escape hatches to the low-level crate.

Specifically: 
- Expose the `wasm_quick_sys` module from `quickjs_wasm_rs` to avoid users having to add that crate themselves and potentially ending up with different version.
- Add a function to convert raw QuickJS value (`u64`) into a `JSValueRef`
- Add functions to convert a `*mut JSContext` to a `JSContextRef` and vice versa (in fact, `*mut JSContext` was already exposed via [`new_callback`](https://docs.rs/quickjs-wasm-rs/latest/quickjs_wasm_rs/struct.JSContextRef.html#method.new_callback), but hard to utilize without the other parts).