### PR TITLE
v3.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "javy-config"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "bitflags",
 ]
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "javy-test-macros"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.1.1"
+version = "3.1.2"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
## Description of the change
Prepare version 3.1.2

- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [ ] I've updated documentation including crate documentation if necessary.
