### PR TITLE
Remove clean target from `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,3 @@ fmt-core:
 fmt-cli:
 	cargo fmt --package=javy-cli -- --check
 	CARGO_PROFILE_RELEASE_LTO=off cargo clippy --package=javy-cli --release --all-targets -- -D warnings
-
-clean: clean-wasi-sdk clean-cargo
-
-clean-cargo:
-	cargo clean


### PR DESCRIPTION
This commit removes the `clean` target from the `Makefile`:

* We no longer have to deal with downloading `wasi-sdk`
* Given (1), we can simply call `cargo clean` if we want to clean cargo artifacts.


## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
