### PR TITLE
Remove usage of the custom `rquickjs` fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,6 +1693,8 @@ dependencies = [
  "quickcheck",
  "rmp-serde",
  "rquickjs",
+ "rquickjs-core",
+ "rquickjs-sys",
  "serde",
  "serde-transcode",
  "serde_json",
@@ -2535,7 +2537,8 @@ dependencies = [
 [[package]]
 name = "rquickjs"
 version = "0.6.1"
-source = "git+https://github.com/Shopify/rquickjs?branch=improved-wasm-support#3d80f5757db52e9e1af2605cb6e1aaba6d44ceac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313802853d6b1a91a7ecaef37b88b2e3be94dbfd8e46e8c585ec7d03977c4585"
 dependencies = [
  "rquickjs-core",
  "rquickjs-macro",
@@ -2544,7 +2547,8 @@ dependencies = [
 [[package]]
 name = "rquickjs-core"
 version = "0.6.1"
-source = "git+https://github.com/Shopify/rquickjs?branch=improved-wasm-support#3d80f5757db52e9e1af2605cb6e1aaba6d44ceac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b61d5ef0cf929f69b30c106b70cafbf8c9b00435da7b13c004e61db639ae7cc"
 dependencies = [
  "relative-path",
  "rquickjs-sys",
@@ -2553,7 +2557,8 @@ dependencies = [
 [[package]]
 name = "rquickjs-macro"
 version = "0.6.1"
-source = "git+https://github.com/Shopify/rquickjs?branch=improved-wasm-support#3d80f5757db52e9e1af2605cb6e1aaba6d44ceac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52decfafae40368b74e1513235245612680224924925736f386b9456b78efce9"
 dependencies = [
  "convert_case",
  "fnv",
@@ -2570,7 +2575,8 @@ dependencies = [
 [[package]]
 name = "rquickjs-sys"
 version = "0.6.1"
-source = "git+https://github.com/Shopify/rquickjs?branch=improved-wasm-support#3d80f5757db52e9e1af2605cb6e1aaba6d44ceac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a6df95dbd61eacfa2fb7571c9d0a6d2acb168135f6261ddd53d0347fd65441"
 dependencies = [
  "bindgen",
  "cc",

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -10,7 +10,7 @@ fn test_identity() {
 
     let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 42);
     assert_eq!(42, output);
-    assert_fuel_consumed_within_threshold(43239, fuel_consumed);
+    assert_fuel_consumed_within_threshold(47_773, fuel_consumed);
 }
 
 #[test]
@@ -19,7 +19,7 @@ fn test_fib() {
 
     let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 5);
     assert_eq!(8, output);
-    assert_fuel_consumed_within_threshold(59_822, fuel_consumed);
+    assert_fuel_consumed_within_threshold(66_007, fuel_consumed);
 }
 
 #[test]
@@ -28,7 +28,7 @@ fn test_recursive_fib() {
 
     let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 5);
     assert_eq!(8, output);
-    assert_fuel_consumed_within_threshold(61_617, fuel_consumed);
+    assert_fuel_consumed_within_threshold(69_306, fuel_consumed);
 }
 
 #[test]
@@ -46,7 +46,7 @@ fn test_encoding() {
 
     let (output, _, fuel_consumed) = run(&mut runner, "hello".as_bytes());
     assert_eq!("el".as_bytes(), output);
-    assert_fuel_consumed_within_threshold(218_527, fuel_consumed);
+    assert_fuel_consumed_within_threshold(258_197, fuel_consumed);
 
     let (output, _, _) = run(&mut runner, "invalid".as_bytes());
     assert_eq!("true".as_bytes(), output);
@@ -76,7 +76,7 @@ fn test_readme_script() {
 
     let (output, _, fuel_consumed) = run(&mut runner, r#"{ "n": 2, "bar": "baz" }"#.as_bytes());
     assert_eq!(r#"{"foo":3,"newBar":"baz!"}"#.as_bytes(), output);
-    assert_fuel_consumed_within_threshold(235_476, fuel_consumed);
+    assert_fuel_consumed_within_threshold(270_919, fuel_consumed);
 }
 
 #[cfg(feature = "experimental_event_loop")]
@@ -106,7 +106,7 @@ fn test_exported_functions() {
     let mut runner = Runner::new_with_exports("exported-fn.js", "exported-fn.wit", "exported-fn");
     let (_, logs, fuel_consumed) = run_fn(&mut runner, "foo", &[]);
     assert_eq!("Hello from top-level\nHello from foo\n", logs);
-    assert_fuel_consumed_within_threshold(72552, fuel_consumed);
+    assert_fuel_consumed_within_threshold(80023, fuel_consumed);
     let (_, logs, _) = run_fn(&mut runner, "foo-bar", &[]);
     assert_eq!("Hello from top-level\nHello from fooBar\n", logs);
 }
@@ -180,7 +180,7 @@ fn test_exported_default_arrow_fn() {
     );
     let (_, logs, fuel_consumed) = run_fn(&mut runner, "default", &[]);
     assert_eq!(logs, "42\n");
-    assert_fuel_consumed_within_threshold(67547, fuel_consumed);
+    assert_fuel_consumed_within_threshold(76706, fuel_consumed);
 }
 
 #[test]

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -192,7 +192,7 @@ fn test_exported_default_fn() {
     );
     let (_, logs, fuel_consumed) = run_fn(&mut runner, "default", &[]);
     assert_eq!(logs, "42\n");
-    assert_fuel_consumed_within_threshold(67792, fuel_consumed);
+    assert_fuel_consumed_within_threshold(77909, fuel_consumed);
 }
 
 fn run_with_u8s(r: &mut Runner, stdin: u8) -> (u8, String, u64) {

--- a/crates/javy-test-macros/src/lib.rs
+++ b/crates/javy-test-macros/src/lib.rs
@@ -161,7 +161,7 @@ fn gen_tests(
 
                         let test_contents = ::std::fs::read(&#path_str).expect("test file contents to be available");
                         let r: ::javy::quickjs::Result<()> = this.eval_with_options(test_contents, ::javy::quickjs::context::EvalOptions::default());
-                        assert!(r.is_ok(), "{}", ::javy::val_to_string(this.clone(), this.catch()).unwrap());
+                        assert!(r.is_ok(), "{}", ::javy::val_to_string(&this, this.catch()).unwrap());
                     });
 
                 }

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -11,7 +11,9 @@ categories = ["wasm"]
 
 [dependencies]
 anyhow = { workspace = true }
-rquickjs = { git = "https://github.com/Shopify/rquickjs", branch = "improved-wasm-support", features = ["array-buffer", "bindgen", "no-free"] }
+rquickjs = { version = "=0.6.1", features = ["array-buffer", "bindgen"] }
+rquickjs-core = "=0.6.1"
+rquickjs-sys = "=0.6.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 serde-transcode = { version = "1.1", optional = true }

--- a/crates/javy/src/apis/console/mod.rs
+++ b/crates/javy/src/apis/console/mod.rs
@@ -71,7 +71,7 @@ fn log<'js, T: Write>(args: Args<'js>, stream: &mut T) -> Result<Value<'js>> {
             write!(stream, " ")?;
         }
 
-        let str = val_to_string(ctx.clone(), arg)?;
+        let str = val_to_string(&ctx, arg)?;
         write!(stream, "{str}")?;
     }
     writeln!(stream)?;

--- a/crates/javy/src/apis/json.rs
+++ b/crates/javy/src/apis/json.rs
@@ -114,7 +114,7 @@ fn call_json_parse<'a>(args: Args<'a>, default: Function<'a>) -> Result<Value<'a
                 bail!(Exception::throw_type(&this, "Expected string primitive"));
             }
 
-            let mut string = val_to_string(this.clone(), args[0].clone())?;
+            let mut string = val_to_string(&this, args[0].clone())?;
             let bytes = unsafe { string.as_bytes_mut() };
             json::parse(this.clone(), bytes).map_err(|original| {
                 if original.downcast_ref::<SError>().is_none() {

--- a/crates/javy/src/lib.rs
+++ b/crates/javy/src/lib.rs
@@ -108,7 +108,7 @@ pub fn from_js_error(ctx: Ctx<'_>, e: JSError) -> Error {
         if let Some(exception) = val.clone().into_exception() {
             anyhow!("{exception}")
         } else {
-            anyhow!(val_to_string(ctx, val).unwrap_or_else(|_| "Internal error".to_string()))
+            anyhow!(val_to_string(&ctx, val).unwrap_or_else(|_| "Internal error".to_string()))
         }
     } else {
         Into::into(e)
@@ -202,21 +202,21 @@ pub fn to_string_lossy<'js>(cx: &Ctx<'js>, string: &JSString<'js>, error: JSErro
 }
 
 /// Retrieves the string representation of a JavaScript value.
-pub fn val_to_string<'js>(this: Ctx<'js>, val: Value<'js>) -> Result<String> {
+pub fn val_to_string<'js>(this: &Ctx<'js>, val: Value<'js>) -> Result<String> {
     if let Some(symbol) = val.as_symbol() {
         if let Some(description) = symbol.description()?.into_string() {
             let description = description
                 .to_string()
-                .unwrap_or_else(|e| to_string_lossy(&this, &description, e));
+                .unwrap_or_else(|e| to_string_lossy(this, &description, e));
             Ok(format!("Symbol({description})"))
         } else {
             Ok("Symbol()".into())
         }
     } else {
-        let stringified = <convert::Coerced<JSString>>::from_js(&this, val).map(|string| {
+        let stringified = <convert::Coerced<JSString>>::from_js(this, val).map(|string| {
             string
                 .to_string()
-                .unwrap_or_else(|e| to_string_lossy(&this, &string.0, e))
+                .unwrap_or_else(|e| to_string_lossy(this, &string.0, e))
         })?;
         Ok(stringified)
     }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -358,43 +358,11 @@ criteria = "safe-to-deploy"
 version = "0.1.60"
 criteria = "safe-to-deploy"
 
-[[exemptions.icu_collections]]
-version = "1.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.icu_locid]]
-version = "1.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.icu_locid_transform]]
-version = "1.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.icu_locid_transform_data]]
-version = "1.5.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.icu_normalizer]]
 version = "1.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.icu_normalizer_data]]
-version = "1.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.icu_properties]]
-version = "1.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.icu_properties_data]]
-version = "1.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.icu_provider]]
-version = "1.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.icu_provider_macros]]
 version = "1.5.0"
 criteria = "safe-to-deploy"
 
@@ -472,10 +440,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.libredox]]
 version = "0.1.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.litemap]]
-version = "0.7.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.log]]
@@ -638,6 +602,22 @@ criteria = "safe-to-deploy"
 version = "1.3.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.rquickjs]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rquickjs-core]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rquickjs-macro]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rquickjs-sys]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.rustc-demangle]]
 version = "0.1.24"
 criteria = "safe-to-deploy"
@@ -794,10 +774,6 @@ criteria = "safe-to-deploy"
 version = "3.10.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.tinystr]]
-version = "0.7.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.tower]]
 version = "0.4.13"
 criteria = "safe-to-deploy"
@@ -934,20 +910,8 @@ criteria = "safe-to-deploy"
 version = "1.0.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.writeable]]
-version = "0.5.5"
-criteria = "safe-to-deploy"
-
 [[exemptions.wyz]]
 version = "0.5.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.yoke]]
-version = "0.7.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.yoke-derive]]
-version = "0.7.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]
@@ -958,20 +922,8 @@ criteria = "safe-to-deploy"
 version = "0.7.34"
 criteria = "safe-to-deploy"
 
-[[exemptions.zerofrom]]
-version = "0.1.4"
-criteria = "safe-to-deploy"
-
 [[exemptions.zerofrom-derive]]
 version = "0.1.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.zerovec]]
-version = "0.10.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.zerovec-derive]]
-version = "0.10.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zstd]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1546,12 +1546,6 @@ notes = "I read through the diff between v0.13.1 and v0.13.2, and verified that 
 [[audits.bytecode-alliance.audits.heck]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-version = "0.4.0"
-notes = "Contains `forbid_unsafe` and only uses `std::fmt` from the standard library. Otherwise only contains string manipulation."
-
-[[audits.bytecode-alliance.audits.heck]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
 delta = "0.4.1 -> 0.5.0"
 notes = "Minor changes for a `no_std` upgrade but otherwise everything looks as expected."
 
@@ -2124,10 +2118,132 @@ version = "0.12.3"
 notes = "This version is used in rust's libstd, so effectively we're already trusting it"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.heck]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
+[[audits.mozilla.audits.icu_collections]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
 criteria = "safe-to-deploy"
-delta = "0.4.0 -> 0.4.1"
+version = "1.2.0"
+notes = "This crate is used by ICU4X for internal data structure. There is no fileaccess and network access. This uses unsafe block, but we confirm data is valid before."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_collections]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.4.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_collections]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_locid]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
+notes = "This has unsafe block to handle ascii string in utf-8 string. I've vetted the one instance of unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_locid]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.4.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_locid]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_locid_transform]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "1.4.0"
+notes = "This crate doesn't contain network and file access. Although this has unsafe block, the reason is added in the comment block. I audited code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_locid_transform]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_locid_transform_data]]
+who = "Jonathan Kew <jkew@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "1.4.0"
+notes = "Compile-time static for the icu_locid_transform crate."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_locid_transform_data]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_properties]]
+who = "Jonathan Kew <jkew@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "1.4.0"
+notes = "This is used by ICU4X for character property lookup. The few (4) usages of unsafe have comments clarifying their safety."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_properties]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_properties_data]]
+who = "Jonathan Kew <jkew@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "1.4.0"
+notes = "Compile-time static data for the icu_properties crate."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_properties_data]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_provider]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
+notes = "Although this has unsafe block, this has a commnet why this is safety and I audited code. Also, this doesn't have file access and network access."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_provider]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.4.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_provider]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_provider_macros]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
+notes = "This crate is macros for ICU4X's data provider implementer. This has no unsafe code and uses no ambient capabilities."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_provider_macros]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.4.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.icu_provider_macros]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.5.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.itertools]]
@@ -2142,6 +2258,25 @@ criteria = "safe-to-deploy"
 version = "1.4.0"
 notes = "I have read over the macros, and audited the unsafe code."
 aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.litemap]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "0.7.0"
