### PR TITLE
Disable reference-types since Wizer doesn't support them

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,8 +2,15 @@
 # Cargo doesn't read directives in individual crates when invoking build
 # commands from the workspace root, hence adding it at the workspace root.
 # https://doc.rust-lang.org/cargo/reference/config.html
+# Disable reference-types since Wizer (as of version 7.0.0) does not support
+# reference-types.
 [target.wasm32-wasi]
-rustflags = ["-C", "target-feature=+simd128"]
+rustflags = [
+    "-C",
+    "target-feature=+simd128",
+    "-C",
+    "target-feature=-reference-types",
+]
 
 # We want to ensure that all the MSVC dependencies are statically resolved and
 # included in the final CLI binary.


### PR DESCRIPTION
## Description of the change

Disabling reference types when compiling javy-core.

## Why am I making this change?

The latest Rust stable compiler has started to emit instructions which rely on reference types support. Wizer (as of Wizer 7.0.0) [does not support reference types](https://github.com/bytecodealliance/wizer/blob/afcdfc702514fd8be98ddf025557297d2f79ae4c/src/lib.rs#L85). This causes the build for Javy CLI to fail [when Wizer is executed on javy-core](https://github.com/bytecodealliance/javy/actions/runs/11392246802/job/31698108529#step:6:317).

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
