### PR TITLE
docs: Improve READMEs for `apis` and `javy` crates

### DIFF
--- a/crates/apis/README.md
+++ b/crates/apis/README.md
@@ -1,6 +1,29 @@
 # Javy APIs
 
 A collection of APIs for Javy.
+ 
+Example usage:
+
+```rust
+use anyhow::{anyhow, Error, Result};
+use javy::{quickjs::JSValue, Runtime};
+use javy_apis::RuntimeExt;
+
+let runtime = Runtime::new_with_defaults()?;
+let context = runtime.context();
+context.global_object()?.set_property(
+    "print",
+    context.wrap_callback(move |_ctx, _this, args| {
+        let str = args
+            .first()
+            .ok_or(anyhow!("Need to pass an argument"))?
+            .to_string();
+        println!("{str}");
+       Ok(JSValue::Undefined)
+    })?,
+ )?;
+ context.eval_global("hello.js", "print('hello!');")?;
+```
 
 ## Publishing to crates.io
 

--- a/crates/apis/README.md
+++ b/crates/apis/README.md
@@ -1,6 +1,16 @@
-# Javy APIs
+<div align="center">
+  <h1><code>Javy APIs</code></h1>
+  <p>
+    <strong>A collection of APIs for Javy</strong>
+  </p>
 
