### PR TITLE
Inline function execution with bytecode evaluation

### DIFF
--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -188,7 +188,7 @@ fn test_exported_functions(builder: &mut Builder) -> Result<()> {
         .build()?;
     let (_, logs, fuel_consumed) = run_fn(&mut runner, "foo", &[]);
     assert_eq!("Hello from top-level\nHello from foo\n", logs);
-    assert_fuel_consumed_within_threshold(80023, fuel_consumed);
+    assert_fuel_consumed_within_threshold(63_310, fuel_consumed);
     let (_, logs, _) = run_fn(&mut runner, "foo-bar", &[]);
     assert_eq!("Hello from top-level\nHello from fooBar\n", logs);
     Ok(())
@@ -270,7 +270,7 @@ fn test_exported_default_arrow_fn(builder: &mut Builder) -> Result<()> {
 
     let (_, logs, fuel_consumed) = run_fn(&mut runner, "default", &[]);
     assert_eq!(logs, "42\n");
-    assert_fuel_consumed_within_threshold(76706, fuel_consumed);
+    assert_fuel_consumed_within_threshold(39_004, fuel_consumed);
     Ok(())
 }
 
@@ -283,7 +283,7 @@ fn test_exported_default_fn(builder: &mut Builder) -> Result<()> {
         .build()?;
     let (_, logs, fuel_consumed) = run_fn(&mut runner, "default", &[]);
     assert_eq!(logs, "42\n");
-    assert_fuel_consumed_within_threshold(77909, fuel_consumed);
+    assert_fuel_consumed_within_threshold(39_951, fuel_consumed);
     Ok(())
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn compile_src(js_src_ptr: *const u8, js_src_len: usize) -
 pub unsafe extern "C" fn eval_bytecode(bytecode_ptr: *const u8, bytecode_len: usize) {
     let runtime = RUNTIME.get().unwrap();
     let bytecode = slice::from_raw_parts(bytecode_ptr, bytecode_len);
-    execution::run_bytecode(runtime, bytecode);
+    execution::run_bytecode(runtime, bytecode, None);
 }
 
 /// Evaluates QuickJS bytecode and optionally invokes exported JS function with
@@ -89,9 +89,13 @@ pub unsafe extern "C" fn invoke(
 ) {
     let runtime = RUNTIME.get().unwrap();
     let bytecode = slice::from_raw_parts(bytecode_ptr, bytecode_len);
-    execution::run_bytecode(runtime, bytecode);
-    if !fn_name_ptr.is_null() && fn_name_len != 0 {
-        let fn_name = str::from_utf8_unchecked(slice::from_raw_parts(fn_name_ptr, fn_name_len));
-        execution::invoke_function(runtime, FUNCTION_MODULE_NAME, fn_name);
-    }
+    let fn_name = if !fn_name_ptr.is_null() && fn_name_len != 0 {
+        Some(str::from_utf8_unchecked(slice::from_raw_parts(
+            fn_name_ptr,
+            fn_name_len,
+        )))
+    } else {
+        None
+    };
+    execution::run_bytecode(runtime, bytecode, fn_name);
 }

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -50,7 +50,7 @@ pub extern "C" fn initialize_runtime() {
 fn main() {
     let bytecode = unsafe { BYTECODE.take().unwrap() };
     let runtime = unsafe { RUNTIME.take().unwrap() };
-    execution::run_bytecode(&runtime, &bytecode);
+    execution::run_bytecode(&runtime, &bytecode, None);
 }
 
 // Removed in post-processing.

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -65,8 +65,9 @@ pub unsafe extern "C" fn invoke(fn_name_ptr: *mut u8, fn_name_size: usize) {
     let _wasm_ctx = WasmCtx::new();
 
     let js_fn_name = str::from_utf8_unchecked(slice::from_raw_parts(fn_name_ptr, fn_name_size));
+    let bytecode = unsafe { BYTECODE.take().unwrap() };
     let runtime = unsafe { RUNTIME.take().unwrap() };
-    execution::invoke_function(&runtime, FUNCTION_MODULE_NAME, js_fn_name);
+    execution::run_bytecode(&runtime, &bytecode, Some(js_fn_name));
 }
 
 // RAII abstraction for calling Wasm ctors and dtors for exported non-main functions.


### PR DESCRIPTION
## Description of the change

Updates `run_bytecode` in javy-core to take an optional function name to execute and execute it if it's provided.

## Why am I making this change?

This substantially reduces the amount of fuel to call an exported function with dynamically linked modules. This also allows re-using a runtime after using it when calling `compile_src` (see #781).

In terms of performance numbers, given a function that looks like:
```js
function run() {
    console.log("hello");
}
run()
```

Fuel usage will increase from 36,929 to 36,983 (54 instructions).

Given a function that looks like:
```js
export function run() {
    console.log("hello");
}
```

Fuel usage will decrease from 92,080 to 40,283 (51,797 instructions).

I'm opting to not to update the `main.rs` file for the time being because I'm planning to have it deleted soon.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
