### PR TITLE
Add crypto hmac sha 256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1276,6 +1277,15 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1689,6 +1699,7 @@ dependencies = [
  "anyhow",
  "bitflags",
  "fastrand",
+ "hmac",
  "javy-test-macros",
  "quickcheck",
  "rmp-serde",
@@ -1698,6 +1709,7 @@ dependencies = [
  "serde",
  "serde-transcode",
  "serde_json",
+ "sha2",
  "simd-json",
 ]
 
@@ -2966,6 +2978,12 @@ dependencies = [
  "rustversion",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swc_atoms"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -31,7 +31,7 @@ bitflags! {
         const JAVY_STREAM_IO = 1 << 2;
         const REDIRECT_STDOUT_TO_STDERR = 1 << 3;
         const TEXT_ENCODING = 1 << 4;
-        const JAVY_CRYPTOX = 1 << 5;
+        const CRYPTO = 1 << 5;
     }
 }
 
@@ -45,6 +45,6 @@ mod tests {
         assert!(Config::JAVY_STREAM_IO == Config::from_bits(1 << 2).unwrap());
         assert!(Config::REDIRECT_STDOUT_TO_STDERR == Config::from_bits(1 << 3).unwrap());
         assert!(Config::TEXT_ENCODING == Config::from_bits(1 << 4).unwrap());
-        assert!(Config::JAVY_CRYPTOX == Config::from_bits(1 << 5).unwrap());
+        assert!(Config::CRYPTO == Config::from_bits(1 << 5).unwrap());
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -31,6 +31,7 @@ bitflags! {
         const JAVY_STREAM_IO = 1 << 2;
         const REDIRECT_STDOUT_TO_STDERR = 1 << 3;
         const TEXT_ENCODING = 1 << 4;
+        const JAVY_CRYPTOX = 1 << 5;
     }
 }
 
@@ -44,5 +45,6 @@ mod tests {
         assert!(Config::JAVY_STREAM_IO == Config::from_bits(1 << 2).unwrap());
         assert!(Config::REDIRECT_STDOUT_TO_STDERR == Config::from_bits(1 << 3).unwrap());
         assert!(Config::TEXT_ENCODING == Config::from_bits(1 << 4).unwrap());
+        assert!(Config::JAVY_CRYPTOX == Config::from_bits(1 << 5).unwrap());
     }
 }

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -13,7 +13,7 @@ pub(crate) fn new(shared_config: SharedConfig) -> Result<Runtime> {
         // fix forward.
         .override_json_parse_and_stringify(false)
         .javy_json(false)
-        .javy_cryptox(true);
+        .javy_cryptox(shared_config.contains(SharedConfig::JAVY_CRYPTOX));
 
     Runtime::new(std::mem::take(config))
 }

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -12,7 +12,8 @@ pub(crate) fn new(shared_config: SharedConfig) -> Result<Runtime> {
         // we're disabling this temporarily. It will be enabled once we have a
         // fix forward.
         .override_json_parse_and_stringify(false)
-        .javy_json(false);
+        .javy_json(false)
+        .javy_cryptox(true);
 
     Runtime::new(std::mem::take(config))
 }

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -13,7 +13,7 @@ pub(crate) fn new(shared_config: SharedConfig) -> Result<Runtime> {
         // fix forward.
         .override_json_parse_and_stringify(false)
         .javy_json(false)
-        .javy_cryptox(shared_config.contains(SharedConfig::JAVY_CRYPTOX));
+        .crypto(shared_config.contains(SharedConfig::CRYPTO));
 
     Runtime::new(std::mem::take(config))
 }

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -24,6 +24,8 @@ quickcheck = "1"
 bitflags = { workspace = true }
 fastrand = "2.1.0"
 simd-json = { version = "0.13.10", optional = true, default-features = false, features = ["big-int-as-float", "serde_impl"] }
+sha2 = "0.10.8"
+hmac = "0.12.1"
 
 [dev-dependencies]
 javy-test-macros = { path = "../test-macros/" }

--- a/crates/javy/src/apis/crypto/mod.rs
+++ b/crates/javy/src/apis/crypto/mod.rs
@@ -1,12 +1,9 @@
-use crate::quickjs::{context::Intrinsic, qjs, Ctx, Object, String as JSString, Value, Function};
-use crate::{
-    hold, hold_and_release, val_to_string,
-    to_js_error, Args
-};
+use crate::quickjs::{context::Intrinsic, qjs, Ctx, Function, Object, String as JSString, Value};
+use crate::{hold, hold_and_release, to_js_error, val_to_string, Args};
 use anyhow::{bail, Error, Result};
 
-use sha2::Sha256;
 use hmac::{Hmac, Mac};
