### PR TITLE
Allow using --codegen and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ $ echo '{ "n": 2, "bar": "baz" }' | wasmtime index.wasm
 If you have a lot of JavaScript and you want to reduce compile times, try using the `--no-source-compression` flag. It will skip compressing the JavaScript source code when generating the Wasm module but will result in the Wasm module being larger.
 
 ```bash
-javy build index.js -o destination/index.wasm --no-source-compression
+javy build index.js -o destination/index.wasm -C source-compression=n
 ```
 
 ### Exporting functions
@@ -176,7 +176,7 @@ world index-world {
 
 In the terminal:
 ```bash
-$ javy build index.js --wit index.wit -n index-world -o index.wasm
+$ javy build index.js -C wit=index.wit -C wit-world=index-world -o index.wasm
 $ wasmtime run --invoke foo index.wasm
 Hello world!
 Hello from foo!
@@ -206,7 +206,7 @@ world index {
 
 In the terminal:
 ```bash
-$ javy build index.js --wit index.wit -n index -o index.wasm
+$ javy build index.js -C wit=index.wit -C wit-world=index -o index.wasm
 $ wasmtime run --invoke foo-bar index.wasm
 In foo-bar
 ```
@@ -233,7 +233,7 @@ world index {
 
 In the terminal:
 ```bash
-$ javy build index.js --wit index.wit -n index -o index.wasm
+$ javy build index.js -C wit=index.wit -C wit-world=index -o index.wasm
 $ wasmtime run --invoke default index.wasm
 In default
 ```
@@ -271,7 +271,7 @@ The `javy_quickjs_provider.wasm` module is available as an asset on the Javy rel
 
 ```
 $ echo 'console.log("hello world!");' > my_code.js
-$ javy build -d -o my_code.wasm my_code.js
+$ javy build -C dynamic -o my_code.wasm my_code.js
 $ javy emit-provider -o provider.wasm
 $ wasmtime run --preload javy_quickjs_provider_v2=provider.wasm my_code.wasm
 hello world!

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -81,6 +81,7 @@ pub struct BuildCommandOpts {
 
     #[arg(
         short = 'C',
+        long = "codegen",
         long_help = "Available codegen options:
 -C dynamic[=y|n] -- Creates a smaller module that requires a dynamically linked QuickJS provider Wasm module to execute (see `emit-provider` command).
 -C wit=path -- Optional path to WIT file describing exported functions. Only supports function exports with no arguments and no return values.


### PR DESCRIPTION
## Description of the change

Allows using `--codegen` as well as `-C` and updates the README to reflect the new arguments.

## Why am I making this change?

The README was out of date and #702 mentioned supporting `--codegen`.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
