### PR TITLE
Add `-C` flag to build command

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -90,7 +90,7 @@ pub struct BuildCommandOpts {
 -C dynamic[=y|n] -- Creates a smaller module that requires a dynamically linked QuickJS provider Wasm module to execute (see `emit-provider` command).
 -C wit=path -- Optional path to WIT file describing exported functions. Only supports function exports with no arguments and no return values.
 -C wit-world=val -- Optional WIT world name for WIT file. Must be specified if WIT is file path is specified.
--C no-source-compression[=y|n] -- Disable source code compression, which reduces compile time at the expense of generating larger WebAssembly files.
+-C source-compression[=y|n] -- Enable source code compression, which generates smaller WebAssembly files at the cost of increased compile time. Defaults to enabled.
     "
     )]
     /// Codegen options.
@@ -115,8 +115,8 @@ pub struct CodegenOptionGroup {
     /// Optional path to WIT file describing exported functions.
     /// Only supports function exports with no arguments and no return values.
     pub wit_world: Option<String>,
-    /// Disable source code compression, which reduces compile time at the expense of generating larger WebAssembly files.
-    pub no_source_compression: bool,
+    /// Enable source code compression, which generates smaller WebAssembly files at the cost of increased compile time. Defaults to enabled.
+    pub source_compression: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -130,8 +130,8 @@ pub enum CodegenOption {
     /// Optional path to WIT file describing exported functions.
     /// Only supports function exports with no arguments and no return values.
     WitWorld(String),
-    /// Disable source code compression, which reduces compile time at the expense of generating larger WebAssembly files.
-    NoSourceCompression(bool),
+    /// Enable source code compression, which generates smaller WebAssembly files at the cost of increased compile time. Defaults to enabled.
+    SourceCompression(bool),
 }
 
 impl FromStr for CodegenOption {
@@ -156,11 +156,11 @@ impl FromStr for CodegenOption {
                     .ok_or_else(|| anyhow!("Must provide value for wit-world"))?
                     .to_string(),
             ),
-            "no-source-compression" => Self::NoSourceCompression(match value {
+            "source-compression" => Self::SourceCompression(match value {
                 None => true,
                 Some("y") => true,
                 Some("n") => false,
-                _ => bail!("Invalid value for no-source-compression"),
+                _ => bail!("Invalid value for source-compression"),
             }),
             _ => bail!("Invalid codegen key"),
         };
@@ -173,14 +173,14 @@ impl From<Vec<CodegenOption>> for CodegenOptionGroup {
         let mut dynamic = false;
         let mut wit = None;
         let mut wit_world = None;
-        let mut no_source_compression = false;
+        let mut source_compression = true;
 
         for option in value {
             match option {
                 CodegenOption::Dynamic(enabled) => dynamic = enabled,
                 CodegenOption::Wit(path) => wit = Some(path),
                 CodegenOption::WitWorld(world) => wit_world = Some(world),
-                CodegenOption::NoSourceCompression(enabled) => no_source_compression = enabled,
+                CodegenOption::SourceCompression(enabled) => source_compression = enabled,
             }
         }
 
@@ -188,7 +188,7 @@ impl From<Vec<CodegenOption>> for CodegenOptionGroup {
             dynamic,
             wit,
             wit_world,
-            no_source_compression,
+            source_compression,
         }
     }
 }

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -39,13 +39,6 @@ pub enum Command {
     EmitProvider(EmitProviderCommandOpts),
 }
 
-impl Command {
-    /// Returns true if it is [`Command::Compile`].
-    pub fn is_compile(&self) -> bool {
-        matches!(self, Command::Compile(_))
-    }
-}
-
 #[derive(Debug, Parser)]
 pub struct CompileCommandOpts {
     #[arg(value_name = "INPUT", required = true)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -56,13 +56,10 @@ fn main() -> Result<()> {
         }
         Command::Build(opts) => {
             let js = JS::from_file(&opts.input)?;
-            let codegen: CodegenOptionGroup = opts.codegen.clone().into();
+            let codegen: CodegenOptionGroup = opts.codegen.clone().try_into()?;
             let mut builder = CodeGenBuilder::new();
             builder
-                .wit_opts(WitOptions::from_tuple((
-                    codegen.wit.clone(),
-                    codegen.wit_world.clone(),
-                ))?)
+                .wit_opts(codegen.wit)
                 .source_compression(codegen.source_compression)
                 .provider_version("2");
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -63,7 +63,7 @@ fn main() -> Result<()> {
                     codegen.wit.clone(),
                     codegen.wit_world.clone(),
                 ))?)
-                .source_compression(!codegen.no_source_compression)
+                .source_compression(codegen.source_compression)
                 .provider_version("2");
 
             let mut gen = if codegen.dynamic {

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
-use javy_runner::Builder;
+use javy_runner::{Builder, JavyCommand};
 
 pub fn run_with_compile_and_build<F>(test: F) -> Result<()>
 where
     F: Fn(&mut Builder) -> Result<()>,
 {
-    test(Builder::default().use_compile())?;
-    test(&mut Builder::default())?;
+    test(Builder::default().command(JavyCommand::Compile))?;
+    test(Builder::default().command(JavyCommand::Build))?;
     Ok(())
 }

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+use javy_runner::Builder;
+
+pub fn run_with_compile_and_build<F>(test: F) -> Result<()>
+where
+    F: Fn(&mut Builder) -> Result<()>,
+{
+    test(Builder::default().use_compile())?;
+    test(&mut Builder::default())?;
+    Ok(())
+}

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -1,129 +1,148 @@
 use anyhow::Result;
-use javy_runner::{Builder, Runner, RunnerError};
+use javy_runner::{Runner, RunnerError};
 use std::path::PathBuf;
 use std::str;
+
+mod common;
+use common::run_with_compile_and_build;
 
 static BIN: &str = env!("CARGO_BIN_EXE_javy");
 static ROOT: &str = env!("CARGO_MANIFEST_DIR");
 
 #[test]
 fn test_identity() -> Result<()> {
-    let mut runner = Builder::default().root(sample_scripts()).bin(BIN).build()?;
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder.root(sample_scripts()).bin(BIN).build()?;
 
-    let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 42);
-    assert_eq!(42, output);
-    assert_fuel_consumed_within_threshold(47_773, fuel_consumed);
-    Ok(())
+        let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 42);
+        assert_eq!(42, output);
+        assert_fuel_consumed_within_threshold(47_773, fuel_consumed);
+        Ok(())
+    })
 }
 
 #[test]
 fn test_fib() -> Result<()> {
-    let mut runner = Builder::default()
-        .root(sample_scripts())
-        .bin(BIN)
-        .input("fib.js")
-        .build()?;
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .root(sample_scripts())
+            .bin(BIN)
+            .input("fib.js")
+            .build()?;
 
-    let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 5);
-    assert_eq!(8, output);
-    assert_fuel_consumed_within_threshold(66_007, fuel_consumed);
-    Ok(())
+        let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 5);
+        assert_eq!(8, output);
+        assert_fuel_consumed_within_threshold(66_007, fuel_consumed);
+        Ok(())
+    })
 }
 
 #[test]
 fn test_recursive_fib() -> Result<()> {
-    let mut runner = Builder::default()
-        .bin(BIN)
-        .root(sample_scripts())
-        .input("recursive-fib.js")
-        .build()?;
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .bin(BIN)
+            .root(sample_scripts())
+            .input("recursive-fib.js")
+            .build()?;
 
-    let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 5);
-    assert_eq!(8, output);
-    assert_fuel_consumed_within_threshold(69_306, fuel_consumed);
-    Ok(())
+        let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 5);
+        assert_eq!(8, output);
+        assert_fuel_consumed_within_threshold(69_306, fuel_consumed);
+        Ok(())
+    })
 }
 
 #[test]
 fn test_str() -> Result<()> {
-    let mut runner = Builder::default()
-        .root(sample_scripts())
-        .bin(BIN)
-        .input("str.js")
-        .build()?;
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .root(sample_scripts())
+            .bin(BIN)
+            .input("str.js")
+            .build()?;
 
-    let (output, _, fuel_consumed) = run(&mut runner, "hello".as_bytes());
-    assert_eq!("world".as_bytes(), output);
-    assert_fuel_consumed_within_threshold(142_849, fuel_consumed);
-    Ok(())
+        let (output, _, fuel_consumed) = run(&mut runner, "hello".as_bytes());
+        assert_eq!("world".as_bytes(), output);
+        assert_fuel_consumed_within_threshold(142_849, fuel_consumed);
+        Ok(())
+    })
 }
 
 #[test]
 fn test_encoding() -> Result<()> {
-    let mut runner = Builder::default()
-        .root(sample_scripts())
-        .bin(BIN)
-        .input("text-encoding.js")
-        .build()?;
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .root(sample_scripts())
+            .bin(BIN)
+            .input("text-encoding.js")
+            .build()?;
 
-    let (output, _, fuel_consumed) = run(&mut runner, "hello".as_bytes());
-    assert_eq!("el".as_bytes(), output);
-    assert_fuel_consumed_within_threshold(258_197, fuel_consumed);
+        let (output, _, fuel_consumed) = run(&mut runner, "hello".as_bytes());
+        assert_eq!("el".as_bytes(), output);
+        assert_fuel_consumed_within_threshold(258_197, fuel_consumed);
 
-    let (output, _, _) = run(&mut runner, "invalid".as_bytes());
-    assert_eq!("true".as_bytes(), output);
+        let (output, _, _) = run(&mut runner, "invalid".as_bytes());
+        assert_eq!("true".as_bytes(), output);
 
-    let (output, _, _) = run(&mut runner, "invalid_fatal".as_bytes());
-    assert_eq!("The encoded data was not valid utf-8".as_bytes(), output);
+        let (output, _, _) = run(&mut runner, "invalid_fatal".as_bytes());
+        assert_eq!("The encoded data was not valid utf-8".as_bytes(), output);
 
-    let (output, _, _) = run(&mut runner, "test".as_bytes());
-    assert_eq!("test2".as_bytes(), output);
-    Ok(())
+        let (output, _, _) = run(&mut runner, "test".as_bytes());
+        assert_eq!("test2".as_bytes(), output);
+        Ok(())
+    })
 }
 
 #[test]
 fn test_logging() -> Result<()> {
-    let mut runner = Builder::default()
-        .root(sample_scripts())
-        .bin(BIN)
-        .input("logging.js")
-        .build()?;
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .root(sample_scripts())
+            .bin(BIN)
+            .input("logging.js")
+            .build()?;
 
-    let (_output, logs, fuel_consumed) = run(&mut runner, &[]);
-    assert_eq!(
-        "hello world from console.log\nhello world from console.error\n",
-        logs.as_str(),
-    );
-    assert_fuel_consumed_within_threshold(34169, fuel_consumed);
-    Ok(())
+        let (_output, logs, fuel_consumed) = run(&mut runner, &[]);
+        assert_eq!(
+            "hello world from console.log\nhello world from console.error\n",
+            logs.as_str(),
+        );
+        assert_fuel_consumed_within_threshold(34169, fuel_consumed);
+        Ok(())
+    })
 }
 
 #[test]
 fn test_readme_script() -> Result<()> {
-    let mut runner = Builder::default()
-        .root(sample_scripts())
-        .bin(BIN)
-        .input("readme.js")
-        .build()?;
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .root(sample_scripts())
+            .bin(BIN)
+            .input("readme.js")
+            .build()?;
 
-    let (output, _, fuel_consumed) = run(&mut runner, r#"{ "n": 2, "bar": "baz" }"#.as_bytes());
-    assert_eq!(r#"{"foo":3,"newBar":"baz!"}"#.as_bytes(), output);
-    assert_fuel_consumed_within_threshold(270_919, fuel_consumed);
-    Ok(())
+        let (output, _, fuel_consumed) = run(&mut runner, r#"{ "n": 2, "bar": "baz" }"#.as_bytes());
+        assert_eq!(r#"{"foo":3,"newBar":"baz!"}"#.as_bytes(), output);
+        assert_fuel_consumed_within_threshold(270_919, fuel_consumed);
+        Ok(())
+    })
 }
 
 #[cfg(feature = "experimental_event_loop")]
 #[test]
 fn test_promises() -> Result<()> {
-    let mut runner = Builder::default()
-        .bin(BIN)
-        .root(sample_scripts())
-        .input("promise.js")
-        .build()?;
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .bin(BIN)
+            .root(sample_scripts())
+            .input("promise.js")
+            .build()?;
 
-    let (output, _, _) = run(&mut runner, &[]);
-    assert_eq!("\"foo\"\"bar\"".as_bytes(), output);
-    Ok(())
+        let (output, _, _) = run(&mut runner, &[]);
+        assert_eq!("\"foo\"\"bar\"".as_bytes(), output);
+        Ok(())
+    })
 }
 
 #[cfg(not(feature = "experimental_event_loop"))]
