### PR TITLE
Add relese versions of deprecated crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-rs"
-version = "3.1.0-alpha.1"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-wasm-sys"
-version = "1.2.1-alpha.1"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "bindgen",

--- a/crates/quickjs-wasm-rs/CHANGELOG.md
+++ b/crates/quickjs-wasm-rs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.0]
+## [3.1.0] - 2024-05-07
 
 - Mark crate as deprecated
 - Add a new `expose-sys` feature that exposes unstable escape hatch functions to the underlying `quickjs_wasm_sys` crate.

--- a/crates/quickjs-wasm-rs/CHANGELOG.md
+++ b/crates/quickjs-wasm-rs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [3.1.0]
 
 - Mark crate as deprecated
 - Add a new `expose-sys` feature that exposes unstable escape hatch functions to the underlying `quickjs_wasm_sys` crate.

--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-rs"
-version = "3.1.0-alpha.1"
+version = "3.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/quickjs-wasm-sys/CHANGELOG.md
+++ b/crates/quickjs-wasm-sys/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased changes
+## [1.2.1] 
 
 - Mark crate as deprecated.
 - Expose `JS_DupValue` via `JS_DupValueExt`.

--- a/crates/quickjs-wasm-sys/CHANGELOG.md
+++ b/crates/quickjs-wasm-sys/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.1] 
+## [1.2.1] - 2024-05-07
 
 - Mark crate as deprecated.
 - Expose `JS_DupValue` via `JS_DupValueExt`.

--- a/crates/quickjs-wasm-sys/Cargo.toml
+++ b/crates/quickjs-wasm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-wasm-sys"
-version = "1.2.1-alpha.1"
+version = "1.2.1"
 authors.workspace = true
 edition.workspace = true 
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Follow up to https://github.com/bytecodealliance/javy/pull/641; this commit introduces the final versions for publishing the deprecated crates

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
