### PR TITLE
Skip serializing object entries w/ undefined value

### DIFF
--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Introduce `rquickjs` to interface with QuickJS instead of `quickjs-wasm-rs`;
-  this version no longer includes re-exports from `quickjs-wasm-rs`. 
+  this version no longer includes re-exports from `quickjs-wasm-rs`.
+- `javy::serde::de::Deserializer` should now match `JSON.stringify`: non-JSON
+  primitives are skipped in Objects and nullified in Arrays.
 
 ## [2.2.0] - 2024-01-31
 


### PR DESCRIPTION
## Description of the change

Improve Javy's Value serializer compatibility with `JSON.stringify`:
- For Arrays, nullify non-JSONable values
- For Objects, skip entries with non-JSONable values

## Why am I making this change?

Encoding a QuickJS value to JSON using the transcoder offers a nice performance gain over QuickJS's `JSON.stringify`, but differs in behaviour. This PR should partially close the gap.


```
$ echo "console.log(JSON.stringify({foo: undefined}))" | node
{}
```

Without this change, transcoding the above `{foo: undefined}` to a JSON string would result in `{"foo":null}`.


This PR fixes that by skipping skipping the deserialization of entries with `undefined`. **This is a lossy conversion** given serde data model doesn't know about `undefined`,  and both the serde `Unit` and `None` data types are serialized as `null` in JSON.

Similar logic is applied to Array values, but in that case the values are nullified instead of skipped.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- ~[ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)~
- ~[ ] I've updated documentation including crate documentation if necessary.~
