### PR TITLE
Remove javy-cli from NPM publishing workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -7,11 +7,8 @@ on:
 
 jobs:
   publish_npm:
-    name: Publish ${{ matrix.package }} NPM package
+    name: Publish javy NPM package
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package: [javy, javy-cli]
     steps:
       - uses: actions/checkout@v4
 
@@ -21,20 +18,19 @@ jobs:
 
       - name: Install package dependencies
         run: npm install
-        working-directory: npm/${{ matrix.package }}
+        working-directory: npm/javy
 
       - name: Build NPM package
-        if: matrix.package == 'javy'
         run: npm run build
-        working-directory: npm/${{ matrix.package }}
+        working-directory: npm/javy
 
       - name: Publish NPM package if new version
         run: |
-          if [[ $(cat package.json | jq -r .version) == $(npm view ${{ matrix.package }} version) ]]; then
+          if [[ $(cat package.json | jq -r .version) == $(npm view javy version) ]]; then
             echo "Skipping publish because the version is already published"
           else
             npm publish
           fi
-        working-directory: npm/${{ matrix.package }}
+        working-directory: npm/javy
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description of the change

Updating the NPM package publishing workflow to remove `javy-cli` from it.

## Why am I making this change?

I should've done this as part of #726 but I missed it in the search results (there's also a lot of references to the `javy-cli` crate in a bunch of places). At the moment this is causing a GitHub Action failure after merging to the main branch.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
