### PR TITLE
Update `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "tempfile",


### PR DESCRIPTION
The latest main contains an `out-of-sync` Cargo.lock, which is making the newly introduced `cargo metadata` invocation fail in CI

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
