### PR TITLE
Bump CLI version to 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,7 +1705,7 @@ version = "3.0.0"
 
 [[package]]
 name = "javy-cli"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "javy-config"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "bitflags",
 ]
@@ -1749,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "javy-test-macros"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.0"
+version = "3.0.0"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
## Description of the change

Publishing a new version of the CLI which contains a fix and a breaking change:

- https://github.com/bytecodealliance/javy/pull/671
- https://github.com/bytecodealliance/javy/pull/670

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