+use sha2::Sha256;
 
 /// An implemetation of crypto APIs to optimize fuel.
 /// Currently, hmacSHA256 is the only function implemented.
@@ -58,7 +55,7 @@ fn hmac_sha256(args: Args<'_>) -> Result<Value<'_>> {
 
     let result = mac.finalize();
     let code_bytes = result.into_bytes();
-    let code : String = format!("{code_bytes:x}");
+    let code: String = format!("{code_bytes:x}");
     let js_string = JSString::from_str(cx, &code);
     Ok(Value::from_string(js_string?))
 }

--- a/crates/javy/src/apis/crypto/mod.rs
+++ b/crates/javy/src/apis/crypto/mod.rs
@@ -10,14 +10,13 @@ use hmac::{Hmac, Mac};
 
 /// An implemetation of crypto APIs to optimize fuel.
 /// Currently, hmacSHA256 is the only function implemented.
-pub struct Cryptox;
+pub struct Crypto;
 
-impl Intrinsic for Cryptox {
+impl Intrinsic for Crypto {
     unsafe fn add_intrinsic(ctx: std::ptr::NonNull<qjs::JSContext>) {
-        register(Ctx::from_raw(ctx)).expect("`Cryptox` APIs to succeed")
+        register(Ctx::from_raw(ctx)).expect("`Crypto` APIs to succeed")
     }
 }
-
 fn register(this: Ctx<'_>) -> Result<()> {
     let globals = this.globals();
 
@@ -32,7 +31,7 @@ fn register(this: Ctx<'_>) -> Result<()> {
         }),
     )?;
 
-    globals.set("cryptox", crypto_obj)?;
+    globals.set("crypto", crypto_obj)?;
 
     Ok::<_, Error>(())
 }
