### PR TITLE
Derive the import namespace from the provider module

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -9,7 +9,7 @@ use crate::codegen::WitOptions;
 use crate::commands::{Cli, Command, EmitProviderCommandOpts};
 use anyhow::Result;
 use clap::Parser;
-use codegen::{CodeGenBuilder, DynamicGenerator, StaticGenerator};
+use codegen::{CodeGenBuilder, DynamicGenerator, ImportNamespace, StaticGenerator};
 use commands::{CodegenOptionGroup, JsOptionGroup};
 use javy_config::Config;
 use js::JS;
@@ -43,7 +43,7 @@ fn main() -> Result<()> {
                     opts.wit_world.clone(),
                 ))?)
                 .source_compression(!opts.no_source_compression)
-                .provider_version("2");
+                .import_namespace(ImportNamespace::JavyQuickJsProviderV2);
 
             let config = Config::default();
             let mut gen = if opts.dynamic {
@@ -64,7 +64,7 @@ fn main() -> Result<()> {
             builder
                 .wit_opts(codegen.wit)
                 .source_compression(codegen.source_compression)
-                .provider_version("3");
+                .import_namespace(ImportNamespace::FromProvider);
 
             let js_opts: JsOptionGroup = opts.js.clone().into();
             let mut gen = if codegen.dynamic {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,11 +1,13 @@
 use anyhow::anyhow;
 use javy::Runtime;
 use javy_config::Config;
+use namespace::import_namespace;
 use once_cell::sync::OnceCell;
 use std::slice;
 use std::str;
 
 mod execution;
+mod namespace;
 mod runtime;
 
 const FUNCTION_MODULE_NAME: &str = "function.mjs";
@@ -13,6 +15,8 @@ const FUNCTION_MODULE_NAME: &str = "function.mjs";
 static mut COMPILE_SRC_RET_AREA: [u32; 2] = [0; 2];
 
 static mut RUNTIME: OnceCell<Runtime> = OnceCell::new();
+
+import_namespace!("javy_quickjs_provider_v3");
 
 /// Used by Wizer to preinitialize the module.
 #[export_name = "initialize_runtime"]

--- a/crates/core/src/namespace.rs
+++ b/crates/core/src/namespace.rs
@@ -1,0 +1,20 @@
+// Create a custom section named `import_namespace` with the contents of the
+// string argument.
+macro_rules! import_namespace {
+    ($str:literal) => {
+        const IMPORT_NAMESPACE_BYTES: &[u8] = $str.as_bytes();
+
+        #[link_section = "import_namespace"]
+        pub static IMPORT_NAMESPACE: [u8; IMPORT_NAMESPACE_BYTES.len()] = {
+            let mut arr = [0u8; IMPORT_NAMESPACE_BYTES.len()];
+            let mut i = 0;
+            while i < IMPORT_NAMESPACE_BYTES.len() {
+                arr[i] = IMPORT_NAMESPACE_BYTES[i];
+                i += 1;
+            }
+            arr
+        };
+    };
+}
+
+pub(crate) use import_namespace;


### PR DESCRIPTION
## Description of the change

Updates the provider to have a custom section named `import_namespace` and has the Javy CLI use that custom section to determine what import namespace to use when creating dynamically linked modules.

## Why am I making this change?

Part of #768. This change will allow plugins to specify their own import namespaces instead of having to use one set in the Javy CLI. Also arguably, javy-core should be responsible for saying when to bump any version and not the CLI.

I had a little trouble figuring out a logical place to put the `derive_import_namespace_from_provider` function. I'm putting it in the `bytecode` module for now. Arguably we could introduce an abstraction around providers with various methods for things like getting a byte slice for writing to disk, performing bytecode compilation, and getting the import namespace. I'll probably need to do that refactoring very shortly to accommodate some changes I want to make to codegen so I'm thinking it makes sense to punt until I'm working on that.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
