### PR TITLE
Update `wasmtime` version in CI

### DIFF
--- a/.github/actions/ci-shared-setup/action.yml
+++ b/.github/actions/ci-shared-setup/action.yml
@@ -25,12 +25,17 @@ runs:
           ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}
           ${{ runner.os }}-cargo-target
 
-    - name: Install wasmtime-cli
-      env:
-        WASMTIME_VERSION: 8.0.0
+    - name: Read wasmtime version
+      id: wasmtime_version
       shell: bash
       run: |
-        wget -nv 'https://github.com/bytecodealliance/wasmtime/releases/download/v${{ env.WASMTIME_VERSION }}/wasmtime-v${{ env.WASMTIME_VERSION }}-x86_64-${{ inputs.os }}.tar.xz' -O /tmp/wasmtime.tar.xz
+        VERSION=$(cargo metadata | jq '.packages[] | select(.name == "wasmtime") | .version' -r)
+        echo "::set-output name=wasmtime_version::$VERSION"
+
+    - name: Install wasmtime-cli
+      shell: bash
+      run: |
+        wget -nv 'https://github.com/bytecodealliance/wasmtime/releases/download/v${{ steps.wasmtime_version.outputs.wasmtime_version }}/wasmtime-v${{ steps.wasmtime_version.outputs.wasmtime_version }}-x86_64-${{ inputs.os }}.tar.xz' -O /tmp/wasmtime.tar.xz
         mkdir /tmp/wasmtime
         tar xvf /tmp/wasmtime.tar.xz --strip-components=1 -C /tmp/wasmtime
         echo "/tmp/wasmtime" >> $GITHUB_PATH

--- a/.github/actions/ci-shared-setup/action.yml
+++ b/.github/actions/ci-shared-setup/action.yml
@@ -29,7 +29,7 @@ runs:
       id: wasmtime_version
       shell: bash
       run: |
-        VERSION=$(cargo metadata | jq '.packages[] | select(.name == "wasmtime") | .version' -r)
+        VERSION=$(cargo metadata --format-version=1 --locked | jq '.packages[] | select(.name == "wasmtime") | .version' -r)
         echo "::set-output name=wasmtime_version::$VERSION"
 
     - name: Install wasmtime-cli


### PR DESCRIPTION
This commit updates the wasmtime version used in CI, which is currently
a very outdated version. The new version matches the version used in the
CLI.

Additionally, this commit introduces a mechanism to retrieve the `wasmtime` CLI version
from `cargo metadata` through `jq`

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
