### PR TITLE
Add note about running git submodule deinit to Javy README

### DIFF
--- a/crates/javy/README.md
+++ b/crates/javy/README.md
@@ -45,4 +45,6 @@ context.with(|cx| {
 
 ## Publishing to crates.io
 
-To publish this crate to crates.io, run `./publish.sh`.
+To publish this crate to crates.io, run `./publish.sh`. You will likely need to
+run `git submodule deinit test262` so the working tree is small enough for the
+publishing to succeed.


### PR DESCRIPTION
## Description of the change

Add a note about running `git submodule deinit ...` to Javy crate's README.

## Why am I making this change?

I got an error about the source code being too large to publish. It was due to cargo trying to upload the contents of the submodule.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
