### PR TITLE
Clarify ES2023 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you are going to recompile frequently, you may want to prepend `CARGO_PROFILE
 
 Pre-compiled binaries of the Javy CLI can be found on [the releases page](https://github.com/bytecodealliance/javy/releases).
 
-Javy supports ECMA2020 JavaScript. Javy does _not_ provide support for NodeJS or CommonJS APIs.
+Javy supports ES2023 JavaScript. Javy does _not_ provide support for NodeJS or CommonJS APIs.
 
 ### Compiling to WebAssembly
 


### PR DESCRIPTION
Since it's now based on 2024-01-13 of QuickJS.

https://bellard.org/quickjs/

The exact version of QuickJS isn't specified somewhere. Don't know if that's something we want to spell out or not? I left it out for now.