### PR TITLE
Derive runtime config defaults from javy_config::Config

### DIFF
--- a/crates/cli/src/codegen/builder.rs
+++ b/crates/cli/src/codegen/builder.rs
@@ -87,7 +87,7 @@ impl CodeGenBuilder {
         match T::classify() {
             CodeGenType::Static => self.build_static(js_runtime_config),
             CodeGenType::Dynamic => {
-                if js_runtime_config != Config::all() {
+                if js_runtime_config != Config::default() {
                     bail!("Cannot set JS runtime options when building a dynamic module")
                 }
                 self.build_dynamic()

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -210,9 +210,7 @@ pub struct JsRuntimeOptionGroup {
 
 impl Default for JsRuntimeOptionGroup {
     fn default() -> Self {
-        Self {
-            redirect_stdout_to_stderr: true,
-        }
+        Config::default().into()
     }
 }
 
@@ -262,11 +260,19 @@ impl From<Vec<JsRuntimeOption>> for JsRuntimeOptionGroup {
 
 impl From<JsRuntimeOptionGroup> for Config {
     fn from(value: JsRuntimeOptionGroup) -> Self {
-        let mut config = Self::all();
+        let mut config = Self::default();
         config.set(
             Config::REDIRECT_STDOUT_TO_STDERR,
             value.redirect_stdout_to_stderr,
         );
         config
+    }
+}
+
+impl From<Config> for JsRuntimeOptionGroup {
+    fn from(value: Config) -> Self {
+        Self {
+            redirect_stdout_to_stderr: value.contains(Config::REDIRECT_STDOUT_TO_STDERR),
+        }
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -44,7 +44,7 @@ fn main() -> Result<()> {
                 .source_compression(!opts.no_source_compression)
                 .provider_version("2");
 
-            let config = Config::all();
+            let config = Config::default();
             let mut gen = if opts.dynamic {
                 builder.build::<DynamicGenerator>(config)?
             } else {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -34,6 +34,18 @@ bitflags! {
     }
 }
 
+impl Default for Config {
+    fn default() -> Self {
+        let mut config = Config::empty();
+        config.set(Config::OVERRIDE_JSON_PARSE_AND_STRINGIFY, false);
+        config.set(Config::JAVY_JSON, false);
+        config.set(Config::JAVY_STREAM_IO, true);
+        config.set(Config::REDIRECT_STDOUT_TO_STDERR, true);
+        config.set(Config::TEXT_ENCODING, true);
+        config
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Config;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,7 +17,7 @@ static mut RUNTIME: OnceCell<Runtime> = OnceCell::new();
 /// Used by Wizer to preinitialize the module.
 #[export_name = "wizer.initialize"]
 pub extern "C" fn init() {
-    let runtime = runtime::new(Config::all()).unwrap();
+    let runtime = runtime::new(Config::default()).unwrap();
     unsafe {
         RUNTIME
             .set(runtime)
@@ -44,7 +44,7 @@ pub extern "C" fn init() {
 #[export_name = "compile_src"]
 pub unsafe extern "C" fn compile_src(js_src_ptr: *const u8, js_src_len: usize) -> *const u32 {
     // Use fresh runtime to avoid depending on Wizened runtime
-    let runtime = runtime::new(Config::all()).unwrap();
+    let runtime = runtime::new(Config::default()).unwrap();
     let js_src = str::from_utf8(slice::from_raw_parts(js_src_ptr, js_src_len)).unwrap();
 
     let bytecode = runtime

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -8,11 +8,10 @@ pub(crate) fn new(shared_config: SharedConfig) -> Result<Runtime> {
         .text_encoding(shared_config.contains(SharedConfig::TEXT_ENCODING))
         .redirect_stdout_to_stderr(shared_config.contains(SharedConfig::REDIRECT_STDOUT_TO_STDERR))
         .javy_stream_io(shared_config.contains(SharedConfig::JAVY_STREAM_IO))
-        // Due to an issue with our custom serializer and property accesses
-        // we're disabling this temporarily. It will be enabled once we have a
-        // fix forward.
-        .override_json_parse_and_stringify(false)
-        .javy_json(false);
+        .override_json_parse_and_stringify(
+            shared_config.contains(SharedConfig::OVERRIDE_JSON_PARSE_AND_STRINGIFY),
+        )
+        .javy_json(shared_config.contains(SharedConfig::JAVY_JSON));
 
     Runtime::new(std::mem::take(config))
 }


### PR DESCRIPTION
## Description of the change

Centralizes the default JS runtime configuration in the `javy_config::Config` struct's `Default` implementation. This will also keep the JS runtime command line settings default values in sync with the `javy_config::Config` default values.

## Why am I making this change?

Prior there were a few different places in the code that would set configuration properties to different values depending on the path through the code (e.g., some used `Config::all`, others disabled `OVERRIDE_JSON_PARSE_AND_STRINGIFY`).

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