-A collection of APIs for Javy.
+  <p>
+    <a href="https://docs.rs/javy-apis"><img src="https://docs.rs/javy-apis/badge.svg" alt="Documentation Status" /></a>
+    <a href="https://crates.io/crates/javy-apis"><img src="https://img.shields.io/crates/v/javy-apis.svg" alt="crates.io status" /></a>
+  </p>
+</div>
+
+Refer to the [crate level documentation](https://docs.rs/javy-apis) to learn more.
  
 Example usage:
 

--- a/crates/apis/README.md
+++ b/crates/apis/README.md
@@ -1,36 +1,6 @@
-# javy-apis
+# Javy APIs
 
-A collection of APIs that can be added to a Javy runtime.
-
-APIs are registered by enabling crate features.
-
-## Example usage
-
-```rust
-
-// With the `console` feature enabled.
-use javy::{Runtime, from_js_error};
-use javy_apis::RuntimeExt;
-use anyhow::Result;
-
-fn main() -> Result<()> {
-    let runtime = Runtime::new_with_defaults()?;
-    let context = runtime.context();
-    context.with(|cx| {
-        cx.eval_with_options(Default::default(), "console.log('hello!');")
-            .map_err(|e| to_js_error(cx.clone(), e))?
-    });
-    Ok(())
-}
-```
-
-If you want to customize the runtime or the APIs, you can use the `Runtime::new_with_apis` method instead to provide a `javy::Config` for the underlying `Runtime` or an `APIConfig` for the APIs.
-
-## Features
-* `console` - Registers an implementation of the `console` API.
-* `text_encoding` - Registers implementations of `TextEncoder` and `TextDecoder`.
-* `random` - Overrides the implementation of `Math.random` to one that seeds the RNG on first call to `Math.random`. This is helpful to enable when using Wizer to snapshot a Javy Runtime so that the output of `Math.random` relies on the WASI context used at runtime and not the WASI context used when Wizening. Enabling this feature will increase the size of the Wasm module that includes the Javy Runtime and will introduce an additional hostcall invocation when `Math.random` is invoked for the first time.
-* `stream_io` - Registers implementations of `Javy.IO.readSync` and `Javy.IO.writeSync`.
+A collection of APIs for Javy.
 
 ## Publishing to crates.io
 

--- a/crates/apis/README.md
+++ b/crates/apis/README.md
@@ -5,24 +5,20 @@ A collection of APIs for Javy.
 Example usage:
 
 ```rust
-use anyhow::{anyhow, Error, Result};
-use javy::{quickjs::JSValue, Runtime};
+// With the `console` feature enabled.
+use javy::{Runtime, from_js_error};
 use javy_apis::RuntimeExt;
+use anyhow::Result;
 
-let runtime = Runtime::new_with_defaults()?;
-let context = runtime.context();
-context.global_object()?.set_property(
-    "print",
-    context.wrap_callback(move |_ctx, _this, args| {
-        let str = args
-            .first()
-            .ok_or(anyhow!("Need to pass an argument"))?
-            .to_string();
-        println!("{str}");
-       Ok(JSValue::Undefined)
-    })?,
- )?;
- context.eval_global("hello.js", "print('hello!');")?;
+fn main() -> Result<()> {
+    let runtime = Runtime::new_with_defaults()?;
+    let context = runtime.context();
+    context.with(|cx| {
+        cx.eval_with_options(Default::default(), "console.log('hello!');")
+            .map_err(|e| to_js_error(cx.clone(), e))?
+    });
+    Ok(())
+}
 ```
 
 ## Publishing to crates.io

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -3,25 +3,23 @@
 //! APIs are enabled through cargo features.
 //!
 //! Example usage:
-//! ```
-//! # use anyhow::{anyhow, Error, Result};
-//! use javy::{quickjs::JSValue, Runtime};
-//! use javy_apis::RuntimeExt;
+//! ```rust
 //!
-//! let runtime = Runtime::new_with_defaults()?;
-//! let context = runtime.context();
-//! context.global_object()?.set_property(
-//!    "print",
-//!    context.wrap_callback(move |_ctx, _this, args| {
-//!        let str = args
-//!            .first()
-//!            .ok_or(anyhow!("Need to pass an argument"))?
-//!            .to_string();
-//!        println!("{str}");
-//!        Ok(JSValue::Undefined)
-//!    })?,
-//! )?;
-//! context.eval_global("hello.js", "print('hello!');")?;
+//! //With the `console` feature enabled.
+//! use javy::{Runtime, from_js_error};
+//! use javy_apis::RuntimeExt;
+//! use anyhow::Result;
+//!
+//! fn main() -> Result<()> {
+//!     let runtime = Runtime::new_with_defaults()?;
+//!     let context = runtime.context();
+//!     context.with(|cx| {
+//!         cx.eval_with_options(Default::default(), "console.log('hello!');")
+//!             .map_err(|e| to_js_error(cx.clone(), e))?
+//!     });
+//!     Ok(())
+//! }
+//!
 //! ```
 //!
 //! If you want to customize the runtime or the APIs, you can use the

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -22,7 +22,6 @@
 //!    })?,
 //! )?;
 //! context.eval_global("hello.js", "print('hello!');")?;
-//! # Ok::<(), Error>(())
 //! ```
 //!
 //! If you want to customize the runtime or the APIs, you can use the

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -41,7 +41,7 @@
 //! the Wasm module that includes the Javy Runtime and will introduce an
 //! additional hostcall invocation when `Math.random` is invoked for the first
 //! time.
-//! * `stream_io`: Adds the implementation of `Javy.IO.readSync` and `Javy.IO.writeSync`.
+//! * `stream_io`: Adds an implementation of `Javy.IO.readSync` and `Javy.IO.writeSync`.
 
 use anyhow::Result;
 use javy::Runtime;

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -1,6 +1,6 @@
-//! JS APIs for Javy.
+//! A collection of APIs for Javy.
 //!
-//! This crate provides JS APIs you can add to Javy.
+//! APIs are enabled through cargo features.
 //!
 //! Example usage:
 //! ```
@@ -30,17 +30,18 @@
 //! for the underlying [`Runtime`] or an [`APIConfig`] for the APIs.
 //!
 //! ## Features
-//! * `console` - Registers an implementation of the `console` API.
-//! * `text_encoding` - Registers implementations of `TextEncoder` and `TextDecoder`.
-//! * `random` - Overrides the implementation of `Math.random` to one that
-//!   seeds the RNG on first call to `Math.random`. This is helpful to enable
-//!   when using Wizer to snapshot a [`javy::Runtime`] so that the output of
-//!   `Math.random` relies on the WASI context used at runtime and not the
-//!   WASI context used when Wizening. Enabling this feature will increase the
-//!   size of the Wasm module that includes the Javy Runtime and will
-//!   introduce an additional hostcall invocation when `Math.random` is
-//!   invoked for the first time.
-//! * `stream_io` - Registers implementations of `Javy.IO.readSync` and `Javy.IO.writeSync`.
+//! * `console`:  Adds an implementation of the `console.log` and `console.error`,
+//! enabling the configuration of the standard streams.
+//! * `text_encoding`:  Registers implementations of `TextEncoder` and `TextDecoder`.
+//! * `random`: Overrides the implementation of `Math.random` to one that seeds
+//! the RNG on first call to `Math.random`. This is helpful to enable when using
+//! using a tool like Wizer to snapshot a [`Runtime`] so that the output of
+//! `Math.random` relies on the WASI context used at runtime and not the WASI
+//! context used when Wizening. Enabling this feature will increase the size of
+//! the Wasm module that includes the Javy Runtime and will introduce an
+//! additional hostcall invocation when `Math.random` is invoked for the first
+//! time.
+//! * `stream_io`: Adds the implementation of `Javy.IO.readSync` and `Javy.IO.writeSync`.
 
 use anyhow::Result;
 use javy::Runtime;

--- a/crates/javy/README.md
+++ b/crates/javy/README.md
@@ -1,11 +1,21 @@
-# javy
+<div align="center">
+  <h1><code>Javy</code></h1>
+  <p>
+    <strong>A configurable JavaScript runtime for WebAssembly</strong>
+  </p>
+  <p>
+    <a href="https://docs.rs/javy"><img src="https://docs.rs/javy/badge.svg" alt="Documentation Status" /></a>
+    <a href="https://crates.io/crates/javy"><img src="https://img.shields.io/crates/v/javy.svg" alt="crates.io status" /></a>
+  </p>
+</div>
 
-A configurable JavaScript runtime for WebAssembly.
 
 Uses QuickJS through the [`rquickjs`](https://docs.rs/rquickjs/latest/rquickjs/)
 crate to evalulate JavaScript source code or QuickJS bytecode.
 
-## Example usage
+Refer to the [crate level documentation](https://docs.rs/javy) to learn more.
+
+Example usage:
 
 ```rust
 use anyhow::anyhow;
@@ -32,14 +42,6 @@ context.with(|cx| {
          .map(|_| ())
 });
 ```
-
-Create a `Runtime` and use the reference returned by `context()` to add functions and evaluate source code.
-
-## Features
-
-- `export_alloc_fns` - exports `canonical_abi_realloc` and `canonical_abi_free` from generated WebAssembly for allocating and freeing memory
-- `json` - transcoding functions for converting between `JSValueRef` and JSON
-- `messagepack` - transcoding functions for converting between `JSValueRef` and MessagePack
 
 ## Publishing to crates.io
 


### PR DESCRIPTION
## Description of the change

In preparation to adding more APIs I decided to do a very light cleanup of some of the documentation in this crate. I opted to remove the documentation in the README to reduce the overhead of having to maintain the same documentation in multiple places.

## Why am I making this change?

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
