### PR TITLE
Fix missing argument for wizer build assets workflow

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Wizen and archive wizened quickjs_provider
         run: |
-          wizer target/wasm32-wasi/release/javy_quickjs_provider.wasm --allow-wasi --wasm-bulk-memory true -o target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm
+          wizer target/wasm32-wasi/release/javy_quickjs_provider.wasm --allow-wasi --init-func initialize_runtime --wasm-bulk-memory true -o target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm
           gzip -k -f target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm && mv target/wasm32-wasi/release/javy_quickjs_provider_wizened.wasm.gz javy-quickjs_provider.wasm.gz
 
       - name: Upload archived quickjs_provider to artifacts


### PR DESCRIPTION
## Description of the change

Instructs Wizer to use `initialize_runtime` as the initialization function in the build assets GitHub workflow.

## Why am I making this change?

I should have updated this in #780 but we only run this on commits to `main` and when releasing.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
