### PR TITLE
Update wasmparser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
+ "serde",
 ]
 
 [[package]]
@@ -1548,7 +1549,7 @@ dependencies = [
  "walrus",
  "wasi-common",
  "wasm-opt",
- "wasmparser 0.206.0",
+ "wasmparser 0.209.1",
  "wasmprinter 0.206.0",
  "wasmtime",
  "wasmtime-wasi",
@@ -3613,6 +3614,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "indexmap 2.2.6",
  "semver 1.0.22",
+ "serde",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -41,7 +41,7 @@ lazy_static = "1.4"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 criterion = "0.5"
 num-format = "0.4.4"
-wasmparser = "0.206.0"
+wasmparser = "0.209.1"
 
 [build-dependencies]
 anyhow = "1.0.81"


### PR DESCRIPTION
## Description of the change

Updates the `wasmparser` dependency.

## Why am I making this change?

#658 fails to pass CI because the `ProducersSectionReader::new` function takes different arguments now. 

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
