### PR TITLE
Fix version refernce

### DIFF
--- a/crates/quickjs-wasm-rs/Cargo.toml
+++ b/crates/quickjs-wasm-rs/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 anyhow = { workspace = true }
-quickjs-wasm-sys = { version = "1.2.1-alpha.1", path = "../quickjs-wasm-sys" }
+quickjs-wasm-sys = { version = "1.2.1", path = "../quickjs-wasm-sys" }
 serde = { version = "1.0", features = ["derive"] }
 once_cell = "1.19"
 


### PR DESCRIPTION
This commit fixes the version reference to `quickjs-wasm-sys`

