### PR TITLE
CLI options improvements

### DIFF
--- a/crates/cli/src/codegen/builder.rs
+++ b/crates/cli/src/codegen/builder.rs
@@ -4,7 +4,7 @@ use javy_config::Config;
 use std::path::PathBuf;
 
 /// Options for using WIT in the code generation process.
-#[derive(Default)]
+#[derive(Default, Clone, Debug)]
 pub(crate) struct WitOptions {
     /// The path of the .wit file to use.
     pub path: Option<PathBuf>,

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -243,7 +243,7 @@ impl Default for JsOptionGroup {
 option_group! {
     #[derive(Clone, Debug)]
     pub enum JsOption {
-        /// Whether to redirect console.log to stderr.
+        /// Whether to redirect the output of console.log to standard error.
         RedirectStdoutToStderr(bool),
     }
 }

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -88,12 +88,12 @@ pub struct BuildCommandOpts {
     #[arg(short = 'C', long = "codegen")]
     /// Code generation options.
     /// Use `-C help` for more details.
-    pub codegen: CodegenOptionGroup,
+    pub codegen: Option<CodegenOptionGroup>,
 
     #[arg(short = 'J', long = "javascript")]
     /// JS runtime options.
     /// Use `-J help` for more details.
-    pub js: JsOptionGroup,
+    pub js: Option<JsOptionGroup>,
 }
 
 #[derive(Debug, Parser)]

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -187,12 +187,12 @@ impl TypedValueParser for CodegenOptionGroupParser {
         let long = arg.get_long().expect("long version to be defined");
 
         if val == "help" {
-            fmt_help(&long, &short.to_string(), &CodegenOption::options());
+            fmt_help(long, &short.to_string(), &CodegenOption::options());
             std::process::exit(0);
         }
 
         let mut options = vec![];
-        for opt in val.split(",").into_iter() {
+        for opt in val.split(',') {
             options.push(CodegenOption::from_str(opt).map_err(|e| {
                 clap::Error::raw(clap::error::ErrorKind::InvalidValue, format!("{}", e))
             })?);
@@ -291,20 +291,18 @@ impl TypedValueParser for JsOptionGroupParser {
         let long = arg.get_long().expect("long version to be defined");
 
         if val == "help" {
-            fmt_help(&long, &short.to_string(), &JsOption::options());
+            fmt_help(long, &short.to_string(), &JsOption::options());
             std::process::exit(0);
         }
 
         let mut options = vec![];
-        for opt in val.split(",").into_iter() {
+        for opt in val.split(',') {
             options.push(JsOption::from_str(opt).map_err(|e| {
                 clap::Error::raw(clap::error::ErrorKind::InvalidValue, format!("{}", e))
             })?);
         }
 
-        options.try_into().map_err(|e| {
-            clap::Error::raw(clap::error::ErrorKind::InvalidValue, format!("{}", e)).with_cmd(cmd)
-        })
+        Ok(options.into())
     }
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -10,7 +10,7 @@ use crate::commands::{Cli, Command, EmitProviderCommandOpts};
 use anyhow::Result;
 use clap::Parser;
 use codegen::{CodeGenBuilder, DynamicGenerator, StaticGenerator};
-use commands::JsOptionGroup;
+use commands::{CodegenOptionGroup, JsOptionGroup};
 use javy_config::Config;
 use js::JS;
 use std::fs;
@@ -59,14 +59,14 @@ fn main() -> Result<()> {
         }
         Command::Build(opts) => {
             let js = JS::from_file(&opts.input)?;
-            let codegen = opts.codegen.clone().unwrap_or_default();
+            let codegen: CodegenOptionGroup = opts.codegen.clone().try_into()?;
             let mut builder = CodeGenBuilder::new();
             builder
                 .wit_opts(codegen.wit)
                 .source_compression(codegen.source_compression)
                 .provider_version("2");
 
-            let js_opts: JsOptionGroup = opts.js.clone().unwrap_or_default();
+            let js_opts: JsOptionGroup = opts.js.clone().into();
             let mut gen = if codegen.dynamic {
                 builder.build::<DynamicGenerator>(js_opts.into())?
             } else {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,6 +2,7 @@ mod bytecode;
 mod codegen;
 mod commands;
 mod js;
+mod option;
 mod wit;
 
 use crate::codegen::WitOptions;
@@ -9,7 +10,7 @@ use crate::commands::{Cli, Command, EmitProviderCommandOpts};
 use anyhow::Result;
 use clap::Parser;
 use codegen::{CodeGenBuilder, DynamicGenerator, StaticGenerator};
-use commands::{CodegenOptionGroup, JsRuntimeOptionGroup};
+use commands::JsOptionGroup;
 use javy_config::Config;
 use js::JS;
 use std::fs;
@@ -58,18 +59,18 @@ fn main() -> Result<()> {
         }
         Command::Build(opts) => {
             let js = JS::from_file(&opts.input)?;
-            let codegen: CodegenOptionGroup = opts.codegen.clone().try_into()?;
+            let codegen = opts.codegen.clone();
             let mut builder = CodeGenBuilder::new();
             builder
                 .wit_opts(codegen.wit)
                 .source_compression(codegen.source_compression)
                 .provider_version("2");
 
-            let js_runtime_options: JsRuntimeOptionGroup = opts.js_runtime.clone().into();
+            let js_options: JsOptionGroup = opts.js.clone().into();
             let mut gen = if codegen.dynamic {
-                builder.build::<DynamicGenerator>(js_runtime_options.into())?
+                builder.build::<DynamicGenerator>(js_options.into())?
             } else {
-                builder.build::<StaticGenerator>(js_runtime_options.into())?
+                builder.build::<StaticGenerator>(js_options.into())?
             };
 
             let wasm = gen.generate(&js)?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -59,18 +59,18 @@ fn main() -> Result<()> {
         }
         Command::Build(opts) => {
             let js = JS::from_file(&opts.input)?;
-            let codegen = opts.codegen.clone();
+            let codegen = opts.codegen.clone().unwrap_or_default();
             let mut builder = CodeGenBuilder::new();
             builder
                 .wit_opts(codegen.wit)
                 .source_compression(codegen.source_compression)
                 .provider_version("2");
 
-            let js_options: JsOptionGroup = opts.js.clone().into();
+            let js_opts: JsOptionGroup = opts.js.clone().unwrap_or_default();
             let mut gen = if codegen.dynamic {
-                builder.build::<DynamicGenerator>(js_options.into())?
+                builder.build::<DynamicGenerator>(js_opts.into())?
             } else {
-                builder.build::<StaticGenerator>(js_options.into())?
+                builder.build::<StaticGenerator>(js_opts.into())?
             };
 
             let wasm = gen.generate(&js)?;

--- a/crates/cli/src/option.rs
+++ b/crates/cli/src/option.rs
@@ -12,14 +12,14 @@ pub struct OptionMeta {
 pub fn fmt_help(cmd: &str, short: &str, meta: &[OptionMeta]) {
     println!("Available options for {}", cmd);
     for opt in meta {
-        print!("\n");
+        println!();
         print!("-{:<3}", short);
         print!("{:>3}", opt.name);
-        print!("{} \n", opt.help);
-        for line in opt.doc.split("\n") {
+        println!("{}", opt.help);
+        for line in opt.doc.split('\n') {
             print!("{}", line);
         }
-        print!("\n");
+        println!();
     }
 }
 
@@ -66,8 +66,8 @@ macro_rules! option_group {
                     })
                     .collect::<String>();
 
-                    let kebab_case = if kebab_case.starts_with('-') {
-                        &kebab_case[1..]
+                    if let Some(stripped) =  kebab_case.strip_prefix('-') {
+                        stripped
                     } else {
                         &kebab_case
                     };

--- a/crates/cli/src/option.rs
+++ b/crates/cli/src/option.rs
@@ -1,0 +1,127 @@
+use anyhow::{bail, Result};
+use std::path::PathBuf;
+
+/// Generic option attributes.
+#[derive(Debug)]
+pub struct OptionMeta {
+    pub name: String,
+    pub doc: String,
+}
+
+pub fn fmt_help(cmd: &str, short: &str, meta: &[OptionMeta]) {
+    println!("Available options for {}", cmd);
+    for opt in meta {
+        print!("\n");
+        print!("-{:<3}", short);
+        print!("{:>3} \n", opt.name);
+        for line in opt.doc.split("\n") {
+            print!("{}", line);
+        }
+        print!("\n");
+    }
+}
+
+/// Commonalities between all option groups.
+// Until we make more extensive use of this trait.
+#[allow(dead_code)]
+pub trait OptionGroup {
+    fn options() -> Vec<OptionMeta>;
+}
+
+#[macro_export]
+macro_rules! option_group {
+    (
+        $(#[$attr:meta])*
+        pub enum $opts:ident {
+            $(
+                $(#[doc = $doc:tt])*
+                $opt:ident($type:ty),
+            )+
+        }
+
+    ) => {
+
+        $(#[$attr])*
+        pub enum $opts {
+            $(
+                $opt($type),
+            )+
+        }
+
+        impl $crate::option::OptionGroup for $opts {
+            fn options() -> Vec<$crate::option::OptionMeta> {
+                let mut options = vec![];
+                $(
+                    let name = stringify!($opt);
+                    let kebab_case = name
+                    .chars()
+                    .flat_map(|c| {
+                        if c.is_uppercase() {
+                            vec!['-', c.to_ascii_lowercase()]
+                        } else {
+                            vec![c]
+                        }
+                    })
+                    .collect::<String>();
+
+                    let kebab_case = if kebab_case.starts_with('-') {
+                        &kebab_case[1..]
+                    } else {
+                        &kebab_case
+                    };
+                    options.push($crate::option::OptionMeta {
+                        name: kebab_case.into(),
+                        doc: concat!($($doc, "\n",)*).into(),
+                    });
+                )+
+
+                options
+            }
+        }
+    };
+}
+
+/// Represents all values that can be parsed.
+pub trait OptionValue {
+    fn parse(val: Option<&str>) -> Result<Self>
+    where
+        Self: Sized;
+}
+
+impl OptionValue for bool {
+    fn parse(val: Option<&str>) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        match val {
+            None => Ok(true),
+            Some("yes") | Some("y") => Ok(true),
+            Some("no") | Some("n") => Ok(false),
+            Some(_) => bail!("Unknown boolean flag. Valid options: y[es], n[o], (empty)"),
+        }
+    }
+}
+
+impl OptionValue for String {
+    fn parse(val: Option<&str>) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        match val {
+            Some(v) => Ok(v.into()),
+            None => bail!("Expected string argument"),
+        }
+    }
+}
+
+impl OptionValue for PathBuf {
+    fn parse(val: Option<&str>) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        match val {
+            Some(v) => Ok(PathBuf::from(v)),
+            None => bail!("Expected path argument"),
+        }
+    }
+}

--- a/crates/cli/src/option.rs
+++ b/crates/cli/src/option.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 pub struct OptionMeta {
     pub name: String,
     pub doc: String,
+    pub help: String,
 }
 
 pub fn fmt_help(cmd: &str, short: &str, meta: &[OptionMeta]) {
@@ -13,7 +14,8 @@ pub fn fmt_help(cmd: &str, short: &str, meta: &[OptionMeta]) {
     for opt in meta {
         print!("\n");
         print!("-{:<3}", short);
-        print!("{:>3} \n", opt.name);
+        print!("{:>3}", opt.name);
+        print!("{} \n", opt.help);
         for line in opt.doc.split("\n") {
             print!("{}", line);
         }
@@ -72,6 +74,7 @@ macro_rules! option_group {
                     options.push($crate::option::OptionMeta {
                         name: kebab_case.into(),
                         doc: concat!($($doc, "\n",)*).into(),
+                        help: <$type>::help().to_string(),
                     });
                 )+
 
@@ -83,12 +86,17 @@ macro_rules! option_group {
 
 /// Represents all values that can be parsed.
 pub trait OptionValue {
+    fn help() -> &'static str;
     fn parse(val: Option<&str>) -> Result<Self>
     where
         Self: Sized;
 }
 
 impl OptionValue for bool {
+    fn help() -> &'static str {
+        "[=y|n]"
+    }
+
     fn parse(val: Option<&str>) -> Result<Self>
     where
         Self: Sized,
@@ -103,6 +111,10 @@ impl OptionValue for bool {
 }
 
 impl OptionValue for String {
+    fn help() -> &'static str {
+        "=val"
+    }
+
     fn parse(val: Option<&str>) -> Result<Self>
     where
         Self: Sized,
@@ -115,6 +127,10 @@ impl OptionValue for String {
 }
 
 impl OptionValue for PathBuf {
+    fn help() -> &'static str {
+        "=path"
+    }
+
     fn parse(val: Option<&str>) -> Result<Self>
     where
         Self: Sized,

--- a/crates/cli/src/option.rs
+++ b/crates/cli/src/option.rs
@@ -44,7 +44,7 @@ pub trait GroupOptionBuilder: Clone + Sized + Send + Sync + 'static {
 }
 
 pub fn to_kebab_case(val: &str) -> String {
-    let kebab_case = val
+    let mut kebab_case = val
         .chars()
         .flat_map(|c| {
             if c.is_uppercase() {
@@ -55,13 +55,11 @@ pub fn to_kebab_case(val: &str) -> String {
         })
         .collect::<String>();
 
-    let name = if let Some(stripped) = kebab_case.strip_prefix('-') {
-        stripped
-    } else {
-        &kebab_case
-    };
+    if kebab_case.starts_with('-') {
+        kebab_case.remove(0);
+    }
 
-    name.to_string()
+    kebab_case
 }
 
 #[macro_export]


### PR DESCRIPTION
Closes https://github.com/bytecodealliance/javy/issues/742.

This change migrates to `ValueParserFactory` making it easier to manage options and option groups.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
