### PR TITLE
Deprecate bindings crates

### DIFF
--- a/crates/quickjs-wasm-rs/CHANGELOG.md
+++ b/crates/quickjs-wasm-rs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Mark crate as deprecated
 - Add a new `expose-sys` feature that exposes unstable escape hatch functions to the underlying `quickjs_wasm_sys` crate.
 
 ## [3.0.0] - 2024-01-31

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -22,3 +22,6 @@ serde_bytes = "0.11.14"
 [features]
 # Re-exports the quickjs-wasm-sys module and exposes additional, unstable APIs.
 export-sys = []
+
+[badges]
+maintenance = { status = "deprecated" }

--- a/crates/quickjs-wasm-rs/README.md
+++ b/crates/quickjs-wasm-rs/README.md
@@ -1,3 +1,12 @@
+# This crate is deprecated.
+[![crates.io](https://img.shields.io/crates/v/quickjs-wasm-rs.svg)](https://crates.io/crates/quickjs-wasm-rs)
+
+The motivation for this change is explained in detail in 
+https://github.com/bytecodealliance/javy/pull/618 
+
+We recommend using [`rquickjs`](https://github.com/DelSkayn/rquickjs) as the
+high-level bindings for QuickJS.
+
 # quickjs-wasm-rs
 
 High-level bindings and serializers for a Wasm build of QuickJS.

--- a/crates/quickjs-wasm-sys/CHANGELOG.md
+++ b/crates/quickjs-wasm-sys/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased changes
 
+- Mark crate as deprecated.
 - Expose `JS_DupValue` via `JS_DupValueExt`.
 
 ## [1.2.0] - 2024-01-31

--- a/crates/quickjs-wasm-sys/Cargo.toml
+++ b/crates/quickjs-wasm-sys/Cargo.toml
@@ -19,3 +19,6 @@ http-body-util = "0.1.1"
 hyper = "1.3"
 hyper-tls = "0.6.0"
 hyper-util = { version = "0.1.3", features = ["http1"] }
+
+[badges]
+maintenance = { status = "deprecated" }

--- a/crates/quickjs-wasm-sys/README.md
+++ b/crates/quickjs-wasm-sys/README.md
@@ -1,4 +1,15 @@
+# This crate is deprecated.
+[![crates.io](https://img.shields.io/crates/v/quickjs-wasm-sys.svg)](https://crates.io/crates/quickjs-wasm-sys)
+
+The motivation for this change is explained in detail in 
+https://github.com/bytecodealliance/javy/pull/618 
+
+We recommend using [`rquickjs`](https://github.com/DelSkayn/rquickjs) as the
+high-level bindings for QuickJS.
+
 # quickjs-wasm-sys: Wasm QuickJS bindings for Rust
+
+High-level bindings and serializers for a Wasm build of QuickJS.
 
 FFI bindings for a Wasm build of the QuickJS Javascript engine.
 


### PR DESCRIPTION
## Description of the change

This commit is a follow-up to https://github.com/bytecodealliance/javy/pull/618, to formally mark `quckjs-wasm-{sys, rs}` crates as deprecated.

The rollout strategy is to:

* Merge this PR
* Publish the a new version of each of the crates, containing the last unreleased change in each and the deprecation notice.


## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
