### PR TITLE
Improve json support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+# Explicit directive for simd-json
+# Cargo doesn't read directives in individual crates when invoking build
+# commands from the workspace root, hence adding it at the workspace root.
+# https://doc.rust-lang.org/cargo/reference/config.html
+[target.wasm32-wasi]
+rustflags = ["-C", "target-feature=+simd128"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "ambient-authority"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,7 +132,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -137,7 +143,7 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -224,7 +230,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.58",
+ "syn 2.0.66",
  "which",
 ]
 
@@ -791,7 +797,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -808,7 +814,7 @@ checksum = "ad08a837629ad949b73d032c637653d069e909cffe4ee7870b02301939ce39cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -949,6 +955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,7 +1001,7 @@ checksum = "fdc9cc75639b041067353b9bce2450d6847e547276c6fbe4487d7407980e07db"
 dependencies = [
  "proc-macro2",
  "swc_macros_common",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1106,8 +1121,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1149,6 +1166,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "halfbrown"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
+dependencies = [
+ "hashbrown 0.14.3",
+ "serde",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -1423,7 +1451,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1494,6 +1522,7 @@ dependencies = [
  "serde",
  "serde-transcode",
  "serde_json",
+ "simd-json",
 ]
 
 [[package]]
@@ -1571,6 +1600,70 @@ name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
+name = "lexical-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -1815,7 +1908,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1884,7 +1977,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1913,7 +2006,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1975,7 +2068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2014,9 +2107,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -2145,6 +2238,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,7 +2359,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rquickjs-core",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2418,7 +2531,7 @@ checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2475,6 +2588,28 @@ checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
 dependencies = [
  "outref",
 ]
+
+[[package]]
+name = "simd-json"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "570c430b3d902ea083097e853263ae782dfe40857d93db019a12356c8e8143fa"
+dependencies = [
+ "getrandom",
+ "halfbrown",
+ "lexical-core",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "siphasher"
@@ -2574,7 +2709,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2780,7 +2915,7 @@ checksum = "695a1d8b461033d32429b5befbf0ad4d7a2c4d6ba9cd5ba4e0645c615839e8e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2791,7 +2926,7 @@ checksum = "91745f3561057493d2da768437c427c0e979dff7396507ae02f16c981c4a8466"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2814,7 +2949,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2830,9 +2965,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2914,7 +3049,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2967,7 +3102,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3073,7 +3208,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3182,6 +3317,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "value-trait"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad8db98c1e677797df21ba03fca7d3bf9bec3ca38db930954e4fe6e1ea27eb4"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
 ]
 
 [[package]]
@@ -3314,7 +3461,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -3336,7 +3483,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3559,7 +3706,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser 0.201.0",
@@ -3733,7 +3880,7 @@ checksum = "ffaafa5c12355b1a9ee068e9295d50c4ca0a400c721950cdae4f5b54391a2da5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3881,7 +4028,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "shellexpand",
- "syn 2.0.58",
+ "syn 2.0.66",
  "witx",
 ]
 
@@ -3893,7 +4040,7 @@ checksum = "acdb12de36507498abaa3a042f895a43ee00a2f6125b6901b9a27edf72bfdbe7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
  "wiggle-generate",
 ]
 
@@ -4203,7 +4350,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = { workspace = true }
-javy = { workspace = true, features = ["export_alloc_fns"] }
+javy = { workspace = true, features = ["export_alloc_fns", "json"] }
 once_cell = { workspace = true }
 
 [features]

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -6,7 +6,8 @@ pub(crate) fn new_runtime() -> Result<Runtime> {
     let config = config
         .text_encoding(true)
         .redirect_stdout_to_stderr(true)
-        .javy_stream_io(true);
+        .javy_stream_io(true)
+        .javy_json(true);
 
     Runtime::new(std::mem::take(config))
 }

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -12,7 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce `rquickjs` to interface with QuickJS instead of `quickjs-wasm-rs`;
   this version no longer includes re-exports from `quickjs-wasm-rs`.
 - `javy::serde::de::Deserializer` should now match `JSON.stringify`: non-JSON
