### PR TITLE
Change javy-cli to download a specific version of Javy instead of the latest version

### DIFF
--- a/npm/javy-cli/CHANGELOG.md
+++ b/npm/javy-cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Download version 3.0.1 of Javy instead of the latest released version of Javy.
+
 ## [0.2.0] - 2023-08-17
 
 ### Removed

--- a/npm/javy-cli/README.md
+++ b/npm/javy-cli/README.md
@@ -1,8 +1,10 @@
-# Javy npm package
+# javy-cli npm package
+
+**This package is deprecated. Please download the appropriate release from [Javy's release page](https://github.com/bytecodealliance/javy/releases).**
 
 This is the npm package for Javy. The package contains a small Node script
 that downloads the appropriate Javy binary on demand and invokes it with the
-parameters given. 
+parameters given.
 
 ## Usage
 
@@ -12,18 +14,4 @@ $ npm install -g javy-cli
 
 # Directly invoke it via npm
 $ npx javy-cli@latest
-```
-
-## Updating javy
-
-The npm package will automatically download the newest version of Javy if a
-newer version is available.
-
-## Using a specific version of javy
-
-To use a specific version of Javy, set the environment variable
-`FORCE_RELEASE` to the version you would like to use.
-
-```
-FORCE_RELEASE=v1.1.0 npx javy-cli@latest
 ```

--- a/npm/javy-cli/index.js
+++ b/npm/javy-cli/index.js
@@ -10,14 +10,14 @@ import cachedir from "cachedir";
 
 const REPO = "bytecodealliance/javy";
 const NAME = "javy";
+const VERSION = "v3.0.1";
 
 async function main() {
 	try {
-		const version = await getDesiredVersionNumber();
-		if (!(await isBinaryDownloaded(version))) {
-			await downloadBinary(version);
+		if (!(await isBinaryDownloaded(VERSION))) {
+			await downloadBinary(VERSION);
 		}
-		const result = childProcess.spawnSync(binaryPath(version), getArgs(), {
+		const result = childProcess.spawnSync(binaryPath(VERSION), getArgs(), {
 			stdio: "inherit",
 		});
 		process.exitCode = result.status === null ? 1 : result.status;
@@ -30,7 +30,7 @@ async function main() {
 			// We delete the cached binary because that cached binary will never run successfully and
 			// stops `javy-cli` from redownloading the binary.
 			console.error(`${NAME} was not downloaded correctly. Please retry.`);
-			fs.unlinkSync(binaryPath(version));
+			fs.unlinkSync(binaryPath(VERSION));
 		}
 	} catch (e) {
 		console.error(e);
@@ -78,33 +78,6 @@ async function downloadBinary(version) {
 	});
 
 	await fs.promises.chmod(binaryPath(version), 0o775);
-}
-
-/**
- * getDesiredVersionNumber returns the version number of the release that
- * should be downloaded and launched. If the FORCE_RELEASE env variable is set,
- * that will be used as the desired version number, if not, we determine the
- * latest release available on GitHub.
- *
- * GitHub has a public Release API, but  rate limits it per IP, so that the
- * CLI can end up breaking. Instead, we use a little trick. You can download
- * artifacts from the latest release by using `latest` as your version number.
- * The server will respond with a 302 redirect to the artifact's URL. That URL
- * contains the actual release version number, which we can extract.
- */
-async function getDesiredVersionNumber() {
-	if (process.env.FORCE_RELEASE) return process.env.FORCE_RELEASE;
-	const resp = await fetch(
-		`https://github.com/${REPO}/releases/latest/download/lol`,
-		{ redirect: "manual" }
-	);
-	if (resp.status != 302) {
-		throw Error(
-			`Could not determine latest release using the GitHub (Status code ${resp.status
-			}): ${await resp.text().catch(() => "<No error message>")}`
-		);
-	}
-	return resp.headers.get("location").split("/").at(-2);
 }
 
 function binaryUrl(version) {


### PR DESCRIPTION
## Description of the change

Changes `javy-cli` to download a specific version instead of the current latest released version.

## Why am I making this change?

The current behaviour of downloading the latest version of Javy makes it impossible for us to introduce breaking changes to the command line interface in Javy.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
