### PR TITLE
Fix CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,16 +587,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,21 +1002,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,101 +1272,6 @@ dependencies = [
  "phf",
  "rustc-hash",
  "triomphe",
-]
-
-[[package]]
-name = "http"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
-dependencies = [
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
-
-[[package]]
-name = "hyper"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1886,23 +1766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,50 +1864,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
-name = "openssl"
-version = "0.10.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.70",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "outref"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,26 +1921,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.70",
 ]
 
 [[package]]
@@ -2247,33 +2046,6 @@ dependencies = [
  "env_logger",
  "log",
  "rand",
-]
-
-[[package]]
-name = "quickjs-wasm-rs"
-version = "3.1.0"
-dependencies = [
- "anyhow",
- "once_cell",
- "quickcheck",
- "quickjs-wasm-sys",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "quickjs-wasm-sys"
-version = "1.2.1"
-dependencies = [
- "anyhow",
- "bindgen",
- "cc",
- "http-body-util",
- "hyper",
- "hyper-tls",
- "hyper-util",
- "tokio",
- "walkdir",
 ]
 
 [[package]]
@@ -2554,15 +2326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2573,29 +2336,6 @@ name = "scratch"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
-
-[[package]]
-name = "security-framework"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -2635,15 +2375,6 @@ name = "serde-transcode"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
@@ -3183,29 +2914,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "socket2",
- "tokio-macros",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.70",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -3254,33 +2963,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
-
-[[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
-
-[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3321,12 +3003,6 @@ dependencies = [
  "serde",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-arena"
@@ -3430,12 +3106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "vergen"
 version = "8.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3489,15 +3159,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,5 @@
 [workspace]
 members = [
-  "crates/quickjs-wasm-sys",
-  "crates/quickjs-wasm-rs",
   "crates/javy",
   "crates/apis",
   "crates/core",

--- a/Makefile
+++ b/Makefile
@@ -49,15 +49,7 @@ test-config:
 
 tests: test-javy test-core test-runner test-cli test-wpt test-config
 
-fmt: fmt-quickjs-wasm-sys fmt-quickjs-wasm-rs fmt-javy fmt-apis fmt-core fmt-cli
-
-fmt-quickjs-wasm-sys:
-	cargo fmt --package=quickjs-wasm-sys -- --check
-	cargo clippy --package=quickjs-wasm-sys --target=wasm32-wasi --all-targets -- -D warnings
-
-fmt-quickjs-wasm-rs:
-	cargo fmt --package=quickjs-wasm-rs -- --check
-	cargo clippy --package=quickjs-wasm-rs --target=wasm32-wasi --all-targets -- -D warnings
+fmt: fmt-javy fmt-apis fmt-core fmt-cli
 
 fmt-javy:
 	cargo fmt --package=javy -- --check

--- a/crates/cli/src/bytecode.rs
+++ b/crates/cli/src/bytecode.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use wasi_common::{sync::WasiCtxBuilder, WasiCtx};
-use wasmtime::{Engine, Instance, Linker, Memory, Module, Store};
+use wasmtime::{AsContextMut, Engine, Instance, Linker, Memory, Module, Store};
 
 pub const QUICKJS_PROVIDER_MODULE: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/provider.wasm"));
@@ -8,9 +8,9 @@ pub const QUICKJS_PROVIDER_MODULE: &[u8] =
 pub fn compile_source(js_source_code: &[u8]) -> Result<Vec<u8>> {
     let (mut store, instance, memory) = create_wasm_env()?;
     let (js_src_ptr, js_src_len) =
-        copy_source_code_into_instance(js_source_code, &mut store, &instance, &memory)?;
-    let ret_ptr = call_compile(js_src_ptr, js_src_len, &mut store, &instance)?;
-    let bytecode = copy_bytecode_from_instance(ret_ptr, &mut store, &memory)?;
+        copy_source_code_into_instance(js_source_code, store.as_context_mut(), &instance, &memory)?;
+    let ret_ptr = call_compile(js_src_ptr, js_src_len, store.as_context_mut(), &instance)?;
+    let bytecode = copy_bytecode_from_instance(ret_ptr, store.as_context_mut(), &memory)?;
     Ok(bytecode)
 }
 
@@ -24,29 +24,39 @@ fn create_wasm_env() -> Result<(Store<WasiCtx>, Instance, Memory)> {
     )?;
     let wasi = WasiCtxBuilder::new().inherit_stderr().build();
     let mut store = Store::new(&engine, wasi);
-    let instance = linker.instantiate(&mut store, &module)?;
-    let memory = instance.get_memory(&mut store, "memory").unwrap();
+    let instance = linker.instantiate(store.as_context_mut(), &module)?;
+    let memory = instance
+        .get_memory(store.as_context_mut(), "memory")
+        .unwrap();
     Ok((store, instance, memory))
 }
 
 fn copy_source_code_into_instance(
     js_source_code: &[u8],
-    mut store: &mut Store<WasiCtx>,
+    mut store: impl AsContextMut,
     instance: &Instance,
     memory: &Memory,
 ) -> Result<(u32, u32)> {
-    let realloc_fn = instance
-        .get_typed_func::<(u32, u32, u32, u32), u32>(&mut store, "canonical_abi_realloc")?;
+    let realloc_fn = instance.get_typed_func::<(u32, u32, u32, u32), u32>(
+        store.as_context_mut(),
+        "canonical_abi_realloc",
+    )?;
     let js_src_len = js_source_code.len().try_into()?;
 
     let original_ptr = 0;
     let original_size = 0;
     let alignment = 1;
     let size = js_src_len;
-    let js_source_ptr =
-        realloc_fn.call(&mut store, (original_ptr, original_size, alignment, size))?;
+    let js_source_ptr = realloc_fn.call(
+        store.as_context_mut(),
+        (original_ptr, original_size, alignment, size),
+    )?;
 
-    memory.write(&mut store, js_source_ptr.try_into()?, js_source_code)?;
+    memory.write(
+        store.as_context_mut(),
+        js_source_ptr.try_into()?,
+        js_source_code,
+    )?;
 
     Ok((js_source_ptr, js_src_len))
 }
@@ -54,29 +64,30 @@ fn copy_source_code_into_instance(
 fn call_compile(
     js_src_ptr: u32,
     js_src_len: u32,
-    mut store: &mut Store<WasiCtx>,
+    mut store: impl AsContextMut,
     instance: &Instance,
 ) -> Result<u32> {
-    let compile_src_fn = instance.get_typed_func::<(u32, u32), u32>(&mut store, "compile_src")?;
+    let compile_src_fn =
+        instance.get_typed_func::<(u32, u32), u32>(store.as_context_mut(), "compile_src")?;
     let ret_ptr = compile_src_fn
-        .call(&mut store, (js_src_ptr, js_src_len))
+        .call(store.as_context_mut(), (js_src_ptr, js_src_len))
         .map_err(|_| anyhow!("JS compilation failed"))?;
     Ok(ret_ptr)
 }
 
 fn copy_bytecode_from_instance(
     ret_ptr: u32,
-    mut store: &mut Store<WasiCtx>,
+    mut store: impl AsContextMut,
     memory: &Memory,
 ) -> Result<Vec<u8>> {
     let mut ret_buffer = [0; 8];
-    memory.read(&mut store, ret_ptr.try_into()?, &mut ret_buffer)?;
+    memory.read(store.as_context_mut(), ret_ptr.try_into()?, &mut ret_buffer)?;
 
     let bytecode_ptr = u32::from_le_bytes(ret_buffer[0..4].try_into()?);
     let bytecode_len = u32::from_le_bytes(ret_buffer[4..8].try_into()?);
 
     let mut bytecode = vec![0; bytecode_len.try_into()?];
-    memory.read(&mut store, bytecode_ptr.try_into()?, &mut bytecode)?;
+    memory.read(store.as_context(), bytecode_ptr.try_into()?, &mut bytecode)?;
 
     Ok(bytecode)
 }

--- a/crates/cli/tests/dylib_test.rs
+++ b/crates/cli/tests/dylib_test.rs
@@ -161,6 +161,9 @@ fn allocate_memory(
     let orig_ptr = 0;
     let orig_size = 0;
     realloc_func
-        .call(store, (orig_ptr, orig_size, alignment, new_size))
+        .call(
+            store.as_context_mut(),
+            (orig_ptr, orig_size, alignment, new_size),
+        )
         .map_err(Into::into)
 }

--- a/crates/javy/src/alloc.rs
+++ b/crates/javy/src/alloc.rs
@@ -18,8 +18,8 @@ const ZERO_SIZE_ALLOCATION_PTR: *mut u8 = 1 as _;
 ///
 /// 1. Allocate memory of new_size with alignment.
 /// 2. If original_ptr != 0.  
-///   a. copy min(new_size, original_size) bytes from original_ptr to new memory.  
-///   b. de-allocate original_ptr.
+///    a. copy min(new_size, original_size) bytes from original_ptr to new memory.  
+///    b. de-allocate original_ptr.
 /// 3. Return new memory ptr.
 ///
 /// # Safety

--- a/crates/javy/tests/misc.rs
+++ b/crates/javy/tests/misc.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "json")]
 use anyhow::Result;
+#[cfg(feature = "json")]
 use javy::{quickjs::context::EvalOptions, Config, Runtime};
 
 #[cfg(feature = "json")]


### PR DESCRIPTION
## Description of the change

Removing deprecated crates from the workspace, the fmt checks for deprecated crates from the makefile, and a few updates to appease the new version of Clippy:
- changing `&mut store` to `store.as_mut_context()`
- adjust indentation in one set of docs
- mark two imports that are only used if a particular feature is enabled are only imported when that feature is enabled

## Why am I making this change?

CI always uses the latest stable version of Clippy and that version of Clippy introduced new checks which our code fails. I adjusted the workspace and the `Makefile` since I don't want to make changes to the deprecated `quickjs-wasm-sys` or `quickjs-wasm-rs` crates but still want to be able to run `make fmt` to see all failing Clippy checks that would show up in CI.

For the `&mut store` to `store.as_mut_context()` changes, Clippy seems to sometimes get confused when passing `&mut store` to a Wasmtime method that takes `store: impl AsContextMut` and states we should only pass `store`. Unfortunately the Rust compiler obviously complains when passing `store` without the `&mut` if `store` is referenced again later because Rust will treat it as a move. At first I wrote I just updated call sites where Clippy complained but then it looks inconsistent within a function or file where sometimes we're passing `store.as_context_mut()` and sometimes we're passing `&mut store` and it's not obvious why we're using the first in some places and the second in others. So, I decided to make passing stores consistent since the behaviour is identical anyway.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
