### PR TITLE
Prepare version 3.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,7 +1707,7 @@ version = "3.0.0"
 
 [[package]]
 name = "javy-cli"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "javy-config"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "bitflags",
 ]
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "javy-test-macros"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.0.0"
+version = "3.0.1"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
Prepares version `3.0.1` of the CLI.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
