### PR TITLE
Introduce the `javy-config` crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
       - name: Test
         env: 
           CARGO_TARGET_WASM32_WASI_RUNNER: wasmtime --dir=.
-        run: cargo hack wasi test --workspace --exclude=javy-cli --each-feature -- --nocapture
+        run: cargo hack wasi test --workspace --exclude=javy-cli --exclude=javy-config --each-feature -- --nocapture
+
+      - name: Test Config
+        run: cargo test --package=javy-config
 
       - name: Lint
         run: cargo clippy --workspace --exclude=javy-cli --target=wasm32-wasi --all-targets -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,11 +1559,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "javy-config"
+version = "1.4.0"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "javy-core"
 version = "0.2.0"
 dependencies = [
  "anyhow",
  "javy",
+ "javy-config",
  "once_cell",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "crates/core",
   "crates/cli",
   "crates/javy-test-macros",
+  "crates/javy-config",
 ]
 resolver = "2"
 
@@ -23,7 +24,9 @@ wasmtime-wasi = "19"
 wasi-common = "19"
 anyhow = "1.0"
 once_cell = "1.19"
+bitflags = "2.5.0"
 javy = { path = "crates/javy", version = "3.0.0-alpha.1" }
+javy-config = { path = "crates/javy-config" }
 
 [profile.release]
 lto = true

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,10 @@ test-wpt:
 	npm install --prefix wpt
 	npm test --prefix wpt 
 
-tests: test-javy test-core test-cli test-wpt
+test-config:
+	CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-config -- --nocapture
+
+tests: test-javy test-core test-cli test-wpt test-config
 
 fmt: fmt-quickjs-wasm-sys fmt-quickjs-wasm-rs fmt-javy fmt-apis fmt-core fmt-cli
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib"]
 anyhow = { workspace = true }
 javy = { workspace = true, features = ["export_alloc_fns", "json"] }
 once_cell = { workspace = true }
+javy-config = { workspace = true }
 
 [features]
 experimental_event_loop = []

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,6 @@
 use anyhow::anyhow;
 use javy::Runtime;
+use javy_config::Config;
 use once_cell::sync::OnceCell;
 use std::slice;
 use std::str;
