### PR TITLE
v3.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "javy-config"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "bitflags",
 ]
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "javy-test-macros"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.1.0"
+version = "3.1.1"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
Prepare `v3.1.1` of the CLI

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
