### PR TITLE
Bump provider version to v2

### DIFF
--- a/crates/cli/benches/benchmark.rs
+++ b/crates/cli/benches/benchmark.rs
@@ -121,7 +121,7 @@ impl FunctionCase {
                 ))?,
             )?;
             let instance = linker.instantiate(&mut store, &qjs_provider)?;
-            linker.instance(&mut store, "javy_quickjs_provider_v1", instance)?;
+            linker.instance(&mut store, "javy_quickjs_provider_v2", instance)?;
         }
 
         Ok((linker, store))

--- a/crates/cli/src/wasm_generator/dynamic.rs
+++ b/crates/cli/src/wasm_generator/dynamic.rs
@@ -12,10 +12,10 @@ use walrus::{DataKind, FunctionBuilder, Module, ValType};
 //    (type (;1;) (func (param i32 i32)))
 //    (type (;2;) (func (param i32 i32 i32 i32)))
 //    (type (;3;) (func (param i32 i32 i32 i32) (result i32)))
-//    (import "javy_quickjs_provider_v1" "canonical_abi_realloc" (func (;0;) (type 3)))
-//    (import "javy_quickjs_provider_v1" "eval_bytecode" (func (;1;) (type 1)))
-//    (import "javy_quickjs_provider_v1" "memory" (memory (;0;) 0))
-//    (import "javy_quickjs_provider_v1" "invoke" (func (;2;) (type 2)))
+//    (import "javy_quickjs_provider_v2" "canonical_abi_realloc" (func (;0;) (type 3)))
+//    (import "javy_quickjs_provider_v2" "eval_bytecode" (func (;1;) (type 1)))
+//    (import "javy_quickjs_provider_v2" "memory" (memory (;0;) 0))
+//    (import "javy_quickjs_provider_v2" "invoke" (func (;2;) (type 2)))
 //    (func (;3;) (type 0)
 //      (local i32 i32)
 //      i32.const 0
@@ -71,7 +71,7 @@ pub fn generate(
 ) -> Result<Vec<u8>> {
     let mut module = Module::with_config(transform::module_config());
 
-    const IMPORT_NAMESPACE: &str = "javy_quickjs_provider_v1";
+    const IMPORT_NAMESPACE: &str = "javy_quickjs_provider_v2";
 
     let canonical_abi_realloc_type = module.types.add(
         &[ValType::I32, ValType::I32, ValType::I32, ValType::I32],

--- a/crates/cli/tests/dynamic_linking_test.rs
+++ b/crates/cli/tests/dynamic_linking_test.rs
@@ -54,12 +54,12 @@ pub fn check_for_new_imports() -> Result<()> {
     let module = Module::from_binary(&engine, &wasm)?;
     for import in module.imports() {
         match (import.module(), import.name(), import.ty()) {
-            ("javy_quickjs_provider_v1", "canonical_abi_realloc", ExternType::Func(f))
+            ("javy_quickjs_provider_v2", "canonical_abi_realloc", ExternType::Func(f))
                 if f.params().map(|t| t.is_i32()).eq([true, true, true, true])
                     && f.results().map(|t| t.is_i32()).eq([true]) => {}
-            ("javy_quickjs_provider_v1", "eval_bytecode", ExternType::Func(f))
+            ("javy_quickjs_provider_v2", "eval_bytecode", ExternType::Func(f))
                 if f.params().map(|t| t.is_i32()).eq([true, true]) && f.results().len() == 0 => {}
-            ("javy_quickjs_provider_v1", "memory", ExternType::Memory(_)) => (),
+            ("javy_quickjs_provider_v2", "memory", ExternType::Memory(_)) => (),
             _ => panic!("Unknown import {:?}", import),
         }
     }
@@ -82,15 +82,15 @@ pub fn check_for_new_imports_for_exports() -> Result<()> {
     let module = Module::from_binary(&engine, &wasm)?;
     for import in module.imports() {
         match (import.module(), import.name(), import.ty()) {
-            ("javy_quickjs_provider_v1", "canonical_abi_realloc", ExternType::Func(f))
+            ("javy_quickjs_provider_v2", "canonical_abi_realloc", ExternType::Func(f))
                 if f.params().map(|t| t.is_i32()).eq([true, true, true, true])
                     && f.results().map(|t| t.is_i32()).eq([true]) => {}
-            ("javy_quickjs_provider_v1", "eval_bytecode", ExternType::Func(f))
+            ("javy_quickjs_provider_v2", "eval_bytecode", ExternType::Func(f))
                 if f.params().map(|t| t.is_i32()).eq([true, true]) && f.results().len() == 0 => {}
-            ("javy_quickjs_provider_v1", "invoke", ExternType::Func(f))
+            ("javy_quickjs_provider_v2", "invoke", ExternType::Func(f))
                 if f.params().map(|t| t.is_i32()).eq([true, true, true, true])
                     && f.results().len() == 0 => {}
-            ("javy_quickjs_provider_v1", "memory", ExternType::Memory(_)) => (),
+            ("javy_quickjs_provider_v2", "memory", ExternType::Memory(_)) => (),
             _ => panic!("Unknown import {:?}", import),
         }
     }
@@ -175,7 +175,7 @@ fn invoke_fn_on_generated_module(
     let quickjs_provider_instance = linker.instantiate(&mut store, &quickjs_provider_module)?;
     linker.instance(
         &mut store,
-        "javy_quickjs_provider_v1",
+        "javy_quickjs_provider_v2",
         quickjs_provider_instance,
     )?;
     let js_instance = linker.instantiate(&mut store, &js_module)?;


### PR DESCRIPTION
## Description of the change

Bump the provider from `v1` to `v2`

## Why am I making this change?

#618 introduced breaking changes in the bytecode, thus modules compiled for the provider v1 will no longer work. By bumping the provider to v2, runtimes will be able to load both Javy modules that were compiled for v1 and v2.

## Checklist

- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.

-> I'd suggest making 1 entry for the version bump / rquickjs change, agreed?

- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)

-> Ditto, we'll do that later

- [ ] I've updated documentation including crate documentation if necessary.

-> N/A