-  primitives are skipped in Objects and nullified in Arrays.
+  primitives are skipped in Objects and nullified in Arrays. 
+- Introduce a faster implemementation for `JSON.parse` and `JSON.stringify`
+  based on `simd-json`, `serde-json` and `serde-transcode`. Also introduce the
+  `Javy.JSON` temporary helper namespace which contains helpers for working with
+  JSON.
 
 ## [2.2.0] - 2024-01-31
 

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
@@ -32,9 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `alloc` module containing implementations of a realloc function and a free function.
-- An `export_alloc_fns` crate feature which when enabled, will export `canonical_abi_realloc` and `canonical_abi_free`
-  functions from your Wasm module.
+- `alloc` module containing implementations of a realloc function and a free
+  function.
+- An `export_alloc_fns` crate feature which when enabled, will export
+  `canonical_abi_realloc` and `canonical_abi_free` functions from your Wasm
+  module.
 
 ### Fixed
 
@@ -45,7 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update of `quickjs` types to use types in `quickjs-wasm-rs` 2.0.0.
-- WASI SDK will be automatically downloaded at build time if `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable is not set.
+- WASI SDK will be automatically downloaded at build time if
+  `QUICKJS_WASM_SYS_WASI_SDK_PATH` environment variable is not set.
 
 ## [1.0.0] - 2023-05-16
 

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -21,8 +21,16 @@ rmp-serde = { version = "^1.3", optional = true }
 quickcheck = "1"
 bitflags = "2.5.0"
 fastrand = "2.1.0"
+simd-json = { version = "0.13.10", optional = true, default-features = false, features = ["big-int-as-float", "serde_impl"] }
 
 [features]
 export_alloc_fns = []
 messagepack = ["rmp-serde", "serde-transcode"]
-json = ["serde_json", "serde-transcode"]
+# According to our benchmarks and experiments, the fastest and most efficient
+# JSON implementation comes from:
+# * Using SIMD JSON for parsing
+# * Using serde_json for stringifying
+# This implementation is behind a feature flag, because of the code size
+# implications of enabling by default (due to the extra dependencies) and also
+# because the native implementation is probably fine for most use-cases.
+json = ["serde_json", "serde-transcode", "simd-json"]

--- a/crates/javy/src/apis/json.rs
+++ b/crates/javy/src/apis/json.rs
@@ -1,0 +1,187 @@
+//! High-performance JSON implementation for  Javy.
+//!
+//! The provided implementation is based on
+//! [simd-json](https://crates.io/crates/simd-json)
+//!
+//! The most efficient combination according to our experiments, is to use:
+//! * SIMD JSON for `JSON.parse`
+//! * Serde JSON for `JSON.stringify`
+//!
+//! It's also important to note that this implementation optimizes for the hot
+//! path:
+//! - If `JSON.parse` is invoked with the reviver argument, the native QuickJS
+//!   `JSON.parse` is invoked instead.
+//! - If `JSON.stringify` is invoked with the replacer and/or space arguments, the
+//!   native QuickJS `JSON.stringify` is invoked instead.
+//!
+//! The reason behind this decision is simple: most use-cases will hit the
+//! hotpath and doing any sort of inline processing of the parsed or stringified
+//! values is likely to void any performance benefits.
+use crate::{
+    hold, hold_and_release, json,
+    quickjs::{
+        context::Intrinsic,
+        prelude::{MutFn, Rest},
+        qjs, Ctx, Function, Object, String as JSString, Value,
+    },
+    to_js_error, val_to_string, Args,
+};
+
+use anyhow::{anyhow, Result};
+use std::{
+    io::{Read, Write},
+    ptr::NonNull,
+};
+
+/// Intrinsic to attach faster JSON.{parse/stringify} functions.
+pub struct Json;
+
+/// Intrinsic to attach functions under the `Javy.JSON` namespace.
+pub struct JavyJson;
+
+impl Intrinsic for JavyJson {
+    unsafe fn add_intrinsic(ctx: NonNull<qjs::JSContext>) {
+        register_javy_json(Ctx::from_raw(ctx)).expect("registering Javy.JSON builtins to succeed")
+    }
+}
+
+impl Intrinsic for Json {
+    unsafe fn add_intrinsic(ctx: NonNull<qjs::JSContext>) {
+        register(Ctx::from_raw(ctx)).expect("registering JSON builtins to succeed")
+    }
+}
+
+fn register<'js>(this: Ctx<'js>) -> Result<()> {
+    let parse = Function::new(
+        this.clone(),
+        MutFn::new(move |cx: Ctx<'js>, args: Rest<Value<'js>>| {
+            call_json_parse(hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
+        }),
+    )?;
+
+    let stringify = Function::new(
+        this.clone(),
+        MutFn::new(move |cx: Ctx<'js>, args: Rest<Value<'js>>| {
+            call_json_stringify(hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
+        }),
+    )?;
+
+    let global = this.globals();
+    let json: Object = global.get("JSON")?;
+    json.set("parse", parse)?;
+    json.set("stringify", stringify)?;
+
+    Ok(())
+}
+
+fn call_json_parse<'js>(args: Args<'js>) -> Result<Value> {
+    let (this, args) = args.release();
+
+    match args.len() {
+        0 => Err(anyhow!("Error: \"undefined\" is not valid JSON")),
+        1 => {
+            let val = args[0].clone();
+            // Fast path. Number and null are treated as identity.
+            if val.is_number() || val.is_null() {
+                return Ok(val);
+            }
+
+            let mut string = val_to_string(this.clone(), args[0].clone())?;
+            let mut bytes = unsafe { string.as_bytes_mut() };
+            json::parse(this, &mut bytes)
+        }
+        _ => {
+            // If there's more than one argument, defer to the built-in
+            // JSON.parse, which will take care of validating and invoking the
+            // reviver argument.
+            //
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#reviver.
+            let global = this.globals();
+            let json: Object = global.get("JSON")?;
+            let parse: Function = json.get("parse")?;
+
+            parse
+                .call((args[0].clone(), args[1].clone()))
+                .map_err(|e| anyhow!("{e}"))
+        }
+    }
+}
+
+fn call_json_stringify<'js>(args: Args<'js>) -> Result<Value> {
+    let (this, args) = args.release();
+
+    match args.len() {
+        0 => Ok(Value::new_undefined(this.clone())),
+        1 => {
+            let bytes = json::stringify(args[0].clone())?;
+            let str = String::from_utf8(bytes)?;
+            let str = JSString::from_str(this, &str)?;
+            Ok(str.into_value())
+        }
+        _ => {
+            // Similar to the parse case, if there's more than one argument,
+            // defer to the built-in JSON.stringify, which will take care of
+            // validating invoking the replacer function and/or applying the
+            // space argument.
+            let global = this.globals();
+            let json: Object = global.get("JSON")?;
+            let stringify: Function = json.get("stringify")?;
+
+            if args.len() == 2 {
+                stringify
+                    .call((args[0].clone(), args[1].clone()))
+                    .map_err(|e| anyhow!("{e}"))
+            } else {
+                stringify
+                    .call((args[0].clone(), args[1].clone(), args[2].clone()))
+                    .map_err(|e| anyhow!("{e}"))
+            }
+        }
+    }
+}
+
+fn register_javy_json<'js>(this: Ctx<'js>) -> Result<()> {
+    let globals = this.globals();
+    let javy = if globals.get::<_, Object>("Javy").is_err() {
+        Object::new(this.clone())?
+    } else {
+        globals.get::<_, Object>("Javy").unwrap()
+    };
+
+    let from_stdin = Function::new(this.clone(), |cx, args| {
+        let (cx, args) = hold_and_release!(cx, args);
+        from_stdin(hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
+    });
+
+    let to_stdout = Function::new(this.clone(), |cx, args| {
+        let (cx, args) = hold_and_release!(cx, args);
+        to_stdout(hold!(cx.clone(), args)).map_err(|e| to_js_error(cx, e))
+    });
+
+    let json = Object::new(this)?;
+    json.set("fromStdin", from_stdin)?;
+    json.set("toStdout", to_stdout)?;
+
+    javy.set("JSON", json)?;
+    globals.set("Javy", javy).map_err(Into::into)
+}
+
+/// Definition for Javy.JSON.fromStdin
+fn from_stdin<'js>(args: Args<'js>) -> Result<Value<'js>> {
+    // Light experimentation shows that 1k bytes is enough to avoid paying the
+    // high relocation costs. We can modify as we see fit or even make this
+    // configurable if needed.
+    let mut buffer = Vec::with_capacity(1000);
+    let mut fd = std::io::stdin();
+    fd.read_to_end(&mut buffer)?;
+    let (ctx, _) = args.release();
+    json::parse(ctx, &mut buffer)
+}
+
+/// Definition for Javy.JSON.toStdout
+fn to_stdout<'js>(args: Args<'js>) -> Result<()> {
+    let (_, args) = args.release();
+    let mut fd = std::io::stdout();
+    let buffer = json::stringify(args[0].clone())?;
+    fd.write_all(&buffer).map_err(Into::into)
+}

--- a/crates/javy/src/apis/json.rs
+++ b/crates/javy/src/apis/json.rs
@@ -74,7 +74,7 @@ fn register<'js>(this: Ctx<'js>) -> Result<()> {
     Ok(())
 }
 
-fn call_json_parse<'js>(args: Args<'js>) -> Result<Value> {
+fn call_json_parse(args: Args<'_>) -> Result<Value> {
     let (this, args) = args.release();
 
     match args.len() {
@@ -87,8 +87,8 @@ fn call_json_parse<'js>(args: Args<'js>) -> Result<Value> {
             }
 
             let mut string = val_to_string(this.clone(), args[0].clone())?;
-            let mut bytes = unsafe { string.as_bytes_mut() };
-            json::parse(this, &mut bytes)
+            let bytes = unsafe { string.as_bytes_mut() };
+            json::parse(this, bytes)
         }
         _ => {
             // If there's more than one argument, defer to the built-in
@@ -107,7 +107,7 @@ fn call_json_parse<'js>(args: Args<'js>) -> Result<Value> {
     }
 }
 
-fn call_json_stringify<'js>(args: Args<'js>) -> Result<Value> {
+fn call_json_stringify(args: Args<'_>) -> Result<Value> {
     let (this, args) = args.release();
 
     match args.len() {
@@ -140,7 +140,7 @@ fn call_json_stringify<'js>(args: Args<'js>) -> Result<Value> {
     }
 }
 
-fn register_javy_json<'js>(this: Ctx<'js>) -> Result<()> {
+fn register_javy_json(this: Ctx<'_>) -> Result<()> {
     let globals = this.globals();
     let javy = if globals.get::<_, Object>("Javy").is_err() {
         Object::new(this.clone())?
@@ -167,7 +167,7 @@ fn register_javy_json<'js>(this: Ctx<'js>) -> Result<()> {
 }
 
 /// Definition for Javy.JSON.fromStdin
-fn from_stdin<'js>(args: Args<'js>) -> Result<Value<'js>> {
+fn from_stdin(args: Args<'_>) -> Result<Value> {
     // Light experimentation shows that 1k bytes is enough to avoid paying the
     // high relocation costs. We can modify as we see fit or even make this
     // configurable if needed.
@@ -179,7 +179,7 @@ fn from_stdin<'js>(args: Args<'js>) -> Result<Value<'js>> {
 }
 
 /// Definition for Javy.JSON.toStdout
-fn to_stdout<'js>(args: Args<'js>) -> Result<()> {
+fn to_stdout(args: Args<'_>) -> Result<()> {
     let (_, args) = args.release();
     let mut fd = std::io::stdout();
     let buffer = json::stringify(args[0].clone())?;

--- a/crates/javy/src/apis/mod.rs
+++ b/crates/javy/src/apis/mod.rs
@@ -36,7 +36,7 @@
 //! ### `TextEncoding`
 //!
 //! Provides partial implementations of `TextEncoder` and `TextDecoder`.
-//! Disables by default.
+//! Disabled by default.
 //!
 //! ### `Random`
 //!
@@ -50,13 +50,22 @@
 //!
 //! Provides an implementation of `Javy.IO.readSync` and `Javy.IO.writeSync`.
 //! Disabled by default.
-
+//!
+//! ###  `JSON`
+//! Provides an efficient implementation of JSON functions based on [`simd-json`](https://crates.io/crates/simd-json/0.13.10)
+//! and [`serde_json`](https://crates.io/crates/serde_json)
+//!
+//! Disabled by default.
 pub(crate) mod console;
+#[cfg(feature = "json")]
+pub(crate) mod json;
 pub(crate) mod random;
 pub(crate) mod stream_io;
 pub(crate) mod text_encoding;
 
 pub(crate) use console::*;
+#[cfg(feature = "json")]
+pub(crate) use json::*;
 pub(crate) use random::*;
 pub(crate) use stream_io::*;
 pub(crate) use text_encoding::*;

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -208,6 +208,7 @@ impl Config {
 }
 
 #[cfg(test)]
+#[cfg(feature = "json")]
 mod tests {
     use super::Config;
 

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -53,7 +53,7 @@ pub struct Config {
     /// Whether to use a custom console implementation provided by Javy,
     /// that redirects stdout to stderr.
     pub(crate) redirect_stdout_to_stderr: bool,
-    /// Whether to override the implemenation of JSON.parse and JSON.stringify
+    /// Whether to override the implementation of JSON.parse and JSON.stringify
     /// with a Rust implementation that uses a combination for Serde transcoding
     /// serde_json and simd_json.
     /// This setting requires the `JSON` intrinsic to be enabled, and the `json`

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -186,7 +186,7 @@ impl Config {
         self
     }
 
-    /// Whether to override the implemenation of JSON.parse and JSON.stringify
+    /// Whether to override the implementation of JSON.parse and JSON.stringify
     /// with a Rust implementation that uses a combination of Serde transcoding
     /// serde_json and simd_json for improved performance.
     /// This setting requires the `JSON` intrinsic to be enabled and the `json`

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -1,3 +1,4 @@
+use anyhow::{bail, Result};
 use bitflags::bitflags;
 
 bitflags! {
@@ -36,6 +37,7 @@ bitflags! {
     /// moved out.
     pub(crate) struct JavyIntrinsics: u32 {
         const STREAM_IO = 1;
+        const JSON = 1 << 1;
     }
 }
 
@@ -51,6 +53,12 @@ pub struct Config {
     /// Whether to use a custom console implementation provided by Javy,
     /// that redirects stdout to stderr.
     pub(crate) redirect_stdout_to_stderr: bool,
+    /// Whether to override the implemenation of JSON.parse and JSON.stringify
+    /// with a Rust implementation that uses a combination for Serde transcoding
+    /// serde_json and simd_json.
+    /// This setting requires the `JSON` intrinsic to be enabled, and the `json`
+    /// crate feature to be enabled as well.
+    pub(crate) override_json_parse_and_stringify: bool,
 }
 
 impl Default for Config {
@@ -62,6 +70,7 @@ impl Default for Config {
             intrinsics,
             javy_intrinsics: JavyIntrinsics::empty(),
             redirect_stdout_to_stderr: false,
+            override_json_parse_and_stringify: false,
         }
     }
 }
@@ -161,10 +170,61 @@ impl Config {
         self
     }
 
+    /// Whether the `Javy.JSON` intrinsic will be available.
+    /// Disabled by default.
+    /// This setting requires the `json` crate feature to be enabled.
+    #[cfg(feature = "json")]
+    pub fn javy_json(&mut self, enable: bool) -> &mut Self {
+        self.javy_intrinsics.set(JavyIntrinsics::JSON, enable);
+        self
+    }
+
     /// Enables whether the output of console.log will be redirected to
     /// `stderr`.
     pub fn redirect_stdout_to_stderr(&mut self, enable: bool) -> &mut Self {
         self.redirect_stdout_to_stderr = enable;
         self
+    }
+
+    /// Whether to override the implemenation of JSON.parse and JSON.stringify
+    /// with a Rust implementation that uses a combination of Serde transcoding
+    /// serde_json and simd_json for improved performance.
+    /// This setting requires the `JSON` intrinsic to be enabled and the `json`
+    /// crate feature to be enabled as well.
+    /// Disabled by default.
+    #[cfg(feature = "json")]
+    pub fn override_json_parse_and_stringify(&mut self, enable: bool) -> &mut Self {
+        self.override_json_parse_and_stringify = enable;
+        self
+    }
+
+    pub(crate) fn validate(self) -> Result<Self> {
+        if self.override_json_parse_and_stringify && !self.intrinsics.contains(JSIntrinsics::JSON) {
+            bail!("JSON Intrinsic is required to override JSON.parse and JSON.stringify");
+        }
+
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+
+    #[test]
+    fn err_config_validation() {
+        let mut config = Config::default();
+        config.override_json_parse_and_stringify(true);
+        config.json(false);
+
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn ok_config_validation() {
+        let mut config = Config::default();
+        config.override_json_parse_and_stringify(true);
+
+        assert!(config.validate().is_ok());
     }
 }

--- a/crates/javy/src/json.rs
+++ b/crates/javy/src/json.rs
@@ -3,16 +3,16 @@ use crate::serde::{de::Deserializer, ser::Serializer};
 use anyhow::Result;
 
 /// Transcodes a byte slice containing a JSON encoded payload into a [Value].
-pub fn transcode_input<'js>(context: Ctx<'js>, bytes: &[u8]) -> Result<Value<'js>> {
-    let mut deserializer = serde_json::Deserializer::from_slice(bytes);
+pub fn parse<'js>(context: Ctx<'js>, bytes: &mut [u8]) -> Result<Value<'js>> {
+    let mut deserializer = simd_json::Deserializer::from_slice(bytes)?;
     let mut serializer = Serializer::from_context(context)?;
     serde_transcode::transcode(&mut deserializer, &mut serializer)?;
     Ok(serializer.value)
 }
 
 /// Transcodes a [Value] into a slice of JSON bytes.
-pub fn transcode_output(val: Value<'_>) -> Result<Vec<u8>> {
-    let mut output = Vec::new();
+pub fn stringify(val: Value<'_>) -> Result<Vec<u8>> {
+    let mut output: Vec<u8> = Vec::new();
     let mut deserializer = Deserializer::from(val);
     let mut serializer = serde_json::Serializer::new(&mut output);
     serde_transcode::transcode(&mut deserializer, &mut serializer)?;

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -1,7 +1,7 @@
 // use crate::quickjs::JSContextRef;
 use super::from_js_error;
 use crate::{
-    apis::{Console, NonStandardConsole, Random, StreamIO, TextEncoding},
+    apis::{Console, JavyJson, Json, NonStandardConsole, Random, StreamIO, TextEncoding},
     config::{JSIntrinsics, JavyIntrinsics},
     Config,
 };
@@ -42,11 +42,12 @@ impl Runtime {
 
         // See comment above about configuring GC behaviour.
         rt.set_gc_threshold(usize::MAX);
-        let context = Self::build_from_config(&rt, &config)?;
+        let context = Self::build_from_config(&rt, config)?;
         Ok(Self { inner: rt, context })
     }
 
-    fn build_from_config(rt: &QRuntime, cfg: &Config) -> Result<ManuallyDrop<Context>> {
+    fn build_from_config(rt: &QRuntime, cfg: Config) -> Result<ManuallyDrop<Context>> {
+        let cfg = cfg.validate()?;
         let intrinsics = &cfg.intrinsics;
         let javy_intrinsics = &cfg.javy_intrinsics;
         // We always set Random given that the principles around snapshotting and
@@ -78,6 +79,12 @@ impl Runtime {
 
             if intrinsics.contains(JSIntrinsics::JSON) {
                 unsafe { intrinsic::Json::add_intrinsic(ctx.as_raw()) }
+            }
+
+            if cfg.override_json_parse_and_stringify {
+                if cfg!(feature = "json") {
+                    unsafe { Json::add_intrinsic(ctx.as_raw()) }
+                }
             }
 
             if intrinsics.contains(JSIntrinsics::PROXY) {
@@ -124,6 +131,12 @@ impl Runtime {
 
             if javy_intrinsics.contains(JavyIntrinsics::STREAM_IO) {
                 unsafe { StreamIO::add_intrinsic(ctx.as_raw()) }
+            }
+
+            if javy_intrinsics.contains(JavyIntrinsics::JSON) {
+                if cfg!(feature = "json") {
+                    unsafe { JavyJson::add_intrinsic(ctx.as_raw()) }
+                }
             }
         });
 

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -1,10 +1,14 @@
 // use crate::quickjs::JSContextRef;
 use super::from_js_error;
 use crate::{
-    apis::{Console, JavyJson, Json, NonStandardConsole, Random, StreamIO, TextEncoding},
+    apis::{Console, NonStandardConsole, Random, StreamIO, TextEncoding},
     config::{JSIntrinsics, JavyIntrinsics},
     Config,
 };
+
+#[cfg(feature = "json")]
+use crate::apis::{JavyJson, Json};
+
 use anyhow::{bail, Result};
 use rquickjs::{
     context::{intrinsic, Intrinsic},
@@ -82,8 +86,9 @@ impl Runtime {
             }
 
             if cfg.override_json_parse_and_stringify {
-                if cfg!(feature = "json") {
-                    unsafe { Json::add_intrinsic(ctx.as_raw()) }
+                #[cfg(feature = "json")]
+                unsafe {
+                    Json::add_intrinsic(ctx.as_raw())
                 }
             }
 
@@ -134,8 +139,9 @@ impl Runtime {
             }
 
             if javy_intrinsics.contains(JavyIntrinsics::JSON) {
-                if cfg!(feature = "json") {
-                    unsafe { JavyJson::add_intrinsic(ctx.as_raw()) }
+                #[cfg(feature = "json")]
+                unsafe {
+                    JavyJson::add_intrinsic(ctx.as_raw())
                 }
             }
         });

--- a/crates/javy/src/serde/ser.rs
+++ b/crates/javy/src/serde/ser.rs
@@ -13,7 +13,7 @@ use super::as_key;
 /// serialization framework.
 ///
 /// ```
