### PR TITLE
Remove outdated audit-as-crates-io policies

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -34,18 +34,6 @@ audit-as-crates-io = false
 [policy.quickjs-wasm-sys]
 audit-as-crates-io = false
 
-[policy.rquickjs]
-audit-as-crates-io = false
-
-[policy.rquickjs-core]
-audit-as-crates-io = false
-
-[policy.rquickjs-macro]
-audit-as-crates-io = false
-
-[policy.rquickjs-sys]
-audit-as-crates-io = false
-
 [[exemptions.Inflector]]
 version = "0.11.4"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Description of the change

Removes a few outdated `audit-as-crates-io` cargo vet policies.

## Why am I making this change?

We no longer use forks of these crates and continuing to include these policies stops `cargo vet` from working (but `cargo vet --locked` does continue to work which is why CI didn't catch this).

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