+notes = "This crete has no unsafe code, no file acceess and no network access."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.litemap]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.7.0 -> 0.7.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.litemap]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.7.2 -> 0.7.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.num-integer]]
 who = "Josh Stone <jistone@redhat.com>"
@@ -2238,4 +2373,123 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.13.0 -> 0.13.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinystr]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "0.7.0"
+notes = "One of original auther was Zibi Braniecki who worked at Mozilla and maintained by ICU4X developers (Google and Mozilla). I've vetted the one instance of unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinystr]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.7.0 -> 0.7.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinystr]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.7.1 -> 0.7.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tinystr]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.7.4 -> 0.7.6"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.writeable]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "0.5.2"
+notes = "writeable is a variation of fmt::Write with sink version. This uses `unsafe` block to handle potentially-invalid UTF-8 character. I've vetted the one instance of unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.writeable]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.5.2 -> 0.5.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.writeable]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.5.4 -> 0.5.5"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.yoke]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "0.7.1"
+notes = "This crate is for zero-copy serialization for ICU4X data structure, and maintained by ICU4X team. Since this uses unsafe block for serialization, I audited code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.yoke]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.7.1 -> 0.7.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.yoke]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.7.3 -> 0.7.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.yoke-derive]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "0.7.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.yoke-derive]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.7.3 -> 0.7.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerofrom]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "0.1.2"
+notes = "This crate is zero-copy version of \"From\". This has no unsafe code and uses no ambient capabilities."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerofrom]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.1.2 -> 0.1.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "0.9.4"
+notes = "This crate is zero-copy data structure implmentation. Although this uses unsafe block in several code, it requires for zero-copy. And this has a comment in code why this uses unsafe and I audited code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.9.4 -> 0.10.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.10.1 -> 0.10.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec-derive]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+version = "0.10.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.zerovec-derive]]
+who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
+criteria = "safe-to-deploy"
+delta = "0.10.1 -> 0.10.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"


