### PR TITLE
Extract the `runner` module into its own crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,13 @@ jobs:
       - name: Test
         env: 
           CARGO_TARGET_WASM32_WASI_RUNNER: wasmtime --dir=.
-        run: cargo hack wasi test --workspace --exclude=javy-cli --exclude=javy-config --each-feature -- --nocapture
+        run: cargo hack wasi test --workspace --exclude=javy-cli --exclude=javy-config --exclude=javy-runner --each-feature -- --nocapture
 
       - name: Test Config
         run: cargo test --package=javy-config
+
+      - name: Test Runner
+        run: cargo test --package=javy-runner
 
       - name: Lint
         run: cargo clippy --workspace --exclude=javy-cli --target=wasm32-wasi --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,12 @@ jobs:
         run: cargo test --package=javy-runner
 
       - name: Lint
-        run: cargo clippy --workspace --exclude=javy-cli --target=wasm32-wasi --all-targets -- -D warnings
+        run: cargo clippy --workspace --exclude=javy-cli --exclude=javy-runner --target=wasm32-wasi --all-targets -- -D warnings
+        
+      # We need to specify a different job for linting `javy-runner` given that 
+      # it depends on Wasmtime and Cranelift cannot be compiled to `wasm32-wasi`
+      - name: Lint Runner
+        run: cargo clippy --package=javy-runner -- -D warnings
 
       - name: Upload core binary to artifacts
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,6 +1714,7 @@ dependencies = [
  "clap",
  "convert_case",
  "criterion",
+ "javy-runner",
  "lazy_static",
  "num-format",
  "serde",
@@ -1747,6 +1748,18 @@ dependencies = [
  "javy",
  "javy-config",
  "once_cell",
+]
+
+[[package]]
+name = "javy-runner"
+version = "3.0.0"
+dependencies = [
+ "anyhow",
+ "tempfile",
+ "uuid",
+ "wasi-common",
+ "wasmtime",
+ "wasmtime-wasi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "crates/cli",
   "crates/test-macros",
   "crates/config",
+  "crates/runner",
 ]
 resolver = "2"
 
@@ -27,6 +28,8 @@ once_cell = "1.19"
 bitflags = "2.5.0"
 javy-config = { path = "crates/config" }
 javy = { path = "crates/javy", version = "3.0.0" }
+tempfile = "3.10.1"
+uuid = { version = "1.8", features = ["v4"] }
 
 [profile.release]
 lto = true

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ test-core:
 test-cli: core
 	CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-cli --release --features=$(CLI_FEATURES) -- --nocapture
 
+test-runner:
+	cargo test --package=javy-runner -- --nocapture
+
 # WPT requires a Javy build with the experimental_event_loop feature to pass
 test-wpt: export CORE_FEATURES ?= experimental_event_loop
 test-wpt:
@@ -44,7 +47,7 @@ test-wpt:
 test-config:
 	CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-config -- --nocapture
 
-tests: test-javy test-core test-cli test-wpt test-config
+tests: test-javy test-core test-runner test-cli test-wpt test-config
 
 fmt: fmt-quickjs-wasm-sys fmt-quickjs-wasm-rs fmt-javy fmt-apis fmt-core fmt-cli
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,17 +31,18 @@ swc_core = { version = "0.92.8", features = [
 wit-parser = "0.209.1"
 convert_case = "0.6.0"
 wasm-opt = "0.116.1"
-tempfile = "3.10.1"
+tempfile = { workspace = true }
 clap = { version = "4.5.7", features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0"
-uuid = { version = "1.8", features = ["v4"] }
 lazy_static = "1.4"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 criterion = "0.5"
 num-format = "0.4.4"
 wasmparser = "0.209.1"
+javy-runner = { path = "../runner/" }
+uuid = { workspace = true }
 
 [build-dependencies]
 anyhow = "1.0.86"

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -1,48 +1,72 @@
 mod common;
-mod runner;
 
-use runner::{Runner, RunnerError};
+use anyhow::Result;
+use javy_runner::{Builder, Runner, RunnerError};
+use std::path::PathBuf;
 use std::str;
 
+static BIN: &'static str = env!("CARGO_BIN_EXE_javy");
+static ROOT: &'static str = env!("CARGO_MANIFEST_DIR");
+
 #[test]
-fn test_identity() {
-    let mut runner = Runner::default();
+fn test_identity() -> Result<()> {
+    let mut runner = Builder::default().root(sample_scripts()).bin(BIN).build()?;
 
     let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 42);
     assert_eq!(42, output);
     assert_fuel_consumed_within_threshold(47_773, fuel_consumed);
+    Ok(())
 }
 
 #[test]
-fn test_fib() {
-    let mut runner = Runner::new("fib.js");
+fn test_fib() -> Result<()> {
+    let mut runner = Builder::default()
+        .root(sample_scripts())
+        .bin(BIN)
+        .input("fib.js")
+        .build()?;
 
     let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 5);
     assert_eq!(8, output);
     assert_fuel_consumed_within_threshold(66_007, fuel_consumed);
+    Ok(())
 }
 
 #[test]
-fn test_recursive_fib() {
-    let mut runner = Runner::new("recursive-fib.js");
+fn test_recursive_fib() -> Result<()> {
+    let mut runner = Builder::default()
+        .bin(BIN)
+        .root(sample_scripts())
+        .input("recursive-fib.js")
+        .build()?;
 
     let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 5);
     assert_eq!(8, output);
     assert_fuel_consumed_within_threshold(69_306, fuel_consumed);
+    Ok(())
 }
 
 #[test]
-fn test_str() {
-    let mut runner = Runner::new("str.js");
+fn test_str() -> Result<()> {
+    let mut runner = Builder::default()
+        .root(sample_scripts())
+        .bin(BIN)
+        .input("str.js")
+        .build()?;
 
     let (output, _, fuel_consumed) = run(&mut runner, "hello".as_bytes());
     assert_eq!("world".as_bytes(), output);
     assert_fuel_consumed_within_threshold(142_849, fuel_consumed);
+    Ok(())
 }
 
 #[test]
-fn test_encoding() {
-    let mut runner = Runner::new("text-encoding.js");
+fn test_encoding() -> Result<()> {
+    let mut runner = Builder::default()
+        .root(sample_scripts())
+        .bin(BIN)
+        .input("text-encoding.js")
+        .build()?;
 
     let (output, _, fuel_consumed) = run(&mut runner, "hello".as_bytes());
     assert_eq!("el".as_bytes(), output);
@@ -56,11 +80,16 @@ fn test_encoding() {
 
     let (output, _, _) = run(&mut runner, "test".as_bytes());
     assert_eq!("test2".as_bytes(), output);
+    Ok(())
 }
 
 #[test]
-fn test_logging() {
-    let mut runner = Runner::new("logging.js");
+fn test_logging() -> Result<()> {
+    let mut runner = Builder::default()
+        .root(sample_scripts())
+        .bin(BIN)
+        .input("logging.js")
+        .build()?;
 
     let (_output, logs, fuel_consumed) = run(&mut runner, &[]);
     assert_eq!(
@@ -68,131 +97,192 @@ fn test_logging() {
         logs.as_str(),
     );
     assert_fuel_consumed_within_threshold(34169, fuel_consumed);
+    Ok(())
 }
 
 #[test]
-fn test_readme_script() {
-    let mut runner = Runner::new("readme.js");
+fn test_readme_script() -> Result<()> {
+    let mut runner = Builder::default()
+        .root(sample_scripts())
+        .bin(BIN)
+        .input("readme.js")
+        .build()?;
 
     let (output, _, fuel_consumed) = run(&mut runner, r#"{ "n": 2, "bar": "baz" }"#.as_bytes());
     assert_eq!(r#"{"foo":3,"newBar":"baz!"}"#.as_bytes(), output);
     assert_fuel_consumed_within_threshold(270_919, fuel_consumed);
+    Ok(())
 }
 
 #[cfg(feature = "experimental_event_loop")]
 #[test]
-fn test_promises() {
-    let mut runner = Runner::new("promise.js");
+fn test_promises() -> Result<()> {
+    let mut runner = Builder::default()
+        .bin(BIN)
+        .root(sample_scripts())
+        .input("promise.js")
+        .build()?;
 
     let (output, _, _) = run(&mut runner, &[]);
     assert_eq!("\"foo\"\"bar\"".as_bytes(), output);
+    Ok(())
 }
 
 #[cfg(not(feature = "experimental_event_loop"))]
 #[test]
-fn test_promises() {
-    use crate::runner::RunnerError;
+fn test_promises() -> Result<()> {
+    use javy_runner::RunnerError;
 
-    let mut runner = Runner::new("promise.js");
+    let mut runner = Builder::default()
+        .root(sample_scripts())
+        .bin(BIN)
+        .input("promise.js")
+        .build()?;
     let res = runner.exec(&[]);
     let err = res.err().unwrap().downcast::<RunnerError>().unwrap();
     assert!(str::from_utf8(&err.stderr)
         .unwrap()
         .contains("Pending jobs in the event queue."));
+
+    Ok(())
 }
 
 #[test]
-fn test_exported_functions() {
-    let mut runner = Runner::new_with_exports("exported-fn.js", "exported-fn.wit", "exported-fn");
+fn test_exported_functions() -> Result<()> {
+    let mut runner = Builder::default()
+        .bin(BIN)
+        .root(sample_scripts())
+        .input("exported-fn.js")
+        .wit("exported-fn.wit")
+        .world("exported-fn")
+        .build()?;
     let (_, logs, fuel_consumed) = run_fn(&mut runner, "foo", &[]);
     assert_eq!("Hello from top-level\nHello from foo\n", logs);
     assert_fuel_consumed_within_threshold(80023, fuel_consumed);
     let (_, logs, _) = run_fn(&mut runner, "foo-bar", &[]);
     assert_eq!("Hello from top-level\nHello from fooBar\n", logs);
+    Ok(())
 }
 
 #[cfg(feature = "experimental_event_loop")]
 #[test]
-fn test_exported_promises() {
-    let mut runner = Runner::new_with_exports(
-        "exported-promise-fn.js",
-        "exported-promise-fn.wit",
-        "exported-promise-fn",
-    );
+fn test_exported_promises() -> Result<()> {
+    let mut runner = Builder::default()
+        .bin(BIN)
+        .root(sample_scripts())
+        .input("exported-promise-fn.js")
+        .wit("exported-promise-fn.wit")
+        .world("exported-promise-fn")
+        .build()?;
     let (_, logs, _) = run_fn(&mut runner, "foo", &[]);
     assert_eq!("Top-level\ninside foo\n", logs);
+    Ok(())
 }
 
 #[test]
-fn test_exported_functions_without_flag() {
-    let mut runner = Runner::new("exported-fn.js");
+fn test_exported_functions_without_flag() -> Result<()> {
+    let mut runner = Builder::default()
+        .root(sample_scripts())
+        .bin(BIN)
+        .input("exported-fn.js")
+        .build()?;
     let res = runner.exec_func("foo", &[]);
     assert_eq!(
         "failed to find function export `foo`",
         res.err().unwrap().to_string()
     );
+    Ok(())
 }
 
 #[test]
-fn test_exported_function_without_semicolons() {
-    let mut runner = Runner::new_with_exports(
-        "exported-fn-no-semicolon.js",
-        "exported-fn-no-semicolon.wit",
-        "exported-fn",
-    );
+fn test_exported_function_without_semicolons() -> Result<()> {
+    let mut runner = Builder::default()
+        .root(sample_scripts())
+        .bin(BIN)
+        .input("exported-fn-no-semicolon.js")
+        .wit("exported-fn-no-semicolon.wit")
+        .world("exported-fn")
+        .build()?;
     run_fn(&mut runner, "foo", &[]);
+    Ok(())
 }
 
 #[test]
-fn test_producers_section_present() {
-    let runner = Runner::new("readme.js");
+fn test_producers_section_present() -> Result<()> {
+    let runner = Builder::default()
+        .root(sample_scripts())
+        .bin(BIN)
+        .input("readme.js")
+        .build()?;
     common::assert_producers_section_is_correct(&runner.wasm).unwrap();
+    Ok(())
 }
 
 #[test]
-fn test_error_handling() {
-    let mut runner = Runner::new("error.js");
+fn test_error_handling() -> Result<()> {
+    let mut runner = Builder::default()
+        .root(sample_scripts())
+        .bin(BIN)
+        .input("error.js")
+        .build()?;
     let result = runner.exec(&[]);
     let err = result.err().unwrap().downcast::<RunnerError>().unwrap();
 
     let expected_log_output = "Error:2:9 error\n    at error (function.mjs:2:9)\n    at <anonymous> (function.mjs:5:1)\n\n";
 
     assert_eq!(expected_log_output, str::from_utf8(&err.stderr).unwrap());
+    Ok(())
 }
 
 #[test]
-fn test_same_module_outputs_different_random_result() {
-    let mut runner = Runner::new("random.js");
+fn test_same_module_outputs_different_random_result() -> Result<()> {
+    let mut runner = Builder::default()
+        .bin(BIN)
+        .root(sample_scripts())
+        .input("random.js")
+        .build()?;
     let (output, _, _) = runner.exec(&[]).unwrap();
     let (output2, _, _) = runner.exec(&[]).unwrap();
     // In theory these could be equal with a correct implementation but it's very unlikely.
     assert!(output != output2);
     // Don't check fuel consumed because fuel consumed can be different from run to run. See
     // https://github.com/bytecodealliance/javy/issues/401 for investigating the cause.
+    Ok(())
 }
 
 #[test]
-fn test_exported_default_arrow_fn() {
-    let mut runner = Runner::new_with_exports(
-        "exported-default-arrow-fn.js",
-        "exported-default-arrow-fn.wit",
-        "exported-arrow",
-    );
+fn test_exported_default_arrow_fn() -> Result<()> {
+    let mut runner = Builder::default()
+        .bin(BIN)
+        .root(sample_scripts())
+        .input("exported-default-arrow-fn.js")
+        .wit("exported-default-arrow-fn.wit")
+        .world("exported-arrow")
+        .build()?;
+
     let (_, logs, fuel_consumed) = run_fn(&mut runner, "default", &[]);
     assert_eq!(logs, "42\n");
     assert_fuel_consumed_within_threshold(76706, fuel_consumed);
+    Ok(())
 }
 
 #[test]
-fn test_exported_default_fn() {
-    let mut runner = Runner::new_with_exports(
-        "exported-default-fn.js",
-        "exported-default-fn.wit",
-        "exported-default",
-    );
+fn test_exported_default_fn() -> Result<()> {
+    let mut runner = Builder::default()
+        .bin(BIN)
+        .root(sample_scripts())
+        .input("exported-default-fn.js")
+        .wit("exported-default-fn.wit")
+        .world("exported-default")
+        .build()?;
     let (_, logs, fuel_consumed) = run_fn(&mut runner, "default", &[]);
     assert_eq!(logs, "42\n");
     assert_fuel_consumed_within_threshold(77909, fuel_consumed);
+    Ok(())
+}
+
+fn sample_scripts() -> PathBuf {
+    PathBuf::from(ROOT).join("tests").join("sample-scripts")
 }
 
 fn run_with_u8s(r: &mut Runner, stdin: u8) -> (u8, String, u64) {

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -5,8 +5,8 @@ use javy_runner::{Builder, Runner, RunnerError};
 use std::path::PathBuf;
 use std::str;
 
-static BIN: &'static str = env!("CARGO_BIN_EXE_javy");
-static ROOT: &'static str = env!("CARGO_MANIFEST_DIR");
+static BIN: &str = env!("CARGO_BIN_EXE_javy");
+static ROOT: &str = env!("CARGO_MANIFEST_DIR");
 
 #[test]
 fn test_identity() -> Result<()> {

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "javy-runner"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+wasmtime = { workspace = true }
+wasmtime-wasi = { workspace = true }
+wasi-common = { workspace = true }
+anyhow = { workspace = true }
+tempfile = { workspace = true }
+uuid = { workspace = true }

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -85,7 +85,7 @@ impl Builder {
             capacity,
             root,
             built: _,
-        } = std::mem::replace(self, Default::default());
+        } = std::mem::take(self);
 
         self.built = true;
 

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -287,3 +287,25 @@ impl Write for LogWriter {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Builder;
+    use anyhow::Result;
+
+    #[test]
+    fn test_validation_on_world_defined() -> Result<()> {
+        let result = Builder::default().world("foo").build();
+
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_validation_on_wit_defined() -> Result<()> {
+        let result = Builder::default().wit("foo.wit").build();
+
+        assert!(result.is_err());
+        Ok(())
+    }
+}


### PR DESCRIPTION
This commit extracts the utiility runner module, used in the integration tests into its own private crate.
The main motivation for this change is to enable sharing this functionality between integration tests and the upcoming `javy-fuzz` crate.

Additionally, this change promotes some dependencies to the workspace level, namely:

- `tempfile`
- `uuid`

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
