### PR TITLE
Have provider `invoke` fn support not being given a function name

### DIFF
--- a/crates/cli/tests/dylib_test.rs
+++ b/crates/cli/tests/dylib_test.rs
@@ -21,7 +21,7 @@ fn test_dylib_with_invoke_with_no_fn_name() -> Result<()> {
     let js_src = "console.log(42);";
     let mut runner = Runner::with_dylib(provider_module()?)?;
 
-    let (_, logs, _) = runner.exec_through_dylib(js_src, UseExportedFn::Invoke)?;
+    let (_, logs, _) = runner.exec_through_dylib(js_src, UseExportedFn::Invoke(None))?;
     assert_eq!("42\n", str::from_utf8(&logs)?);
 
     Ok(())
@@ -53,7 +53,7 @@ fn test_dylib_with_exported_func() -> Result<()> {
 
     let mut runner = Runner::with_dylib(provider_module()?)?;
 
-    let (_, logs, _) = runner.exec_through_dylib(js_src, UseExportedFn::InvokeWithFn("foo"))?;
+    let (_, logs, _) = runner.exec_through_dylib(js_src, UseExportedFn::Invoke(Some("foo")))?;
     assert_eq!("Toplevel\nIn foo\n", str::from_utf8(&logs)?);
 
     Ok(())

--- a/crates/cli/tests/dylib_test.rs
+++ b/crates/cli/tests/dylib_test.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use javy_runner::{Runner, RunnerError};
+use javy_runner::{Runner, RunnerError, UseExportedFn};
 use std::path::{Path, PathBuf};
 use std::str;
 
@@ -10,7 +10,18 @@ fn test_dylib() -> Result<()> {
     let js_src = "console.log(42);";
     let mut runner = Runner::with_dylib(provider_module()?)?;
 
-    let (_, logs, _) = runner.exec_through_dylib(js_src, None)?;
+    let (_, logs, _) = runner.exec_through_dylib(js_src, UseExportedFn::EvalBytecode)?;
+    assert_eq!("42\n", str::from_utf8(&logs)?);
+
+    Ok(())
+}
+
+#[test]
+fn test_dylib_with_invoke_with_no_fn_name() -> Result<()> {
+    let js_src = "console.log(42);";
+    let mut runner = Runner::with_dylib(provider_module()?)?;
+
+    let (_, logs, _) = runner.exec_through_dylib(js_src, UseExportedFn::Invoke)?;
     assert_eq!("42\n", str::from_utf8(&logs)?);
 
     Ok(())
@@ -22,7 +33,7 @@ fn test_dylib_with_error() -> Result<()> {
 
     let mut runner = Runner::with_dylib(provider_module()?)?;
 
-    let res = runner.exec_through_dylib(js_src, None);
+    let res = runner.exec_through_dylib(js_src, UseExportedFn::EvalBytecode);
 
     assert!(res.is_err());
 
@@ -42,7 +53,7 @@ fn test_dylib_with_exported_func() -> Result<()> {
 
     let mut runner = Runner::with_dylib(provider_module()?)?;
 
-    let (_, logs, _) = runner.exec_through_dylib(js_src, Some("foo"))?;
+    let (_, logs, _) = runner.exec_through_dylib(js_src, UseExportedFn::InvokeWithFn("foo"))?;
     assert_eq!("Toplevel\nIn foo\n", str::from_utf8(&logs)?);
 
     Ok(())


### PR DESCRIPTION
## Description of the change

Adds support to QuickJS provider's exported `invoke` function to handle not being given a function name. This shouldn't change any behaviour.

## Why am I making this change?

As part of #768, we'll want to remove the `eval_bytecode` exported function (to make it easier for plugin developers) and just have `invoke` so `invoke` needs to also be able to handle `eval_bytecode`'s use case where there is not an exported function to run.

I haven't deleted `eval_bytecode` in this PR because we still emit function invocations for it. I also haven't updated the dynamically linked codegen code to call `invoke` instead of `eval_bytecode` because all runtime environments using the provider would need to be updated with a provider version that includes this code change, otherwise new modules generated to use `invoke` with `0` arguments for function name pointer and length would fail.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
