### PR TITLE
Stop using javy-cli in javy tests

### DIFF
--- a/npm/javy/package-lock.json
+++ b/npm/javy/package-lock.json
@@ -10,7 +10,6 @@
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@rollup/plugin-node-resolve": "^15.0.1",
-				"javy-cli": "^0.2.0",
 				"rollup": "^4.1.4",
 				"rollup-plugin-swc": "^0.2.1",
 				"typescript": "^5.2.2",
@@ -1026,15 +1025,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/cachedir": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
-			"integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/commander": {
 			"version": "9.5.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
@@ -1056,15 +1046,6 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
-		},
-		"node_modules/data-uri-to-buffer": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-			"dev": true,
-			"engines": {
-				"node": ">= 12"
-			}
 		},
 		"node_modules/de-indent": {
 			"version": "1.0.2",
@@ -1165,41 +1146,6 @@
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
-		},
-		"node_modules/fetch-blob": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/jimmywarting"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/jimmywarting"
-				}
-			],
-			"dependencies": {
-				"node-domexception": "^1.0.0",
-				"web-streams-polyfill": "^3.0.3"
-			},
-			"engines": {
-				"node": "^12.20 || >= 14.13"
-			}
-		},
-		"node_modules/formdata-polyfill": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-			"dev": true,
-			"dependencies": {
-				"fetch-blob": "^3.1.2"
-			},
-			"engines": {
-				"node": ">=12.20.0"
-			}
 		},
 		"node_modules/fs-extra": {
 			"version": "7.0.1",
@@ -1313,19 +1259,6 @@
 			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
 			"dev": true
 		},
-		"node_modules/javy-cli": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/javy-cli/-/javy-cli-0.2.0.tgz",
-			"integrity": "sha512-kxY6+q+1bhXjfFb5o8ETlfKtxEMajSqNB/0G1l9tVfFU0RMYiDHHRQgs2r8cSAZhkEgs2gSKlpxgopQ4NuL6Ig==",
-			"dev": true,
-			"dependencies": {
-				"cachedir": "^2.3.0",
-				"node-fetch": "^3.2.10"
-			},
-			"bin": {
-				"javy": "index.js"
-			}
-		},
 		"node_modules/jju": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
@@ -1438,43 +1371,6 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-			}
-		},
-		"node_modules/node-domexception": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/jimmywarting"
-				},
-				{
-					"type": "github",
-					"url": "https://paypal.me/jimmywarting"
-				}
-			],
-			"engines": {
-				"node": ">=10.5.0"
-			}
-		},
-		"node_modules/node-fetch": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
-			"integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
-			"dev": true,
-			"dependencies": {
-				"data-uri-to-buffer": "^4.0.0",
-				"fetch-blob": "^3.1.4",
-				"formdata-polyfill": "^4.0.10"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/node-fetch"
 			}
 		},
 		"node_modules/path-browserify": {
@@ -1856,15 +1752,6 @@
 			},
 			"peerDependencies": {
 				"typescript": "*"
-			}
-		},
-		"node_modules/web-streams-polyfill": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-			"dev": true,
-			"engines": {
-				"node": ">= 8"
 			}
 		},
 		"node_modules/yallist": {
@@ -2509,12 +2396,6 @@
 			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
 			"dev": true
 		},
-		"cachedir": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
-			"integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
-			"dev": true
-		},
 		"commander": {
 			"version": "9.5.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
@@ -2532,12 +2413,6 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true
-		},
-		"data-uri-to-buffer": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
 			"dev": true
 		},
 		"de-indent": {
@@ -2615,25 +2490,6 @@
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
-		},
-		"fetch-blob": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-			"dev": true,
-			"requires": {
-				"node-domexception": "^1.0.0",
-				"web-streams-polyfill": "^3.0.3"
-			}
-		},
-		"formdata-polyfill": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-			"dev": true,
-			"requires": {
-				"fetch-blob": "^3.1.2"
-			}
 		},
 		"fs-extra": {
 			"version": "7.0.1",
@@ -2715,16 +2571,6 @@
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
 			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
 			"dev": true
-		},
-		"javy-cli": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/javy-cli/-/javy-cli-0.2.0.tgz",
-			"integrity": "sha512-kxY6+q+1bhXjfFb5o8ETlfKtxEMajSqNB/0G1l9tVfFU0RMYiDHHRQgs2r8cSAZhkEgs2gSKlpxgopQ4NuL6Ig==",
-			"dev": true,
-			"requires": {
-				"cachedir": "^2.3.0",
-				"node-fetch": "^3.2.10"
-			}
 		},
 		"jju": {
 			"version": "1.4.0",
@@ -2815,23 +2661,6 @@
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
 			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
 			"dev": true
-		},
-		"node-domexception": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-			"dev": true
-		},
-		"node-fetch": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
-			"integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
-			"dev": true,
-			"requires": {
-				"data-uri-to-buffer": "^4.0.0",
-				"fetch-blob": "^3.1.4",
-				"formdata-polyfill": "^4.0.10"
-			}
 		},
 		"path-browserify": {
 			"version": "1.0.1",
@@ -3060,12 +2889,6 @@
 				"@vue/language-core": "1.8.27",
 				"semver": "^7.5.4"
 			}
-		},
-		"web-streams-polyfill": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-			"dev": true
 		},
 		"yallist": {
 			"version": "4.0.0",

--- a/npm/javy/package.json
+++ b/npm/javy/package.json
@@ -23,7 +23,6 @@
 	},
 	"devDependencies": {
 		"@rollup/plugin-node-resolve": "^15.0.1",
-		"javy-cli": "^0.2.0",
 		"rollup": "^4.1.4",
 		"rollup-plugin-swc": "^0.2.1",
 		"typescript": "^5.2.2",


### PR DESCRIPTION
## Description of the change

Stop using `javy-cli` NPM package in `javy` NPM package tests.

## Why am I making this change?

The `javy-cli` NPM package is deprecated so we should stop using it.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