@@ -131,166 +150,190 @@ fn test_promises() -> Result<()> {
 fn test_promises() -> Result<()> {
     use javy_runner::RunnerError;
 
-    let mut runner = Builder::default()
-        .root(sample_scripts())
-        .bin(BIN)
-        .input("promise.js")
-        .build()?;
-    let res = runner.exec(&[]);
-    let err = res.err().unwrap().downcast::<RunnerError>().unwrap();
-    assert!(str::from_utf8(&err.stderr)
-        .unwrap()
-        .contains("Pending jobs in the event queue."));
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .root(sample_scripts())
+            .bin(BIN)
+            .input("promise.js")
+            .build()?;
+        let res = runner.exec(&[]);
+        let err = res.err().unwrap().downcast::<RunnerError>().unwrap();
+        assert!(str::from_utf8(&err.stderr)
+            .unwrap()
+            .contains("Pending jobs in the event queue."));
 
-    Ok(())
+        Ok(())
+    })
 }
 
 #[cfg(feature = "experimental_event_loop")]
 #[test]
 fn test_promise_top_level_await() -> Result<()> {
-    let mut runner = Builder::default()
-        .bin(BIN)
-        .root(sample_scripts())
-        .input("top-level-await.js")
-        .build()?;
-    let (out, _, _) = run(&mut runner, &[]);
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .bin(BIN)
+            .root(sample_scripts())
+            .input("top-level-await.js")
+            .build()?;
+        let (out, _, _) = run(&mut runner, &[]);
 
-    assert_eq!("bar", String::from_utf8(out)?);
-    Ok(())
+        assert_eq!("bar", String::from_utf8(out)?);
+        Ok(())
+    })
 }
 
 #[test]
 fn test_exported_functions() -> Result<()> {
-    let mut runner = Builder::default()
-        .bin(BIN)
-        .root(sample_scripts())
-        .input("exported-fn.js")
-        .wit("exported-fn.wit")
-        .world("exported-fn")
-        .build()?;
-    let (_, logs, fuel_consumed) = run_fn(&mut runner, "foo", &[]);
-    assert_eq!("Hello from top-level\nHello from foo\n", logs);
-    assert_fuel_consumed_within_threshold(80023, fuel_consumed);
-    let (_, logs, _) = run_fn(&mut runner, "foo-bar", &[]);
-    assert_eq!("Hello from top-level\nHello from fooBar\n", logs);
-    Ok(())
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .bin(BIN)
+            .root(sample_scripts())
+            .input("exported-fn.js")
+            .wit("exported-fn.wit")
+            .world("exported-fn")
+            .build()?;
+        let (_, logs, fuel_consumed) = run_fn(&mut runner, "foo", &[]);
+        assert_eq!("Hello from top-level\nHello from foo\n", logs);
+        assert_fuel_consumed_within_threshold(80023, fuel_consumed);
+        let (_, logs, _) = run_fn(&mut runner, "foo-bar", &[]);
+        assert_eq!("Hello from top-level\nHello from fooBar\n", logs);
+        Ok(())
+    })
 }
 
 #[cfg(feature = "experimental_event_loop")]
 #[test]
 fn test_exported_promises() -> Result<()> {
-    let mut runner = Builder::default()
-        .bin(BIN)
-        .root(sample_scripts())
-        .input("exported-promise-fn.js")
-        .wit("exported-promise-fn.wit")
-        .world("exported-promise-fn")
-        .build()?;
-    let (_, logs, _) = run_fn(&mut runner, "foo", &[]);
-    assert_eq!("Top-level\ninside foo\n", logs);
-    Ok(())
+    use clap::builder;
+
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .bin(BIN)
+            .root(sample_scripts())
+            .input("exported-promise-fn.js")
+            .wit("exported-promise-fn.wit")
+            .world("exported-promise-fn")
+            .build()?;
+        let (_, logs, _) = run_fn(&mut runner, "foo", &[]);
+        assert_eq!("Top-level\ninside foo\n", logs);
+        Ok(())
+    })
 }
 
 #[test]
 fn test_exported_functions_without_flag() -> Result<()> {
-    let mut runner = Builder::default()
-        .root(sample_scripts())
-        .bin(BIN)
-        .input("exported-fn.js")
-        .build()?;
-    let res = runner.exec_func("foo", &[]);
-    assert_eq!(
-        "failed to find function export `foo`",
-        res.err().unwrap().to_string()
-    );
-    Ok(())
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .root(sample_scripts())
+            .bin(BIN)
+            .input("exported-fn.js")
+            .build()?;
+        let res = runner.exec_func("foo", &[]);
+        assert_eq!(
+            "failed to find function export `foo`",
+            res.err().unwrap().to_string()
+        );
+        Ok(())
+    })
 }
 
 #[test]
 fn test_exported_function_without_semicolons() -> Result<()> {
-    let mut runner = Builder::default()
-        .root(sample_scripts())
-        .bin(BIN)
-        .input("exported-fn-no-semicolon.js")
-        .wit("exported-fn-no-semicolon.wit")
-        .world("exported-fn")
-        .build()?;
-    run_fn(&mut runner, "foo", &[]);
-    Ok(())
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .root(sample_scripts())
+            .bin(BIN)
+            .input("exported-fn-no-semicolon.js")
+            .wit("exported-fn-no-semicolon.wit")
+            .world("exported-fn")
+            .build()?;
+        run_fn(&mut runner, "foo", &[]);
+        Ok(())
+    })
 }
 
 #[test]
 fn test_producers_section_present() -> Result<()> {
-    let runner = Builder::default()
-        .root(sample_scripts())
-        .bin(BIN)
-        .input("readme.js")
-        .build()?;
+    run_with_compile_and_build(|builder| {
+        let runner = builder
+            .root(sample_scripts())
+            .bin(BIN)
+            .input("readme.js")
+            .build()?;
 
-    runner.assert_producers()
+        runner.assert_producers()
+    })
 }
 
 #[test]
 fn test_error_handling() -> Result<()> {
-    let mut runner = Builder::default()
-        .root(sample_scripts())
-        .bin(BIN)
-        .input("error.js")
-        .build()?;
-    let result = runner.exec(&[]);
-    let err = result.err().unwrap().downcast::<RunnerError>().unwrap();
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .root(sample_scripts())
+            .bin(BIN)
+            .input("error.js")
+            .build()?;
+        let result = runner.exec(&[]);
+        let err = result.err().unwrap().downcast::<RunnerError>().unwrap();
 
-    let expected_log_output = "Error:2:9 error\n    at error (function.mjs:2:9)\n    at <anonymous> (function.mjs:5:1)\n\n";
+        let expected_log_output = "Error:2:9 error\n    at error (function.mjs:2:9)\n    at <anonymous> (function.mjs:5:1)\n\n";
 
-    assert_eq!(expected_log_output, str::from_utf8(&err.stderr).unwrap());
-    Ok(())
+        assert_eq!(expected_log_output, str::from_utf8(&err.stderr).unwrap());
+        Ok(())
+    })
 }
 
 #[test]
 fn test_same_module_outputs_different_random_result() -> Result<()> {
-    let mut runner = Builder::default()
-        .bin(BIN)
-        .root(sample_scripts())
-        .input("random.js")
-        .build()?;
-    let (output, _, _) = runner.exec(&[]).unwrap();
-    let (output2, _, _) = runner.exec(&[]).unwrap();
-    // In theory these could be equal with a correct implementation but it's very unlikely.
-    assert!(output != output2);
-    // Don't check fuel consumed because fuel consumed can be different from run to run. See
-    // https://github.com/bytecodealliance/javy/issues/401 for investigating the cause.
-    Ok(())
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .bin(BIN)
+            .root(sample_scripts())
+            .input("random.js")
+            .build()?;
+        let (output, _, _) = runner.exec(&[]).unwrap();
+        let (output2, _, _) = runner.exec(&[]).unwrap();
+        // In theory these could be equal with a correct implementation but it's very unlikely.
+        assert!(output != output2);
+        // Don't check fuel consumed because fuel consumed can be different from run to run. See
+        // https://github.com/bytecodealliance/javy/issues/401 for investigating the cause.
+        Ok(())
+    })
 }
 
 #[test]
 fn test_exported_default_arrow_fn() -> Result<()> {
-    let mut runner = Builder::default()
-        .bin(BIN)
-        .root(sample_scripts())
-        .input("exported-default-arrow-fn.js")
-        .wit("exported-default-arrow-fn.wit")
-        .world("exported-arrow")
-        .build()?;
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .bin(BIN)
+            .root(sample_scripts())
+            .input("exported-default-arrow-fn.js")
+            .wit("exported-default-arrow-fn.wit")
+            .world("exported-arrow")
+            .build()?;
 
-    let (_, logs, fuel_consumed) = run_fn(&mut runner, "default", &[]);
-    assert_eq!(logs, "42\n");
-    assert_fuel_consumed_within_threshold(76706, fuel_consumed);
-    Ok(())
+        let (_, logs, fuel_consumed) = run_fn(&mut runner, "default", &[]);
+        assert_eq!(logs, "42\n");
+        assert_fuel_consumed_within_threshold(76706, fuel_consumed);
+        Ok(())
+    })
 }
 
 #[test]
 fn test_exported_default_fn() -> Result<()> {
-    let mut runner = Builder::default()
-        .bin(BIN)
-        .root(sample_scripts())
-        .input("exported-default-fn.js")
-        .wit("exported-default-fn.wit")
-        .world("exported-default")
-        .build()?;
-    let (_, logs, fuel_consumed) = run_fn(&mut runner, "default", &[]);
-    assert_eq!(logs, "42\n");
-    assert_fuel_consumed_within_threshold(77909, fuel_consumed);
-    Ok(())
+    run_with_compile_and_build(|builder| {
+        let mut runner = builder
+            .bin(BIN)
+            .root(sample_scripts())
+            .input("exported-default-fn.js")
+            .wit("exported-default-fn.wit")
+            .world("exported-default")
+            .build()?;
+        let (_, logs, fuel_consumed) = run_fn(&mut runner, "default", &[]);
+        assert_eq!(logs, "42\n");
+        assert_fuel_consumed_within_threshold(77909, fuel_consumed);
+        Ok(())
+    })
 }
 
 fn sample_scripts() -> PathBuf {

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -13,6 +13,7 @@ use wasmtime::{
     AsContextMut, Config, Engine, ExternType, Instance, Linker, Module, OptLevel, Store,
 };
 
+#[derive(Clone)]
 pub struct Builder {
     /// The JS source.
     input: PathBuf,
@@ -27,6 +28,8 @@ pub struct Builder {
     built: bool,
     /// Preload the module at path, using the given instance name.
     preload: Option<(String, PathBuf)>,
+    /// Whether to use the `compile` or `build` command.
+    use_compile: bool,
 }
 
 impl Default for Builder {
@@ -39,6 +42,7 @@ impl Default for Builder {
             root: Default::default(),
             built: false,
             preload: None,
+            use_compile: false,
         }
     }
 }
@@ -74,6 +78,11 @@ impl Builder {
         self
     }
 
+    pub fn use_compile(&mut self) -> &mut Self {
+        self.use_compile = true;
+        self
+    }
+
     pub fn build(&mut self) -> Result<Runner> {
         if self.built {
             bail!("Builder already used to build a runner")
@@ -93,14 +102,19 @@ impl Builder {
             root,
             built: _,
             preload,
+            use_compile,
         } = std::mem::take(self);
 
         self.built = true;
 
-        if let Some(preload) = preload {
-            Runner::build_dynamic(bin_path, root, input, wit, world, preload)
+        if use_compile {
+            if let Some(preload) = preload {
+                Runner::compile_dynamic(bin_path, root, input, wit, world, preload)
+            } else {
+                Runner::compile_static(bin_path, root, input, wit, world)
+            }
         } else {
-            Runner::build_static(bin_path, root, input, wit, world)
+            Runner::build(bin_path, root, input, wit, world, preload)
         }
     }
 }
@@ -156,7 +170,46 @@ impl StoreContext {
 }
 
 impl Runner {
-    fn build_static(
+    fn build(
+        bin: String,
+        root: PathBuf,
+        source: impl AsRef<Path>,
+        wit: Option<PathBuf>,
+        world: Option<String>,
+        preload: Option<(String, PathBuf)>,
+    ) -> Result<Self> {
+        // This directory is unique and will automatically get deleted
+        // when `tempdir` goes out of scope.
+        let tempdir = tempfile::tempdir()?;
+        let wasm_file = Self::out_wasm(&tempdir);
+        let js_file = root.join(source);
+        let wit_file = wit.map(|p| root.join(p));
+
+        let args = Self::build_args(&js_file, &wasm_file, &wit_file, &world, preload.is_some());
+
+        Self::exec_command(bin, root, args)?;
+
+        let wasm = fs::read(&wasm_file)?;
+
+        let engine = Self::setup_engine();
+        let linker = Self::setup_linker(&engine)?;
+
+        let preload = preload
+            .map(|(name, path)| {
+                let module = fs::read(path)?;
+                Ok::<(String, Vec<u8>), anyhow::Error>((name, module))
+            })
+            .transpose()?;
+
+        Ok(Self {
+            wasm,
+            linker,
+            initial_fuel: u64::MAX,
+            preload,
+        })
+    }
+
+    fn compile_static(
         bin: String,
         root: PathBuf,
         source: impl AsRef<Path>,
@@ -170,7 +223,7 @@ impl Runner {
         let js_file = root.join(source);
         let wit_file = wit.map(|p| root.join(p));
 
-        let args = Self::base_build_args(&js_file, &wasm_file, &wit_file, &world);
+        let args = Self::base_compile_args(&js_file, &wasm_file, &wit_file, &world);
 
         Self::exec_command(bin, root, args)?;
 
@@ -187,7 +240,7 @@ impl Runner {
         })
     }
 
-    pub fn build_dynamic(
+    pub fn compile_dynamic(
         bin: String,
         root: PathBuf,
         source: impl AsRef<Path>,
@@ -200,7 +253,7 @@ impl Runner {
         let js_file = root.join(source);
         let wit_file = wit.map(|p| root.join(p));
 
-        let mut args = Self::base_build_args(&js_file, &wasm_file, &wit_file, &world);
+        let mut args = Self::base_compile_args(&js_file, &wasm_file, &wit_file, &world);
         args.push("-d".to_string());
 
         Self::exec_command(bin, root, args)?;
@@ -314,7 +367,36 @@ impl Runner {
         file
     }
 
-    fn base_build_args(
+    fn build_args(
+        input: &Path,
+        out: &Path,
+        wit: &Option<PathBuf>,
+        world: &Option<String>,
+        dynamic: bool,
+    ) -> Vec<String> {
+        let mut args = vec![
+            "build".to_string(),
+            input.to_str().unwrap().to_string(),
+            "-o".to_string(),
+            out.to_str().unwrap().to_string(),
+        ];
+
+        if let (Some(wit), Some(world)) = (wit, world) {
+            args.push("-C".to_string());
+            args.push(format!("wit={}", wit.to_str().unwrap()));
+            args.push("-C".to_string());
+            args.push(format!("wit-world={world}"));
+        }
+
+        if dynamic {
+            args.push("-C".to_string());
+            args.push("dynamic".to_string());
+        }
+
+        args
+    }
+
+    fn base_compile_args(
         input: &Path,
         out: &Path,
         wit: &Option<PathBuf>,


### PR DESCRIPTION
## Description of the change

I want to get early feedback on adding support for the `-C` flag documented in #702 so I can iterate on the draft as we figure out what makes sense to change.

There's a few changes:
- `CompileAndBuildCommandOpts` -> `CompileCommandOpts` and `BuildCommandOpts` including splitting out the handling of the `compile` and build` subcommands.
- `BuildCommandOpts` introduces a few extra types to try and get the repeated `-C` flags to play nicely with `clap`. There's a lot of copying triple slash comments around, none of it is picked up by `clap` so not sure if there's something better we can do. I looked at implementing `ValueEnum` as well but it looks like that's intended _only_ for enums with entirely unit variants. There's also a manual step to translate the `Vec<CodegenOption>` to `CodegenOptionGroup` since `clap` out-of-the-box only allows specifying the `-C` flag multiple times if the type associated with the option is a `Vec`.
- Changes to `javy-runner` to default to using the `build` command and support the arguments `build` supports unless a method has been invoked on the builder to use `compile` instead. I'm open to a different API.
- Adding `run_with_compile_and_build` to most tests to check that the build and compile commands function correctly. This could make more sense as a macro, I thought I'd start with a function because IMO it's easier to follow what the code is doing.

## Why am I making this change?

#702

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
