### PR TITLE
Set JS runtime config from CLI for static modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,6 +1468,7 @@ dependencies = [
  "clap",
  "convert_case",
  "criterion",
+ "javy-config",
  "javy-runner",
  "lazy_static",
  "num-format",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,6 +33,7 @@ convert_case = "0.6.0"
 wasm-opt = "0.116.1"
 tempfile = { workspace = true }
 clap = { version = "4.5.15", features = ["derive"] }
+javy-config = { workspace = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/cli/src/codegen/static.rs
+++ b/crates/cli/src/codegen/static.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, fs, rc::Rc, sync::OnceLock};
 
 use anyhow::Result;
+use javy_config::Config;
 use walrus::{DataKind, ExportItem, FunctionBuilder, FunctionId, MemoryId, ValType};
 use wasi_common::{pipe::ReadPipe, sync::WasiCtxBuilder, WasiCtx};
 use wasm_opt::{OptimizationOptions, ShrinkLevel};
@@ -69,6 +70,10 @@ impl CodeGen for StaticGenerator {
             WASI.get_mut()
                 .unwrap()
                 .set_stdin(Box::new(ReadPipe::from(js.as_bytes())));
+
+            WASI.get_mut()
+                .unwrap()
+                .push_env("JS_RUNTIME_CONFIG", &Config::all().bits().to_string())?;
         };
 
         let wasm = Wizer::new()

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -2,9 +2,9 @@ use anyhow::anyhow;
 use javy::Runtime;
 use once_cell::sync::OnceCell;
 use std::io::{self, Read};
-use std::slice;
 use std::str;
 use std::string::String;
+use std::{env, slice};
 
 use javy_config::Config;
 mod execution;
@@ -19,7 +19,15 @@ static mut BYTECODE: OnceCell<Vec<u8>> = OnceCell::new();
 pub extern "C" fn init() {
     let _wasm_ctx = WasmCtx::new();
 
-    let runtime = runtime::new(Config::all()).unwrap();
+    let js_runtime_config = Config::from_bits(
+        env::var("JS_RUNTIME_CONFIG")
+            .expect("JS_RUNTIME_CONFIG should be set")
+            .parse()
+            .expect("JS_RUNTIME_CONFIG should be a u32"),
+    )
+    .expect("JS_RUNTIME_CONFIG should only contain valid flags");
+
+    let runtime = runtime::new(js_runtime_config).unwrap();
 
     let mut contents = String::new();
     io::stdin().read_to_string(&mut contents).unwrap();


### PR DESCRIPTION
## Description of the change

Sets the JS runtime config for static Javy modules from the Javy CLI. Specifically it uses a WASI environment variable to pass the config bitflags when Wizer runs the initialization function. It uses the same `Config:all()` call as was in the main file for Core to initialize the configuration in the CLI. 

## Why am I making this change?

See #702. Specifically for the `-J` flags, I need a way to set the JS runtime configuration from the CLI.

I opted to use an environment variable because I need _some_ way to pass the configuration into the initializer function. I'm open to other suggestions. Presumably we could use the same approach when emitting the provider for the emit provider command.

I'm opting not to bump the provider version in this PR because we're not changing the provider.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
