### PR TITLE
Bump javy crate version to 3.0.2-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "3.0.1"
+version = "3.0.2-alpha.1"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = "1.0"
 once_cell = "1.19"
 bitflags = "2.6.0"
 javy-config = { path = "crates/config" }
-javy = { path = "crates/javy", version = "3.0.1-alpha.1" }
+javy = { path = "crates/javy", version = "3.0.2-alpha.1" }
 tempfile = "3.12.0"
 uuid = { version = "1.10", features = ["v4"] }
 

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "3.0.1"
+version = "3.0.2-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Bumping to next point release with alpha suffix.

## Why am I making this change?

Following the linked versioning policy.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
