### PR TITLE
v3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "javy-config"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "bitflags",
 ]
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -1532,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "javy-test-macros"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.0.1"
+version = "3.1.0"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
## Description of the change

Preparing to release v3.1.0


- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