-/// // Assuming you have [Ctx] instance named context
+/// // Assuming you have [`Ctx`] instance named context
 /// let serializer = Serializer::from_context(context)?;
 /// let value: Value = serializer.serialize_u32(42)?;
 /// ```

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -66,6 +66,10 @@ criteria = "safe-to-deploy"
 version = "0.2.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.allocator-api2]]
+version = "0.2.18"
+criteria = "safe-to-deploy"
+
 [[exemptions.ansi_term]]
 version = "0.12.1"
 criteria = "safe-to-deploy"
@@ -234,6 +238,10 @@ criteria = "safe-to-deploy"
 version = "2.1.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.float-cmp]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.from_variant]]
 version = "0.1.8"
 criteria = "safe-to-deploy"
@@ -290,6 +298,10 @@ criteria = "safe-to-deploy"
 version = "2.4.1"
 criteria = "safe-to-run"
 
+[[exemptions.halfbrown]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+
 [[exemptions.heck]]
 version = "0.3.3"
 criteria = "safe-to-deploy"
@@ -344,6 +356,30 @@ criteria = "safe-to-deploy"
 
 [[exemptions.lazycell]]
 version = "1.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.lexical-core]]
+version = "0.8.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.lexical-parse-float]]
+version = "0.8.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.lexical-parse-integer]]
+version = "0.8.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.lexical-util]]
+version = "0.8.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.lexical-write-float]]
+version = "0.8.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.lexical-write-integer]]
+version = "0.8.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.libloading]]
@@ -482,6 +518,14 @@ criteria = "safe-to-deploy"
 version = "0.4.5"
 criteria = "safe-to-deploy"
 
+[[exemptions.ref-cast]]
+version = "1.0.23"
+criteria = "safe-to-deploy"
+
+[[exemptions.ref-cast-impl]]
+version = "1.0.23"
+criteria = "safe-to-deploy"
+
 [[exemptions.relative-path]]
 version = "1.9.2"
 criteria = "safe-to-deploy"
@@ -548,6 +592,14 @@ criteria = "safe-to-deploy"
 
 [[exemptions.simd-abstraction]]
 version = "0.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.simd-json]]
+version = "0.13.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.simdutf8]]
+version = "0.1.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.siphasher]]
@@ -706,6 +758,10 @@ criteria = "safe-to-deploy"
 version = "1.8.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.value-trait]]
+version = "0.8.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.vergen]]
 version = "8.3.1"
 criteria = "safe-to-deploy"
@@ -742,14 +798,6 @@ criteria = "safe-to-deploy"
 version = "0.116.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.wast]]
-version = "202.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.wat]]
-version = "1.202.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.which]]
 version = "4.4.2"
 criteria = "safe-to-deploy"
@@ -772,14 +820,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.wyz]]
 version = "0.5.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.zerocopy]]
