### PR TITLE
Fully thread the `source-compression` value

### DIFF
--- a/crates/cli/src/codegen/builder.rs
+++ b/crates/cli/src/codegen/builder.rs
@@ -106,6 +106,7 @@ impl CodeGenBuilder {
 
     fn build_dynamic(self) -> Result<Box<dyn CodeGen>> {
         let mut dynamic_gen = Box::new(DynamicGenerator::new());
+        dynamic_gen.source_compression = self.source_compression;
 
         if let Some(v) = self.provider_version {
             dynamic_gen.import_namespace = String::from("javy_quickjs_provider_v");

--- a/crates/cli/src/codegen/dynamic.rs
+++ b/crates/cli/src/codegen/dynamic.rs
@@ -49,7 +49,7 @@ pub(crate) struct DynamicGenerator {
     /// JavaScript function exports.
     function_exports: Exports,
     /// Whether to embed the compressed JS source in the generated module.
-    source_compression: bool,
+    pub source_compression: bool,
     /// WIT options for code generation.
     pub wit_opts: WitOptions,
 }
@@ -58,7 +58,7 @@ impl DynamicGenerator {
     /// Creates a new [`DynamicGenerator`].
     pub fn new() -> Self {
         Self {
-            source_compression: Default::default(),
+            source_compression: true,
             import_namespace: "".into(),
             function_exports: Default::default(),
             wit_opts: Default::default(),

--- a/crates/cli/src/codegen/dynamic.rs
+++ b/crates/cli/src/codegen/dynamic.rs
@@ -304,3 +304,20 @@ fn print_wat(wasm_binary: &[u8]) -> Result<()> {
 fn print_wat(_wasm_binary: &[u8]) -> Result<()> {
     Ok(())
 }
+
+#[cfg(test)]
+mod test {
+    use super::DynamicGenerator;
+    use super::WitOptions;
+    use anyhow::Result;
+
+    #[test]
+    fn default_values() -> Result<()> {
+        let gen = DynamicGenerator::new();
+        assert!(gen.source_compression);
+        assert_eq!(gen.import_namespace, "");
+        assert_eq!(gen.wit_opts, WitOptions::default());
+
+        Ok(())
+    }
+}

--- a/crates/cli/src/codegen/static.rs
+++ b/crates/cli/src/codegen/static.rs
@@ -36,7 +36,7 @@ impl StaticGenerator {
         let engine = include_bytes!(concat!(env!("OUT_DIR"), "/engine.wasm"));
         Self {
             engine,
-            source_compression: Default::default(),
+            source_compression: true,
             function_exports: Default::default(),
             wit_opts: Default::default(),
             js_runtime_config,

--- a/crates/cli/src/codegen/static.rs
+++ b/crates/cli/src/codegen/static.rs
@@ -201,3 +201,20 @@ fn optimize_wasm(wasm: &[u8]) -> Result<Vec<u8>> {
 
     Ok(fs::read(&tempfile_path)?)
 }
+
+#[cfg(test)]
+mod test {
+    use super::StaticGenerator;
+    use super::WitOptions;
+    use anyhow::Result;
+    use javy_config::Config;
+
+    #[test]
+    fn default_values() -> Result<()> {
+        let gen = StaticGenerator::new(Config::default());
+        assert!(gen.source_compression);
+        assert_eq!(gen.wit_opts, WitOptions::default());
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This commit fixes the handling of the `source-compression` option when
`C dynamic` is set. Even though the codegen option gropup defines the
options as `true` by default, it was not threaded correctly.

Additionally this commit sets `source-compression` as `true` in the
default implementation of the builders to ensure that the CLI options
intent is accurately reflected.



## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
