### PR TITLE
Reuse runtime when compiling source code to bytecode

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -43,6 +43,19 @@ pub extern "C" fn init() {
 /// * `js_src_ptr` must reference a valid array of unsigned bytes of `js_src_len` length
 #[export_name = "compile_src"]
 pub unsafe extern "C" fn compile_src(js_src_ptr: *const u8, js_src_len: usize) -> *const u32 {
+    // Use initialized runtime when compiling because certain runtime
+    // configurations can cause different bytecode to be emitted.
+    //
+    // For example, given the following JS:
+    // ```
+    // function foo() {
+    //   "use math"
+    //   1234 % 32
+    // }
+    // ```
+    //
+    // Setting `config.bignum_extension` to `true` will produce different
+    // bytecode than if it were set to `false`.
     let runtime = unsafe { RUNTIME.get().unwrap() };
     let js_src = str::from_utf8(slice::from_raw_parts(js_src_ptr, js_src_len)).unwrap();
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -43,8 +43,7 @@ pub extern "C" fn init() {
 /// * `js_src_ptr` must reference a valid array of unsigned bytes of `js_src_len` length
 #[export_name = "compile_src"]
 pub unsafe extern "C" fn compile_src(js_src_ptr: *const u8, js_src_len: usize) -> *const u32 {
-    // Use fresh runtime to avoid depending on Wizened runtime
-    let runtime = runtime::new(Config::default()).unwrap();
+    let runtime = unsafe { RUNTIME.get().unwrap() };
     let js_src = str::from_utf8(slice::from_raw_parts(js_src_ptr, js_src_len)).unwrap();
 
     let bytecode = runtime

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -670,18 +670,12 @@ impl Runner {
         let module = Module::from_binary(self.linker.engine(), &self.wasm)?;
 
         let instance = self.linker.instantiate(store.as_context_mut(), &module)?;
-        let bytecode = Self::compile(src.as_bytes(), store.as_context_mut(), &instance)?;
 
-        // Need to use a fresh instance so we get a fresh wizened runtime,
-        // otherwise the JS in the outermost scope will be executed a second
-        // time if an exported JS function is invoked.
-        let instance = self.linker.instantiate(store.as_context_mut(), &module)?;
-        let bc_ptr = Self::copy_into_instance(&bytecode, &instance, store.as_context_mut())?;
-
+        let (bc_ptr, bc_len) = Self::compile(src.as_bytes(), store.as_context_mut(), &instance)?;
         let res = match use_exported_fn {
             UseExportedFn::EvalBytecode => instance
                 .get_typed_func::<(u32, u32), ()>(store.as_context_mut(), "eval_bytecode")?
-                .call(store.as_context_mut(), (bc_ptr, bytecode.len().try_into()?)),
+                .call(store.as_context_mut(), (bc_ptr, bc_len)),
             UseExportedFn::Invoke(func) => {
                 let (fn_ptr, fn_len) = match func {
                     Some(func) => Self::copy_func_name(func, &instance, store.as_context_mut())?,
@@ -689,10 +683,7 @@ impl Runner {
                 };
                 instance
                     .get_typed_func::<(u32, u32, u32, u32), ()>(store.as_context_mut(), "invoke")?
-                    .call(
-                        store.as_context_mut(),
-                        (bc_ptr, bytecode.len().try_into()?, fn_ptr, fn_len),
-                    )
+                    .call(store.as_context_mut(), (bc_ptr, bc_len, fn_ptr, fn_len))
             }
         };
 
@@ -704,30 +695,30 @@ impl Runner {
         instance: &Instance,
         mut store: impl AsContextMut,
     ) -> Result<(u32, u32)> {
-        let name_bytes = name.as_bytes();
-        let ptr = Self::copy_into_instance(name_bytes, instance, store.as_context_mut())?;
-        Ok((ptr, name_bytes.len().try_into()?))
-    }
-
-    fn copy_into_instance(
-        data: &[u8],
-        instance: &Instance,
-        mut store: impl AsContextMut,
-    ) -> Result<u32> {
         let memory = instance
             .get_memory(store.as_context_mut(), "memory")
             .unwrap();
-        let ptr =
-            Self::allocate_memory(instance, store.as_context_mut(), 1, data.len().try_into()?)?;
-        memory.write(store.as_context_mut(), ptr.try_into()?, data)?;
-        Ok(ptr)
+        let fn_name_bytes = name.as_bytes();
+        let fn_name_ptr = Self::allocate_memory(
+            instance,
+            store.as_context_mut(),
+            1,
+            fn_name_bytes.len().try_into()?,
+        )?;
+        memory.write(
+            store.as_context_mut(),
+            fn_name_ptr.try_into()?,
+            fn_name_bytes,
+        )?;
+
+        Ok((fn_name_ptr, fn_name_bytes.len().try_into()?))
     }
 
     fn compile(
         source: &[u8],
         mut store: impl AsContextMut,
         instance: &Instance,
-    ) -> Result<Vec<u8>> {
+    ) -> Result<(u32, u32)> {
         let memory = instance
             .get_memory(store.as_context_mut(), "memory")
             .unwrap();
@@ -751,10 +742,7 @@ impl Runner {
         let bytecode_ptr = u32::from_le_bytes(ret_buffer[0..4].try_into()?);
         let bytecode_len = u32::from_le_bytes(ret_buffer[4..8].try_into()?);
 
-        let mut bytecode = vec![0; bytecode_len.try_into()?];
-        memory.read(store.as_context(), bytecode_ptr.try_into()?, &mut bytecode)?;
-
-        Ok(bytecode)
+        Ok((bytecode_ptr, bytecode_len))
     }
 
     fn allocate_memory(


### PR DESCRIPTION
## Description of the change

Re-use the runtime when compiling JS code to QuickJS bytecode. Also update the dylib test code to refresh the instance to work around the module being evaluated twice.

An unfortunate result of this change is the a fresh instance would need to be used after invoking `compile_src` if `invoke` were called were called with a JS function. I don't think anyone would be relying on this behaviour. I'm also not entirely why we're seeing this behaviour. If I update `invoke` to not call `execution::run_bytecode`, everything runs as expected if a fresh instance isn't created. However, if a fresh instance is used (as in the common use case), then QuickJS indicates the module has not been declared and traps.

## Why am I making this change?

Part of #768. If a plugin were to change any JS runtime configurations and if any of those configurations were to effect QuickJS bytecode emission, we would want to use that runtime configuration when compiling the QuickJS bytecode. Without this change, a default runtime configuration would be used instead which may not be intended.

An alternative approach is to persist the configuration generated in `wizer.initialize` and use that configuration when initializing the runtime in `compile_src`. This approach will not continue to work if we were to add the ability to further customize the runtime in `wizer.initialize` (which is planned).

I also looked into if there was a way to "de-register" a JS module from a QuickJS context but couldn't find a way to do it. Hypothetically I could re-register an empty module with the same name after compiling the bytecode which may have a similar effect.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
