### PR TITLE
Leverage QuickJS's `JS_ToString` in logging

### DIFF
--- a/crates/apis/src/console/mod.rs
+++ b/crates/apis/src/console/mod.rs
@@ -114,7 +114,7 @@ mod tests {
     }
 
     #[test]
-    fn test_console_log() -> Result<()> {
+    fn test_value_serialization() -> Result<()> {
         let mut stream = SharedStream::default();
 
         let runtime = Runtime::default();
@@ -122,19 +122,50 @@ mod tests {
         register_console(ctx, stream.clone(), stream.clone())?;
 
         ctx.with(|this| {
-            this.eval("console.log(\"hello world\");")?;
-            assert_eq!(b"hello world\n", stream.buffer.borrow().as_slice());
-            stream.clear();
+            macro_rules! test_console_log {
+                ($js:expr, $expected:expr) => {{
+                    this.eval($js)?;
+                    assert_eq!(
+                        $expected,
+                        std::str::from_utf8(stream.buffer.borrow().as_slice()).unwrap()
+                    );
+                    stream.clear();
+                }};
+            }
 
-            this.eval("console.log(\"bonjour\", \"le\", \"monde\")")?;
-            assert_eq!(b"bonjour le monde\n", stream.buffer.borrow().as_slice());
+            test_console_log!("console.log(\"hello world\");", "hello world\n");
 
-            stream.clear();
+            test_console_log!(
+                "console.log(function(){ return 1 })",
+                "function(){ return 1 }\n"
+            );
 
-            this.eval("console.log(2.3, true, { foo: 'bar' }, null, undefined)")?;
-            assert_eq!(
-                b"2.3 true [object Object] null undefined\n",
-                stream.buffer.borrow().as_slice()
+            test_console_log!(
+                "console.log([1, \"two\", 3.42, null, 5])",
+                "1,two,3.42,,5\n"
+            );
+
+            test_console_log!(
+                "console.log(2.3, true, { foo: 'bar' }, null, undefined)",
+                "2.3 true [object Object] null undefined\n"
+            );
+
+            test_console_log!(
+                "console.log(new Date(0))",
+                "Thu Jan 01 1970 00:00:00 GMT+0000\n"
+            );
+
+            test_console_log!("console.log(new ArrayBuffer())", "[object ArrayBuffer]\n");
+
+            test_console_log!("console.log(NaN)", "NaN\n");
+
+            test_console_log!("console.log(new Set())", "[object Set]\n");
+
+            test_console_log!("console.log(new Map())", "[object Map]\n");
+
+            test_console_log!(
+                "function Foo(){}; console.log(new Foo())",
+                "[object Object]\n"
             );
 
             Ok::<_, Error>(())
@@ -144,29 +175,25 @@ mod tests {
     }
 
     #[test]
-    fn test_console_error() -> Result<()> {
-        let mut stream = SharedStream::default();
+    fn test_console_streams() -> Result<()> {
+        let mut log_stream = SharedStream::default();
+        let error_stream = SharedStream::default();
 
         let runtime = Runtime::default();
         let ctx = runtime.context();
-        register_console(ctx, stream.clone(), stream.clone())?;
+        register_console(ctx, log_stream.clone(), error_stream.clone())?;
 
         ctx.with(|this| {
+            this.eval("console.log(\"hello world\");")?;
+            assert_eq!(b"hello world\n", log_stream.buffer.borrow().as_slice());
+            assert!(error_stream.buffer.borrow().is_empty());
+
+            log_stream.clear();
+
             this.eval("console.error(\"hello world\");")?;
-            assert_eq!(b"hello world\n", stream.buffer.borrow().as_slice());
+            assert_eq!(b"hello world\n", error_stream.buffer.borrow().as_slice());
+            assert!(log_stream.buffer.borrow().is_empty());
 
-            stream.clear();
-
-            this.eval("console.error(\"bonjour\", \"le\", \"monde\")")?;
-            assert_eq!(b"bonjour le monde\n", stream.buffer.borrow().as_slice());
-
-            stream.clear();
-
-            this.eval("console.error(2.3, true, { foo: 'bar' }, null, undefined)")?;
-            assert_eq!(
-                b"2.3 true [object Object] null undefined\n",
-                stream.buffer.borrow().as_slice()
-            );
             Ok::<_, Error>(())
         })?;
 

--- a/crates/apis/src/console/mod.rs
+++ b/crates/apis/src/console/mod.rs
@@ -2,8 +2,8 @@ use std::io::Write;
 
 use anyhow::{Error, Result};
 use javy::{
-    hold, hold_and_release, print,
-    quickjs::{prelude::MutFn, Context, Function, Object, Value},
+    hold, hold_and_release,
+    quickjs::{convert, prelude::MutFn, Context, FromJs, Function, Object, Value},
     to_js_error, Args, Runtime,
 };
 
@@ -71,15 +71,14 @@ where
 
 fn log<'js, T: Write>(args: Args<'js>, stream: &mut T) -> Result<Value<'js>> {
     let (ctx, args) = args.release();
-    let mut buf = String::new();
     for (i, arg) in args.iter().enumerate() {
+        let stringified = <convert::Coerced<String>>::from_js(&ctx, arg.clone())?.0;
         if i != 0 {
-            buf.push(' ');
+            write!(stream, " ")?;
         }
-        print(arg, &mut buf)?;
+        write!(stream, "{stringified}")?;
     }
-
-    writeln!(stream, "{buf}")?;
+    writeln!(stream)?;
 
     Ok(Value::new_undefined(ctx.clone()))
 }

--- a/crates/javy/src/lib.rs
+++ b/crates/javy/src/lib.rs
@@ -50,53 +50,14 @@ mod config;
 mod runtime;
 mod serde;
 
-use anyhow::{anyhow, Error, Result};
-use rquickjs::{
-    prelude::Rest, qjs, Ctx, Error as JSError, Exception, String as JSString, Type, Value,
-};
-use std::fmt::Write;
+use anyhow::{anyhow, Error};
+use rquickjs::{prelude::Rest, qjs, Ctx, Error as JSError, Exception, String as JSString, Value};
 
 #[cfg(feature = "messagepack")]
 pub mod messagepack;
 
 #[cfg(feature = "json")]
 pub mod json;
-
-/// Print the given JS value.
-///
-/// The implementation matches the default JavaScript display format for each value.
-pub fn print(val: &Value, sink: &mut String) -> Result<()> {
-    match val.type_of() {
-        Type::Undefined => write!(sink, "undefined").map_err(Into::into),
-        Type::Null => write!(sink, "null").map_err(Into::into),
-        Type::Bool => {
-            let b = val.as_bool().unwrap();
-            write!(sink, "{}", b).map_err(Into::into)
-        }
-        Type::Int => {
-            let i = val.as_int().unwrap();
-            write!(sink, "{}", i).map_err(Into::into)
-        }
-        Type::Float => {
-            let f = val.as_float().unwrap();
-            write!(sink, "{}", f).map_err(Into::into)
-        }
-        Type::String => {
-            let s = val.as_string().unwrap();
-            write!(sink, "{}", s.to_string()?).map_err(Into::into)
-        }
-        Type::Array => {
-            let inner = val.as_array().unwrap();
-            for e in inner.iter() {
-                print(&e?, sink)?
-            }
-            Ok(())
-        }
-        Type::Object => write!(sink, "[object Object]").map_err(Into::into),
-        // TODO: Implement the rest.
-        x => unimplemented!("{x}"),
-    }
-}
 
 /// A struct to hold the current [`Ctx`] and [`Value`]s passed as arguments to Rust
 /// functions.


### PR DESCRIPTION
## The problem

Javy crashes when `console.log`ing certain JavaScript values. 

## Description of the change

Use QuickJS's `JS_ToString` implementation for `console.{log,error}` instead of rolling our own; reverting to what Javy 2.x did. 


This change also adds new serialization test cases to capture the current behaviour. Symbols are excluded because they crashed on Javy 2.x and throw an exception with this branch (from this [QuickJS line](https://github.com/bellard/quickjs/blob/01454caf78bcc928dfab1ca62a551fe92ada4d4c/quickjs.c#L11724)). See [this repro script and outputs](https://gist.github.com/jbourassa/ede119af314be619390636f08f2b337b).

## Tradeoffs

I suspect this is slower because we'll allocate Strings for any values. At the same time, we get to leverage QuickJS' implementation just like we did prior to the introduction of the rquickjs bindings.

The alternative is to re-implement printing each types, thus choosing a string representation for each type. If we want to go that route, we have to choose wether we want to follow what other engines do (more work, slower), or stick with Javy's current minimal approach.

## Checklist

- ~[ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.~
- ~[ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)~
- ~[ ] I've updated documentation including crate documentation if necessary.~
