### PR TITLE
Statically link to the C runtime in MSVC

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,9 @@
 # https://doc.rust-lang.org/cargo/reference/config.html
 [target.wasm32-wasi]
 rustflags = ["-C", "target-feature=+simd128"]
+
+# We want to ensure that all the MSVC dependencies are statically resolved and
+# included in the final CLI binary.
+# Ref: https://github.com/rust-lang/rust/pull/122268
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION

## Description of the change

Javy version 1.4.0 statically linked to the C runtime. Such version was built with Rust 1.75.

Javy version 2.0.0, built with Rust 1.79.0, which doesn't perform static linking by default. This commit adds a directive to preserve the same behavior as in v 1.4.0.



## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
