### PR TITLE
Rename wizer.initialize to initialize_runtime

### DIFF
--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -55,6 +55,7 @@ fn copy_javy_core() -> Result<()> {
 
     let mut wizer = wizer::Wizer::new();
     let wizened = wizer
+        .init_func("initialize_runtime")
         .allow_wasi(true)?
         .wasm_bulk_memory(true)
         .run(read_file(&quickjs_provider_path)?.as_slice())?;

--- a/crates/cli/src/codegen/static.rs
+++ b/crates/cli/src/codegen/static.rs
@@ -81,6 +81,7 @@ impl CodeGen for StaticGenerator {
         };
 
         let wasm = Wizer::new()
+            .init_func("initialize_runtime")
             .make_linker(Some(Rc::new(|engine| {
                 let mut linker = Linker::new(engine);
                 wasi_common::sync::add_to_linker(&mut linker, |_: &mut Option<WasiCtx>| unsafe {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -15,8 +15,8 @@ static mut COMPILE_SRC_RET_AREA: [u32; 2] = [0; 2];
 static mut RUNTIME: OnceCell<Runtime> = OnceCell::new();
 
 /// Used by Wizer to preinitialize the module.
-#[export_name = "wizer.initialize"]
-pub extern "C" fn init() {
+#[export_name = "initialize_runtime"]
+pub extern "C" fn initialize_runtime() {
     let runtime = runtime::new(Config::default()).unwrap();
     unsafe {
         RUNTIME

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -15,8 +15,8 @@ const FUNCTION_MODULE_NAME: &str = "function.mjs";
 static mut RUNTIME: OnceCell<Runtime> = OnceCell::new();
 static mut BYTECODE: OnceCell<Vec<u8>> = OnceCell::new();
 
-#[export_name = "wizer.initialize"]
-pub extern "C" fn init() {
+#[export_name = "initialize_runtime"]
+pub extern "C" fn initialize_runtime() {
     let _wasm_ctx = WasmCtx::new();
 
     let js_runtime_config = Config::from_bits(


### PR DESCRIPTION
## Description of the change

Refactoring to rename exported `wizer.initialize` function to `initialize_runtime`.

## Why am I making this change?

Part of #768. Trying to keep some of the upcoming PRs smaller so they're easier to review.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
