### PR TITLE
CLI: Allow Input from stdin and Output to stdout

### DIFF
--- a/crates/cli/src/js.rs
+++ b/crates/cli/src/js.rs
@@ -32,7 +32,7 @@ pub struct JS {
 }
 
 impl JS {
-    fn from_string(source_code: String) -> JS {
+    pub fn from_string(source_code: String) -> JS {
         JS {
             source_code: Rc::new(source_code),
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 use js::JS;
 use std::fs;
 use std::fs::File;
-use std::io::Write;
+use std::io::{Read, Write};
 use wasm_generator::dynamic as dynamic_generator;
 
 fn main() -> Result<()> {
@@ -21,7 +21,14 @@ fn main() -> Result<()> {
     match args.command {
         Command::EmitProvider(opts) => emit_provider(&opts),
         Command::Compile(opts) => {
-            let js = JS::from_file(&opts.input)?;
+            let js = match opts.input.to_str() {
+                Some("-") => {
+                    let mut content = String::new();
+                    std::io::stdin().read_to_string(&mut content)?;
+                    JS::from_string(content)
+                }
+                _ => JS::from_file(&opts.input)?,
+            };
             let exports = match (&opts.wit, &opts.wit_world) {
                 (None, None) => Ok(vec![]),
                 (None, Some(_)) => Ok(vec![]),
@@ -33,7 +40,12 @@ fn main() -> Result<()> {
             } else {
                 static_generator::generate(&js, exports, opts.no_source_compression)?
             };
-            fs::write(&opts.output, wasm)?;
+            match opts.output.to_str() {
+                Some("-") => {
+                    std::io::stdout().write_all(&wasm)?;
+                }
+                _ => fs::write(&opts.output, wasm)?,
+            }
             Ok(())
         }
     }


### PR DESCRIPTION
## Description of the change

In this PR, the CLI crate is enhanced so that a hyphen (`-`) can be passed for the input argument or the output option instead of a file name indicating that stdio streams should be used.

### Possible usage

```sh
# Use stdin for input and file for output
echo "console.log('Hello World!');" | javy compile - -o my.wasm

# Pipe wasm output into another command
javy compile my.js -o - | wasm-opt ...

# Use no files at all
echo "console.log('Hello World!');" | javy compile - -o - | wasm-opt ...
```

## Why am I making this change?

I built a wrapper around Javy. The wrapper is not inherently working with files, but to make it work with Javy, I need to write the JavaScript to the filesystem and read the WASM from the filesystem. 

Generally, the changes make the CLI of Javy more flexible.

## Checklist

- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [ ] I've updated documentation including crate documentation if necessary.
