### PR TITLE
v3.0.1 of Javy crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "3.0.1-alpha.1"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.1] - 2024-09-18
+
 ### Changed
 
 - Updated `simd-json` to version that removes dependency on `lexical-core` with

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "3.0.1-alpha.1"
+version = "3.0.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Preparing to publish v3.0.1 of the Javy crate.

## Why am I making this change?

To ship a fix for the security vulnerability in lexical-core and circular dependency checks in `JSON.stringify`.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
