### PR TITLE
Tidy up event loop handling code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,14 +86,7 @@ jobs:
           path: target/wasm32-wasi/release/
 
       - name: Test CLI
-        env:
-          CARGO_PROFILE_RELEASE_LTO: off
-        run: |
-          cargo build --package=javy-core --target=wasm32-wasi --release
-          cargo test --package=javy-cli --release -- --nocapture
-
-          cargo build --package=javy-core --target=wasm32-wasi --release --features=experimental_event_loop
-          cargo test --package=javy-cli --features=experimental_event_loop --release -- --nocapture
+        run: CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-cli --release -- --nocapture
 
       - name: Check benchmarks
         run: CARGO_PROFILE_RELEASE_LTO=off cargo check --package=javy-cli --release --benches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,14 @@ jobs:
           path: target/wasm32-wasi/release/
 
       - name: Test CLI
-        run: CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-cli --release -- --nocapture
+        env:
+          CARGO_PROFILE_RELEASE_LTO: off
+        run: |
+          cargo build --package=javy-core --target=wasm32-wasi --release
+          cargo test --package=javy-cli --release -- --nocapture
+
+          cargo build --package=javy-core --target=wasm32-wasi --release --features=experimental_event_loop
+          cargo test --package=javy-cli --features=experimental_event_loop --release -- --nocapture
 
       - name: Check benchmarks
         run: CARGO_PROFILE_RELEASE_LTO=off cargo check --package=javy-cli --release --benches

--- a/.github/workflows/cli-features.yml
+++ b/.github/workflows/cli-features.yml
@@ -1,4 +1,4 @@
-# Tests extra CLI features as and their dependency with core features.
+# Tests extra CLI features and their dependency with core features.
 name: Test CLI Features
 on:
   push:
@@ -21,6 +21,3 @@ jobs:
         run: |
           cargo build --package=javy-core --target=wasm32-wasi --release --features=experimental_event_loop
           cargo test --package=javy-cli --features=experimental_event_loop --release -- --nocapture
-
-
-    

--- a/.github/workflows/cli-features.yml
+++ b/.github/workflows/cli-features.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cli:
     name: Test CLI Features
-    runs_on: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/cli-features.yml
+++ b/.github/workflows/cli-features.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   cli:
-    name: test_cli
+    name: Test CLI Features
     runs_on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cli-features.yml
+++ b/.github/workflows/cli-features.yml
@@ -1,0 +1,26 @@
+# Tests extra CLI features as and their dependency with core features.
+name: Test CLI Features
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  cli:
+    name: test_cli
+    runs_on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/ci-shared-setup
+        with:
+          os: linux
+
+      - name: Test `experimental_event_loop`
+        run: |
+          cargo build --package=javy-core --target=wasm32-wasi --release --features=experimental_event_loop
+          cargo test --package=javy-cli --features=experimental_event_loop --release -- --nocapture
+
+
+    

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -147,6 +147,20 @@ fn test_promises() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "experimental_event_loop")]
+#[test]
+fn test_promise_top_level_await() -> Result<()> {
+    let mut runner = Builder::default()
+        .bin(BIN)
+        .root(sample_scripts())
+        .input("top-level-await.js")
+        .build()?;
+    let (out, _, _) = run(&mut runner, &[]);
+
+    assert_eq!("bar", String::from_utf8(out)?);
+    Ok(())
+}
+
 #[test]
 fn test_exported_functions() -> Result<()> {
     let mut runner = Builder::default()

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -96,11 +96,7 @@ fn test_logging() -> Result<()> {
         "hello world from console.log\nhello world from console.error\n",
         logs.as_str(),
     );
-    if cfg!(feature = "experimental_event_loop") {
-        assert_fuel_consumed_within_threshold(39602, fuel_consumed);
-    } else {
-        assert_fuel_consumed_within_threshold(34169, fuel_consumed);
-    }
+    assert_fuel_consumed_within_threshold(34169, fuel_consumed);
     Ok(())
 }
 

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -96,7 +96,11 @@ fn test_logging() -> Result<()> {
         "hello world from console.log\nhello world from console.error\n",
         logs.as_str(),
     );
-    assert_fuel_consumed_within_threshold(34169, fuel_consumed);
+    if cfg!(feature = "experimental_event_loop") {
+        assert_fuel_consumed_within_threshold(39602, fuel_consumed);
+    } else {
+        assert_fuel_consumed_within_threshold(34169, fuel_consumed);
+    }
     Ok(())
 }
 

--- a/crates/cli/tests/sample-scripts/top-level-await.js
+++ b/crates/cli/tests/sample-scripts/top-level-await.js
@@ -1,0 +1,6 @@
+async function foo() {
+  return Promise.resolve("bar");
+}
+
+const output = new TextEncoder().encode(await foo());
+Javy.IO.writeSync(1, output);

--- a/crates/core/src/execution.rs
+++ b/crates/core/src/execution.rs
@@ -88,12 +88,10 @@ fn handle_maybe_promise(this: Ctx, value: Value) -> javy::quickjs::Result<()> {
 fn ensure_pending_jobs(rt: &Runtime) -> Result<()> {
     if cfg!(feature = "experimental_event_loop") {
         rt.resolve_pending_jobs()
+    } else if rt.has_pending_jobs() {
+        bail!(EVENT_LOOP_ERR);
     } else {
-        if rt.has_pending_jobs() {
-            bail!(EVENT_LOOP_ERR);
-        } else {
-            Ok(())
-        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This commit refactors the event loop handling code, mainly by extracting the common pieces into a reusable function.

Additionally, this commit ensures that the result of `Promise.finish` is corectly handled, which fixes execution of code with top level awaits.

Finally, this commit also ensures that we test the `experimental_event_loop` in CI for the CLI and core crates (follow-up to https://github.com/bytecodealliance/javy/pull/238)

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
