### PR TITLE
Update wit-parser to 0.212.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,7 +1729,7 @@ dependencies = [
  "wasmprinter 0.209.1",
  "wasmtime",
  "wasmtime-wasi",
- "wit-parser 0.209.1",
+ "wit-parser 0.212.0",
  "wizer",
 ]
 
@@ -3813,6 +3813,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.212.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d28bc49ba1e5c5b61ffa7a2eace10820443c4b7d1c0b144109261d14570fdf8"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "hashbrown 0.14.5",
+ "indexmap 2.2.6",
+ "semver 1.0.23",
+]
+
+[[package]]
 name = "wasmprinter"
 version = "0.201.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4497,9 +4510,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.209.1"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e79b9e3c0b6bb589dec46317e645851e0db2734c44e2be5e251b03ff4a51269"
+checksum = "ceeb0424aa8679f3fcf2d6e3cfa381f3d6fa6179976a2c05a6249dd2bb426716"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -4510,7 +4523,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.209.1",
+ "wasmparser 0.212.0",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -28,7 +28,7 @@ swc_core = { version = "0.92.8", features = [
     "ecma_ast",
     "ecma_parser",
 ] }
-wit-parser = "0.209.1"
+wit-parser = "0.212.0"
 convert_case = "0.6.0"
 wasm-opt = "0.116.1"
 tempfile = { workspace = true }

--- a/crates/cli/src/wit.rs
+++ b/crates/cli/src/wit.rs
@@ -2,14 +2,13 @@ use std::path::Path;
 
 use anyhow::{bail, Result};
 
-use wit_parser::{Resolve, UnresolvedPackage, WorldItem};
+use wit_parser::{Resolve, WorldItem};
 
 pub fn parse_exports(wit: impl AsRef<Path>, world: &str) -> Result<Vec<String>> {
     let mut resolve = Resolve::default();
-    let package = UnresolvedPackage::parse_path(wit.as_ref())?;
-    resolve.push(package)?;
+    resolve.push_path(wit.as_ref())?;
     let (_, package_id) = resolve.package_names.first().unwrap();
-    let world_id = resolve.select_world(*package_id, Some(world))?;
+    let world_id = resolve.select_world(&[*package_id], Some(world))?;
     let world = resolve.worlds.get(world_id).unwrap();
 
     if !world.imports.is_empty() {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -691,6 +691,12 @@ when = "2024-05-29"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmparser]]
+version = "0.212.0"
+when = "2024-06-27"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmprinter]]
 version = "0.201.0"
 when = "2024-02-27"
@@ -1028,8 +1034,8 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-parser]]
-version = "0.209.1"
-when = "2024-05-29"
+version = "0.212.0"
+when = "2024-06-27"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
## Description of the change

Updates `wit-parser` to 0.212.0.

## Why am I making this change?

The automatic `wit-parser` update in #681 doesn't compile. 

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
