### PR TITLE
Flush `stdout` unconditionally

### DIFF
--- a/crates/javy/src/apis/json.rs
+++ b/crates/javy/src/apis/json.rs
@@ -230,5 +230,6 @@ fn to_stdout(args: Args<'_>) -> Result<()> {
     let (_, args) = args.release();
     let mut fd = std::io::stdout();
     let buffer = json::stringify(args[0].clone())?;
-    fd.write_all(&buffer).map_err(Into::into)
+    fd.write_all(&buffer)?;
+    fd.flush().map_err(Into::into)
 }


### PR DESCRIPTION
## Description of the change
This commit ensures that `stdout` is always correctly flushed after writing to it. This is critical for dynamic use-cases of Javy



## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