### PR DESCRIPTION
This commit deprecates the usage of the custom `rquickjs` fork and pins the `rquickjs` version to 0.6.1, which is the current version in the fork.

The main motivation behind this change is to avoid relying on a fork, which precludes publishing version 3.0.0 of the `javy` crates to crates.io, since git dependencies are not supported.

Another motivation, arguably more important than the one stated above, is making sure that we are always relying on the upstream implementation rather than in a fork containing patches maintained out-of-band.

Side-effects:

The fork enabled a slightly more performant execution in Wasm environments, when dealing with short-lived JS programs that don't require garbage collection, more explicitly, it introduced a patch that prevented QuickJS' `__JS_FreeValueRT` from running. Even though there are no known issues with this approach, `__JS_FreeValueRT` is an internal method and no guarantees are made regarding its stability, therefore it's preferred to avoid relying on it. Without this custom patch, I'm observing locally, on average a 2% increase in fuel usage outside of the 10% acceptable variance. Note that there are safe mechanisms in place to mitigate the impact of GC in the codebase, namely: (i) using `ManuallyDrop` where possible (ii) setting the GC threshold to `-1` to reduce the possibility of any GC pauses. With that in mind, the 2% increase seems reasonable given all the benefits that we get from this change.

Alternatives considered:

* Keeping the fork
  * Upgrades will be difficult
  * There's no easy way of publishing the `javy` crate
* Post-processing the generated Wasm code and make `JS_FreeValue` and `JS_FreeContext` no-op.
  * This worked to a certain extent, however, in my opinion, the result is not worth the effort. This approach resulted in minimal performance improvements. Even though `JS_FreeValue` which is a method from the public API and is invoked by Rust `drop`s will end up calling `__JS_FreeValueRT`, which is the most expensive of the `free` variants, not all `__JS_FreeValueRT` invocations stem from `JS_FreeValue`, some of them happen automatically from within the JS code.


## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
