### PR TITLE
Fix issues between reference counting and the custom `JSON.parse` implementation

### DIFF
--- a/crates/javy/tests/misc.rs
+++ b/crates/javy/tests/misc.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use javy::{quickjs::context::EvalOptions, Config, Runtime};
 
+#[cfg(feature = "json")]
 #[test]
 fn string_keys_and_ref_counting() -> Result<()> {
     let mut config = Config::default();

--- a/crates/javy/tests/misc.rs
+++ b/crates/javy/tests/misc.rs
@@ -12,7 +12,7 @@ fn string_keys_and_ref_counting() -> Result<()> {
 
     rt.context().with(|this| {
         let _: () = this
-            .eval_with_options(&*source, EvalOptions::default())
+            .eval_with_options(*source, EvalOptions::default())
             .inspect_err(|e| println!("{e}"))
             .expect("source evaluation to succeed");
     });

--- a/crates/javy/tests/misc.rs
+++ b/crates/javy/tests/misc.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+use javy::{quickjs::context::EvalOptions, Config, Runtime};
+
+#[test]
+fn string_keys_and_ref_counting() -> Result<()> {
+    let mut config = Config::default();
+    config.override_json_parse_and_stringify(true);
+
+    let source = include_bytes!("string_keys_and_ref_counting.js");
+    let rt = Runtime::new(config)?;
+
+    rt.context().with(|this| {
+        let _: () = this
+            .eval_with_options(&*source, EvalOptions::default())
+            .inspect_err(|e| println!("{e}"))
+            .expect("source evaluation to succeed");
+    });
+
+    Ok(())
+}

--- a/crates/javy/tests/string_keys_and_ref_counting.js
+++ b/crates/javy/tests/string_keys_and_ref_counting.js
@@ -1,0 +1,8 @@
+const input = JSON.parse('{"elements":[{"id":"zza"},{"id":"zzb"},{"id":"zzc"},{"id":"zzd"},{"id":"zze"}]}');
+
+const acc = {};
+input.elements.forEach(e => {
+  if (!acc[e.id]) {
+    acc[e.id] = 1;
+  }
+});


### PR DESCRIPTION
## Description of the change

This change contains two commits, each with  a clear description of the change. 

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
