### PR TITLE
Prepare v3.0.0 for the `javy` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ wasi-common = "19"
 anyhow = "1.0"
 once_cell = "1.19"
 bitflags = "2.5.0"
-javy = { path = "crates/javy", version = "3.0.0-alpha.1" }
 javy-config = { path = "crates/javy-config" }
+javy = { path = "crates/javy", version = "3.0.0" }
 
 [profile.release]
 lto = true

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.0] - 2024-06-12
+
 ### Changed
 
 - Introduce `rquickjs` to interface with QuickJS instead of `quickjs-wasm-rs`;

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
