### PR TITLE
Avoiding swallowing errors that arise in exported functions

### DIFF
--- a/crates/cli/tests/dynamic_linking_test.rs
+++ b/crates/cli/tests/dynamic_linking_test.rs
@@ -47,6 +47,25 @@ pub fn test_dynamic_linking_with_func_without_flag() -> Result<()> {
 }
 
 #[test]
+fn test_errors_in_exported_functions_are_correctly_reported() -> Result<()> {
+    let js_src = "export function foo() { throw \"Error\" }";
+    let wit = "
+        package local:main
+
+        world foo-test {
+            export foo: func()
+        }
+    ";
+    let res = invoke_fn_on_generated_module(js_src, "foo", Some((wit, "foo-test")), None, None);
+    assert!(res
+        .err()
+        .unwrap()
+        .to_string()
+        .contains("error while executing"));
+    Ok(())
+}
+
+#[test]
 pub fn check_for_new_imports() -> Result<()> {
     // If you need to change this test, then you've likely made a breaking change.
     let js_src = "console.log(42);";


### PR DESCRIPTION

## Description of the change

Similar to the main (`_start`) case, `eval_with_options` returns a promise, which, needs to be explicitly inspected in order to retrieve any values or any unhandled errors.

This commit ensures that the behaviour is the right one by inspecting the underlying promise.


## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
