### PR TITLE
Update simd-json to remove security vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,70 +1655,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
-name = "lexical-core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-util"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,13 +2502,12 @@ dependencies = [
 
 [[package]]
 name = "simd-json"
-version = "0.13.10"
+version = "0.14.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570c430b3d902ea083097e853263ae782dfe40857d93db019a12356c8e8143fa"
+checksum = "535e814ae750163fc09d5ab9ff73770254b6a1c44b98593e2d1b42e702b8a577"
 dependencies = [
  "getrandom",
  "halfbrown",
- "lexical-core",
  "ref-cast",
  "serde",
  "serde_json",
@@ -3218,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "value-trait"
-version = "0.8.1"
+version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad8db98c1e677797df21ba03fca7d3bf9bec3ca38db930954e4fe6e1ea27eb4"
+checksum = "47641b6867a201e598b2f14df9996d97a2ca0af2c34535faded32047e0bc9430"
 dependencies = [
  "float-cmp",
  "halfbrown",

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `simd-json` to version that removes dependency on `lexical-core` with
+  a security vulnerability.
+
 ### Fixed
 
 - Circular dependency checks for the custom, SIMD-based, `JSON.stringify`

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -23,7 +23,10 @@ rmp-serde = { version = "^1.3", optional = true }
 quickcheck = "1"
 bitflags = { workspace = true }
 fastrand = "2.1.1"
-simd-json = { version = "0.13.10", optional = true, default-features = false, features = ["big-int-as-float", "serde_impl"] }
+simd-json = { version = "0.14.0-rc.3", optional = true, default-features = false, features = [
+    "big-int-as-float",
+    "serde_impl",
+] }
 
 [dev-dependencies]
 javy-test-macros = { path = "../test-macros/" }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -349,30 +349,6 @@ criteria = "safe-to-deploy"
 version = "1.3.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.lexical-core]]
-version = "0.8.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.lexical-parse-float]]
-version = "0.8.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.lexical-parse-integer]]
-version = "0.8.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.lexical-util]]
-version = "0.8.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.lexical-write-float]]
-version = "0.8.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.lexical-write-integer]]
-version = "0.8.5"
-criteria = "safe-to-deploy"
-
 [[exemptions.libc]]
 version = "0.2.155"
 criteria = "safe-to-deploy"
@@ -586,7 +562,7 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.simd-json]]
-version = "0.13.10"
+version = "0.14.0-rc.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.simdutf8]]
@@ -730,7 +706,7 @@ version = "1.10.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.value-trait]]
-version = "0.8.1"
+version = "0.9.0-rc.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.vergen]]


### PR DESCRIPTION
## Description of the change

Updating `simd-json` to a version that does not use `lexical-core`.

I've also performed some additional sanity testing and it does not look like this breaks JSON behaviour.

## Why am I making this change?

To resolve https://github.com/bytecodealliance/javy/security/dependabot/49.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
