### PR TITLE
[Submodule] Use https over git protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/web-platform-tests/wpt
 [submodule "crates/javy/test262"]
 	path = crates/javy/test262
-	url = git@github.com:tc39/test262.git
+	url = https://github.com/tc39/test262


### PR DESCRIPTION
## Description of the change

https is the preferred protocol for cloning repos. This switches the test262 reference to the https protocol.

## Why am I making this change?

Cloning the submodule for test262 was failing for me.

Test instructions:

```
git submodule sync
git submodule update
```

Previously, I was hitting this security error:
```
➜  javy git:(add-crypto-hmac-256) ✗ git submodule update
Cloning into '/Users/a_user_name/src/github.com/bytecodealliance/javy/crates/javy/test262'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:tc39/test262.git' into submodule path '/Users/a_user_name/src/github.com/bytecodealliance/javy/crates/javy/test262' failed
Failed to clone 'crates/javy/test262'. Retry scheduled
Cloning into '/Users/a_user_name/src/github.com/bytecodealliance/javy/crates/javy/test262'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:tc39/test262.git' into submodule path '/Users/a_user_name/src/github.com/bytecodealliance/javy/crates/javy/test262' failed
Failed to clone 'crates/javy/test262' a second time, aborting
```

## Checklist

- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [ ] I've updated documentation including crate documentation if necessary.