@@ -16,7 +17,7 @@ static mut RUNTIME: OnceCell<Runtime> = OnceCell::new();
 /// Used by Wizer to preinitialize the module.
 #[export_name = "wizer.initialize"]
 pub extern "C" fn init() {
-    let runtime = runtime::new_runtime().unwrap();
+    let runtime = runtime::new(Config::all()).unwrap();
     unsafe {
         RUNTIME
             .set(runtime)
@@ -43,7 +44,7 @@ pub extern "C" fn init() {
 #[export_name = "compile_src"]
 pub unsafe extern "C" fn compile_src(js_src_ptr: *const u8, js_src_len: usize) -> *const u32 {
     // Use fresh runtime to avoid depending on Wizened runtime
-    let runtime = runtime::new_runtime().unwrap();
+    let runtime = runtime::new(Config::all()).unwrap();
     let js_src = str::from_utf8(slice::from_raw_parts(js_src_ptr, js_src_len)).unwrap();
 
     let bytecode = runtime

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -6,6 +6,7 @@ use std::slice;
 use std::str;
 use std::string::String;
 
+use javy_config::Config;
 mod execution;
 mod runtime;
 
@@ -18,7 +19,7 @@ static mut BYTECODE: OnceCell<Vec<u8>> = OnceCell::new();
 pub extern "C" fn init() {
     let _wasm_ctx = WasmCtx::new();
 
-    let runtime = runtime::new_runtime().unwrap();
+    let runtime = runtime::new(Config::all()).unwrap();
 
     let mut contents = String::new();
     io::stdin().read_to_string(&mut contents).unwrap();

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -1,14 +1,17 @@
 use anyhow::Result;
 use javy::{Config, Runtime};
+use javy_config::Config as SharedConfig;
 
-pub(crate) fn new_runtime() -> Result<Runtime> {
+pub(crate) fn new(shared_config: SharedConfig) -> Result<Runtime> {
     let mut config = Config::default();
     let config = config
-        .text_encoding(true)
-        .redirect_stdout_to_stderr(true)
-        .javy_stream_io(true)
-        .override_json_parse_and_stringify(true)
-        .javy_json(true);
+        .text_encoding(shared_config.contains(SharedConfig::TEXT_ENCODING))
+        .redirect_stdout_to_stderr(shared_config.contains(SharedConfig::REDIRECT_STDOUT_TO_STDERR))
+        .javy_stream_io(shared_config.contains(SharedConfig::JAVY_STREAM_IO))
+        .override_json_parse_and_stringify(
+            shared_config.contains(SharedConfig::OVERRIDE_JSON_PARSE_AND_STRINGIFY),
+        )
+        .javy_json(shared_config.contains(SharedConfig::JAVY_JSON));
 
     Runtime::new(std::mem::take(config))
 }

--- a/crates/javy-config/Cargo.toml
+++ b/crates/javy-config/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "javy-config"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bitflags = { workspace = true }

--- a/crates/javy-config/README.md
+++ b/crates/javy-config/README.md
@@ -1,0 +1,3 @@
+# Shared Configuration for Javy
+
+See `src/lib.rs` for more details.

--- a/crates/javy-config/src/lib.rs
+++ b/crates/javy-config/src/lib.rs
@@ -24,11 +24,25 @@
 use bitflags::bitflags;
 
 bitflags! {
+    #[derive(Eq, PartialEq)]
     pub struct Config: u32 {
         const OVERRIDE_JSON_PARSE_AND_STRINGIFY = 1;
         const JAVY_JSON = 1 << 1;
-        const JAVY_STREAM_IO = 1 << 1;
-        const REDIRECT_STDOUT_TO_STDERR = 1 << 2;
-        const TEXT_ENCODING = 1 << 3;
+        const JAVY_STREAM_IO = 1 << 2;
+        const REDIRECT_STDOUT_TO_STDERR = 1 << 3;
+        const TEXT_ENCODING = 1 << 4;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+    #[test]
+    fn check_bits() {
+        assert!(Config::OVERRIDE_JSON_PARSE_AND_STRINGIFY == Config::from_bits(1).unwrap());
+        assert!(Config::JAVY_JSON == Config::from_bits(1 << 1).unwrap());
+        assert!(Config::JAVY_STREAM_IO == Config::from_bits(1 << 2).unwrap());
+        assert!(Config::REDIRECT_STDOUT_TO_STDERR == Config::from_bits(1 << 3).unwrap());
+        assert!(Config::TEXT_ENCODING == Config::from_bits(1 << 4).unwrap());
     }
 }

--- a/crates/javy-config/src/lib.rs
+++ b/crates/javy-config/src/lib.rs
@@ -18,7 +18,7 @@
 //! need to override non-standard defaults typically set during CLI invocations.
 //! These defaults often do not align with the preferences of the CLI users.
 //!
-//! In gneneral this crate should be treated as an internal detail and
+//! In general this crate should be treated as an internal detail and
 //! a contract between the CLI and the Javy crate.
 
 use bitflags::bitflags;

--- a/crates/javy-config/src/lib.rs
+++ b/crates/javy-config/src/lib.rs
@@ -1,0 +1,34 @@
+//! Shared Configuration for Javy.
+//!
+//! This crate serves as a central place to facilitate configuration sharing
+//! between the Javy CLI and the Javy crate. It addresses the challenge of
+//! passing configuration settings in environments where the Javy CLI commands
+//! predominantly execute WebAssembly.
+//!
+//! The purpose of this crate is to consolidate configuration parameters,
+//! ensuring consistent and accessible settings across both the CLI and the
+//! crate. This approach simplifies the management of configuration settings and
+//! enhances the integration between different components of the Javy ecosystem.
+//!
+//! Currently, this crate includes only a subset of the available configuration
+//! options. The objective is to eventually encompass all configurable
+//! parameters found in [javy::Config].
+//!
+//! The selection of the current configuration options was influenced by the
+//! need to override non-standard defaults typically set during CLI invocations.
+//! These defaults often do not align with the preferences of the CLI users.
+//!
+//! In gneneral this crate should be treated as an internal detail and
+//! a contract between the CLI and the Javy crate.
+
+use bitflags::bitflags;
+
+bitflags! {
+    pub struct Config: u32 {
+        const OVERRIDE_JSON_PARSE_AND_STRINGIFY = 1;
+        const JAVY_JSON = 1 << 1;
+        const JAVY_STREAM_IO = 1 << 1;
+        const REDIRECT_STDOUT_TO_STDERR = 1 << 2;
+        const TEXT_ENCODING = 1 << 3;
+    }
+}

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -19,7 +19,7 @@ rmp-serde = { version = "^1.3", optional = true }
 # TODO: cargo doesn't seem to pickup the fact that quickcheck is only used for
 # tests.
 quickcheck = "1"
-bitflags = "2.5.0"
+bitflags = { workspace = true }
 fastrand = "2.1.0"
 simd-json = { version = "0.13.10", optional = true, default-features = false, features = ["big-int-as-float", "serde_impl"] }
 


### PR DESCRIPTION
This commit prepares the terrain to bridge the gap in configurability between the CLI and Javy, the crate.
The intention behind introducing a new crate is to:

* Reduce code duplication and sync the options between the CLI and the core crate.
* Make it easy to pass the options into WebAssemlby by using bitflags.

This PR doesn't introduce any new functionality. A follow up PR will include new commands in the CLI which will make use of the share configuration.


## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