@@ -72,14 +71,14 @@ mod tests {
     #[test]
     fn test_text_encoder_decoder() -> Result<()> {
         let mut config = Config::default();
-        config.javy_cryptox(true);
+        config.crypto(true);
         let runtime = Runtime::new(config)?;
 
         runtime.context().with(|this| {
             let result: Value<'_> = this.eval(
                 r#"
                     let expectedHex = "97d2a569059bbcd8ead4444ff99071f4c01d005bcefe0d3567e1be628e5fdcd9";
-                    let result = cryptox.hmacSHA256("my secret and secure key", "input message");
+                    let result = crypto.hmacSHA256("my secret and secure key", "input message");
                     expectedHex === result;
             "#,
             )?;

--- a/crates/javy/src/apis/cryptox/mod.rs
+++ b/crates/javy/src/apis/cryptox/mod.rs
@@ -1,0 +1,92 @@
+use crate::quickjs::{context::Intrinsic, qjs, Ctx, Object, String as JSString, Value, Function};
+use crate::{
+    hold, hold_and_release, val_to_string,
+    to_js_error, Args
+};
+use anyhow::{bail, Error, Result};
+
+use sha2::Sha256;
+use hmac::{Hmac, Mac};
+
+/// An implemetation of crypto APIs to optimize fuel.
+/// Currently, hmacSHA256 is the only function implemented.
+pub struct Cryptox;
+
+impl Intrinsic for Cryptox {
+    unsafe fn add_intrinsic(ctx: std::ptr::NonNull<qjs::JSContext>) {
+        register(Ctx::from_raw(ctx)).expect("`Cryptox` APIs to succeed")
+    }
+}
+
+fn register(this: Ctx<'_>) -> Result<()> {
+    let globals = this.globals();
+
+    // let crypto_obj = Object::new(cx)?;
+    let crypto_obj = Object::new(this.clone())?;
+
+    crypto_obj.set(
+        "hmacSHA256",
+        Function::new(this.clone(), |this, args| {
+            let (this, args) = hold_and_release!(this, args);
+            hmac_sha256(hold!(this.clone(), args)).map_err(|e| to_js_error(this, e))
+        }),
+    )?;
+
+    globals.set("cryptox", crypto_obj)?;
+
+    Ok::<_, Error>(())
+}
+/// hmac_sha256 applies the HMAC algorithm using sha256 for hashing.
+/// Arg[0] - secret
+/// Arg[1] - message
+/// returns - hex encoded string of hmac.
+fn hmac_sha256(args: Args<'_>) -> Result<Value<'_>> {
+    let (cx, args) = args.release();
+
+    if args.len() != 2 {
+        bail!("Wrong number of arguments. Expected 2. Got {}", args.len());
+    }
+
+    let js_string_secret = val_to_string(&cx, args[0].clone())?;
+    let js_string_message = val_to_string(&cx, args[1].clone())?;
+
+    /// Create alias for HMAC-SHA256
+    type HmacSha256 = Hmac<Sha256>;
+
+    let mut mac = HmacSha256::new_from_slice(&js_string_secret.as_bytes())
+        .expect("HMAC can take key of any size");
+    mac.update(&js_string_message.as_bytes());
+
+    let result = mac.finalize();
+    let code_bytes = result.into_bytes();
+    let code : String = format!("{code_bytes:x}");
+    let js_string = JSString::from_str(cx, &code);
+    Ok(Value::from_string(js_string?))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{quickjs::Value, Config, Runtime};
+    use anyhow::{Error, Result};
+
+    #[test]
+    fn test_text_encoder_decoder() -> Result<()> {
+        let mut config = Config::default();
+        config.javy_cryptox(true);
+        let runtime = Runtime::new(config)?;
+
+        runtime.context().with(|this| {
+            let result: Value<'_> = this.eval(
+                r#"
+                    let expectedHex = "97d2a569059bbcd8ead4444ff99071f4c01d005bcefe0d3567e1be628e5fdcd9";
+                    let result = cryptox.hmacSHA256("my secret and secure key", "input message");
+                    expectedHex === result;
+            "#,
+            )?;
+
+            assert!(result.as_bool().unwrap());
+            Ok::<_, Error>(())
+        })?;
+        Ok(())
+    }
+}

--- a/crates/javy/src/apis/cryptox/mod.rs
+++ b/crates/javy/src/apis/cryptox/mod.rs
@@ -53,9 +53,9 @@ fn hmac_sha256(args: Args<'_>) -> Result<Value<'_>> {
     /// Create alias for HMAC-SHA256
     type HmacSha256 = Hmac<Sha256>;
 
-    let mut mac = HmacSha256::new_from_slice(&js_string_secret.as_bytes())
+    let mut mac = HmacSha256::new_from_slice(js_string_secret.as_bytes())
         .expect("HMAC can take key of any size");
-    mac.update(&js_string_message.as_bytes());
+    mac.update(js_string_message.as_bytes());
 
     let result = mac.finalize();
     let code_bytes = result.into_bytes();

--- a/crates/javy/src/apis/mod.rs
+++ b/crates/javy/src/apis/mod.rs
@@ -57,17 +57,17 @@
 //!
 //! Disabled by default.
 pub(crate) mod console;
+pub(crate) mod crypto;
 #[cfg(feature = "json")]
 pub(crate) mod json;
 pub(crate) mod random;
 pub(crate) mod stream_io;
 pub(crate) mod text_encoding;
-pub(crate) mod crypto;
 
 pub(crate) use console::*;
+pub(crate) use crypto::*;
 #[cfg(feature = "json")]
 pub(crate) use json::*;
 pub(crate) use random::*;
 pub(crate) use stream_io::*;
 pub(crate) use text_encoding::*;
-pub(crate) use crypto::*;

--- a/crates/javy/src/apis/mod.rs
+++ b/crates/javy/src/apis/mod.rs
@@ -62,7 +62,7 @@ pub(crate) mod json;
 pub(crate) mod random;
 pub(crate) mod stream_io;
 pub(crate) mod text_encoding;
-pub(crate) mod cryptox;
+pub(crate) mod crypto;
 
 pub(crate) use console::*;
 #[cfg(feature = "json")]
@@ -70,4 +70,4 @@ pub(crate) use json::*;
 pub(crate) use random::*;
 pub(crate) use stream_io::*;
 pub(crate) use text_encoding::*;
-pub(crate) use cryptox::*;
+pub(crate) use crypto::*;

--- a/crates/javy/src/apis/mod.rs
+++ b/crates/javy/src/apis/mod.rs
@@ -62,6 +62,7 @@ pub(crate) mod json;
 pub(crate) mod random;
 pub(crate) mod stream_io;
 pub(crate) mod text_encoding;
+pub(crate) mod cryptox;
 
 pub(crate) use console::*;
 #[cfg(feature = "json")]
@@ -69,3 +70,4 @@ pub(crate) use json::*;
 pub(crate) use random::*;
 pub(crate) use stream_io::*;
 pub(crate) use text_encoding::*;
+pub(crate) use cryptox::*;

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -19,6 +19,7 @@ bitflags! {
         const OPERATORS = 1 << 12;
         const BIGNUM_EXTENSION = 1 << 13;
         const TEXT_ENCODING = 1 << 14;
+        const CRYPTO = 1 << 15;
     }
 }
 
@@ -38,7 +39,6 @@ bitflags! {
     pub(crate) struct JavyIntrinsics: u32 {
         const STREAM_IO = 1;
         const JSON = 1 << 1;
-        const CRYPTOX = 1 << 2;
     }
 }
 
@@ -180,11 +180,11 @@ impl Config {
         self
     }
 
-    /// Whether the `Javy.CRYPTOX` intrinsic will be available.
+    /// Whether the `crypto` intrinsic will be available.
     /// Enabled by default.
-    // #[cfg(feature = "cryptox")]
-    pub fn javy_cryptox(&mut self, enable: bool) -> &mut Self {
-        self.javy_intrinsics.set(JavyIntrinsics::CRYPTOX, enable);
+    // #[cfg(feature = "crypto")]
+    pub fn crypto(&mut self, enable: bool) -> &mut Self {
+        self.intrinsics.set(JSIntrinsics::CRYPTO, enable);
         self
     }
 

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -38,6 +38,7 @@ bitflags! {
     pub(crate) struct JavyIntrinsics: u32 {
         const STREAM_IO = 1;
         const JSON = 1 << 1;
+        const CRYPTOX = 1 << 2;
     }
 }
 
@@ -176,6 +177,14 @@ impl Config {
     #[cfg(feature = "json")]
     pub fn javy_json(&mut self, enable: bool) -> &mut Self {
         self.javy_intrinsics.set(JavyIntrinsics::JSON, enable);
+        self
+    }
+
+    /// Whether the `Javy.CRYPTOX` intrinsic will be available.
+    /// Enabled by default.
+    // #[cfg(feature = "cryptox")]
+    pub fn javy_cryptox(&mut self, enable: bool) -> &mut Self {
+        self.javy_intrinsics.set(JavyIntrinsics::CRYPTOX, enable);
         self
     }
 

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -1,7 +1,7 @@
 // use crate::quickjs::JSContextRef;
 use super::from_js_error;
 use crate::{
-    apis::{Console, NonStandardConsole, Random, StreamIO, TextEncoding},
+    apis::{Cryptox, Console, NonStandardConsole, Random, StreamIO, TextEncoding},
     config::{JSIntrinsics, JavyIntrinsics},
     Config,
 };
@@ -142,6 +142,13 @@ impl Runtime {
                 #[cfg(feature = "json")]
                 unsafe {
                     JavyJson::add_intrinsic(ctx.as_raw())
+                }
+            }
+
+            if javy_intrinsics.contains(JavyIntrinsics::CRYPTOX) {
+                // #[cfg(feature = "cryptox")]
+                unsafe {
+                    Cryptox::add_intrinsic(ctx.as_raw())
                 }
             }
         });

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -1,7 +1,7 @@
 // use crate::quickjs::JSContextRef;
 use super::from_js_error;
 use crate::{
-    apis::{Crypto, Console, NonStandardConsole, Random, StreamIO, TextEncoding},
+    apis::{Console, Crypto, NonStandardConsole, Random, StreamIO, TextEncoding},
     config::{JSIntrinsics, JavyIntrinsics},
     Config,
 };
@@ -147,9 +147,7 @@ impl Runtime {
 
             if intrinsics.contains(JSIntrinsics::CRYPTO) {
                 // #[cfg(feature = "crypto")]
-                unsafe {
-                    Crypto::add_intrinsic(ctx.as_raw())
-                }
+                unsafe { Crypto::add_intrinsic(ctx.as_raw()) }
             }
         });
 

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -1,7 +1,7 @@
 // use crate::quickjs::JSContextRef;
 use super::from_js_error;
 use crate::{
-    apis::{Cryptox, Console, NonStandardConsole, Random, StreamIO, TextEncoding},
+    apis::{Crypto, Console, NonStandardConsole, Random, StreamIO, TextEncoding},
     config::{JSIntrinsics, JavyIntrinsics},
     Config,
 };
@@ -145,10 +145,10 @@ impl Runtime {
                 }
             }
 
-            if javy_intrinsics.contains(JavyIntrinsics::CRYPTOX) {
-                // #[cfg(feature = "cryptox")]
+            if intrinsics.contains(JSIntrinsics::CRYPTO) {
+                // #[cfg(feature = "crypto")]
                 unsafe {
-                    Cryptox::add_intrinsic(ctx.as_raw())
+                    Crypto::add_intrinsic(ctx.as_raw())
                 }
             }
         });


### PR DESCRIPTION
## Description of the change

Running crypto functions in Javascript quickly runs out of fuel, which rust is must more efficient at the job. This is a wrapper to expose the rust hmac-sha256 implementation to javy user code.

## Why am I making this change?

To conserve fuel when running crypto. As a bonus, the crypto function is not left to end users to get right.

## Checklist

- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [ ] I've updated documentation including crate documentation if necessary.
