### PR TITLE
Disable Javy.JSON by default

### DIFF
--- a/crates/cli/tests/dynamic_linking_test.rs
+++ b/crates/cli/tests/dynamic_linking_test.rs
@@ -127,6 +127,8 @@ fn test_producers_section_present() -> Result<()> {
 }
 
 #[test]
+// Temporarily ignore given that Javy.JSON is disabled by default.
+#[ignore]
 fn javy_json_identity() -> Result<()> {
     let src = r#"
         console.log(Javy.JSON.toStdout(Javy.JSON.fromStdin()));

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -8,10 +8,11 @@ pub(crate) fn new(shared_config: SharedConfig) -> Result<Runtime> {
         .text_encoding(shared_config.contains(SharedConfig::TEXT_ENCODING))
         .redirect_stdout_to_stderr(shared_config.contains(SharedConfig::REDIRECT_STDOUT_TO_STDERR))
         .javy_stream_io(shared_config.contains(SharedConfig::JAVY_STREAM_IO))
-        .override_json_parse_and_stringify(
-            shared_config.contains(SharedConfig::OVERRIDE_JSON_PARSE_AND_STRINGIFY),
-        )
-        .javy_json(shared_config.contains(SharedConfig::JAVY_JSON));
+        // Due to an issue with our custom serializer and property accesses
+        // we're disabling this temporarily. It will be enabled once we have a
+        // fix forward.
+        .override_json_parse_and_stringify(false)
+        .javy_json(false);
 
     Runtime::new(std::mem::take(config))
 }


### PR DESCRIPTION
## Description of the change
Prior to this commit this option was true by default in order to profit of the performance benefits of SIMD JSON. Unfortunately this introduced issues with GC which need to be investigated further. In the meantime we're setting as off by default.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
