### PR TITLE
Prepare release 3.0.0 of crates/apis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "javy-apis"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 
 [[package]]
 name = "javy-cli"

--- a/crates/apis/CHANGELOG.md
+++ b/crates/apis/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.0.0] - 2024-05-14
 
 ### Changed
 

--- a/crates/apis/Cargo.toml
+++ b/crates/apis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-apis"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

This is the version that marks the crate as deprecated.