-version = "0.7.32"
-criteria = "safe-to-deploy"
-
-[[exemptions.zerocopy-derive]]
-version = "0.7.32"
 criteria = "safe-to-deploy"
 
 [[exemptions.zstd]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -377,8 +377,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.proc-macro2]]
-version = "1.0.79"
-when = "2024-03-12"
+version = "1.0.84"
+when = "2024-05-25"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -517,8 +517,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.syn]]
-version = "2.0.58"
-when = "2024-04-03"
+version = "2.0.66"
+when = "2024-05-23"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -843,6 +843,18 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "19.0.2"
 when = "2024-04-11"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wast]]
+version = "202.0.0"
+when = "2024-03-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wat]]
+version = "1.202.0"
+when = "2024-03-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1322,6 +1334,30 @@ user-id = 73222 # wasmtime-publish
 start = "2022-11-27"
 end = "2024-06-26"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[audits.bytecode-alliance.wildcard-audits.wast]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2023-01-01"
+end = "2025-05-08"
+notes = """
+The Bytecode Alliance uses the `wasmtime-publish` crates.io account to automate
+publication of this crate from CI. This repository requires all PRs are reviewed
+by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
+"""
+
+[[audits.bytecode-alliance.wildcard-audits.wat]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2023-01-01"
+end = "2025-05-08"
+notes = """
+The Bytecode Alliance uses the `wasmtime-publish` crates.io account to automate
+publication of this crate from CI. This repository requires all PRs are reviewed
+by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
+"""
 
 [[audits.bytecode-alliance.wildcard-audits.wiggle]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -2315,4 +2351,24 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Valentin Gosu <valentin.gosu@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "2.4.1 -> 2.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerocopy]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.7.32"
+notes = """
+This crate is `no_std` so doesn't use any side-effectful std functions. It
+contains quite a lot of `unsafe` code, however. I verified portions of this. It
+also has a large, thorough test suite. The project claims to run tests with
+Miri to have stronger soundness checks, and also claims to use formal
+verification tools to prove correctness.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerocopy-derive]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.7.32"
+notes = "Clean, safe macros for zerocopy."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"


### PR DESCRIPTION
## Description of the change

This  commit introduces several improvements for JSON. Namely:

* Usage of SIMD JSON in order to speed up `JSON.parse` and using `serde_json` in order to speed up `JSON.stringify`. 
* Introduction of `Javy.JSON` functions as helpers to work with the stdin and stdout file descriptors. These are non-standard and live at the `Javy` namespace for that reason. These APIs should be considered unstable, meaning that there's no guarantee that they'll live in-tree forever, the intention is to move these away once our extensibility story is polished. 

-- 

The usage of the more performant JSON functions (based on SIMD and serde_json) *requires* enabling the QuickJS JSON intrinsic (see the config.rs module).  The reason behind this decision is to enable: a compliant JSON implementation that is optimized for the  hotpath: if extra arguments are passed to either JSON.{parse,stringify}, the native parse/stringify functions will be invoked, keeping the standard functionality. 

I believe that the best way to test this would be to run JSON 262 tests, to ensure that the implementation is fully compliant. However, this is not included in this PR. Such change is better packed on its own pull-request. I'll follow up with a change that includes a way to run JSON 262 tests.


## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
