### PR TITLE
javy-cli - v3.0.1

### DIFF
--- a/npm/javy-cli/CHANGELOG.md
+++ b/npm/javy-cli/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.0.1] - 2024-08-13
+
 ### Changed
 
 - Download version 3.0.1 of Javy instead of the latest released version of Javy.

--- a/npm/javy-cli/package-lock.json
+++ b/npm/javy-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "javy-cli",
-  "version": "0.2.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "javy-cli",
-      "version": "0.2.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "cachedir": "^2.3.0",

--- a/npm/javy-cli/package.json
+++ b/npm/javy-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javy-cli",
-  "version": "0.2.0",
+  "version": "3.0.1",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Description of the change

Changing `javy-cli` NPM version to 3.0.1. This will be the final version we publish.

## Why am I making this change?

I need to increment the version to publish the package. It should be at least a major version bump since we're changing the behaviour of the package in a potentially breaking way. I figure having the version match the version of Javy that it's downloading makes sense but I'm open to using a different version.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
