### PR TITLE
Refactor to use a Provider abstraction

### DIFF
--- a/crates/cli/src/codegen/builder.rs
+++ b/crates/cli/src/codegen/builder.rs
@@ -1,4 +1,7 @@
-use crate::codegen::{CodeGen, CodeGenType, DynamicGenerator, StaticGenerator};
+use crate::{
+    codegen::{CodeGen, CodeGenType, DynamicGenerator, StaticGenerator},
+    providers::Provider,
+};
 use anyhow::{bail, Result};
 use javy_config::Config;
 use std::path::PathBuf;
@@ -47,8 +50,8 @@ impl WitOptions {
 /// A code generation builder.
 #[derive(Default)]
 pub(crate) struct CodeGenBuilder {
-    /// The QuickJS provider module version.
-    provider_version: Option<&'static str>,
+    /// The provider to use.
+    provider: Option<Provider>,
     /// WIT options for code generation.
     wit_opts: WitOptions,
     /// Whether to compress the original JS source.
@@ -61,9 +64,9 @@ impl CodeGenBuilder {
         Self::default()
     }
 
-    /// Set the provider version.
-    pub fn provider_version(&mut self, v: &'static str) -> &mut Self {
-        self.provider_version = Some(v);
+    /// Set the provider.
+    pub fn provider(&mut self, provider: Provider) -> &mut Self {
+        self.provider = Some(provider);
         self
     }
 
@@ -108,9 +111,8 @@ impl CodeGenBuilder {
         let mut dynamic_gen = Box::new(DynamicGenerator::new());
         dynamic_gen.source_compression = self.source_compression;
 
-        if let Some(v) = self.provider_version {
-            dynamic_gen.import_namespace = String::from("javy_quickjs_provider_v");
-            dynamic_gen.import_namespace.push_str(v);
+        if let Some(p) = self.provider {
+            dynamic_gen.provider = p
         } else {
             bail!("Provider version not specified")
         }

--- a/crates/cli/src/codegen/dynamic.rs
+++ b/crates/cli/src/codegen/dynamic.rs
@@ -2,6 +2,7 @@ use super::transform::{self, SourceCodeSection};
 use crate::{
     codegen::{exports, CodeGen, CodeGenType, Exports, WitOptions},
     js::JS,
+    providers::Provider,
 };
 use anyhow::Result;
 use walrus::{DataId, DataKind, FunctionBuilder, FunctionId, LocalId, MemoryId, Module, ValType};
@@ -44,8 +45,8 @@ impl BytecodeMetadata {
 
 /// Dynamic Code Generation.
 pub(crate) struct DynamicGenerator {
-    /// Wasm import namcespace.
-    pub import_namespace: String,
+    /// Provider to use.
+    pub provider: Provider,
     /// JavaScript function exports.
     function_exports: Exports,
     /// Whether to embed the compressed JS source in the generated module.
@@ -59,7 +60,7 @@ impl DynamicGenerator {
     pub fn new() -> Self {
         Self {
             source_compression: true,
-            import_namespace: "".into(),
+            provider: Provider::Default,
             function_exports: Default::default(),
             wit_opts: Default::default(),
         }
@@ -67,29 +68,23 @@ impl DynamicGenerator {
 
     /// Generate function imports.
     pub fn generate_imports(&self, module: &mut Module) -> Result<Imports> {
+        let import_namespace = self.provider.import_namespace();
         let canonical_abi_realloc_type = module.types.add(
             &[ValType::I32, ValType::I32, ValType::I32, ValType::I32],
             &[ValType::I32],
         );
         let (canonical_abi_realloc_fn_id, _) = module.add_import_func(
-            &self.import_namespace,
+            &import_namespace,
             "canonical_abi_realloc",
             canonical_abi_realloc_type,
         );
 
         let eval_bytecode_type = module.types.add(&[ValType::I32, ValType::I32], &[]);
         let (eval_bytecode_fn_id, _) =
-            module.add_import_func(&self.import_namespace, "eval_bytecode", eval_bytecode_type);
+            module.add_import_func(&import_namespace, "eval_bytecode", eval_bytecode_type);
 
-        let (memory_id, _) = module.add_import_memory(
-            &self.import_namespace,
-            "memory",
-            false,
-            false,
-            0,
-            None,
-            None,
-        );
+        let (memory_id, _) =
+            module.add_import_memory(&import_namespace, "memory", false, false, 0, None, None);
 
         Ok(Imports::new(
             canonical_abi_realloc_fn_id,
@@ -105,11 +100,7 @@ impl DynamicGenerator {
         js: &JS,
         imports: &Imports,
     ) -> Result<BytecodeMetadata> {
-        let bytecode = if self.import_namespace == "javy_quickjs_provider_v2" {
-            js.compile_legacy()?
-        } else {
-            js.compile()?
-        };
+        let bytecode = js.compile(&self.provider)?;
         let bytecode_len: i32 = bytecode.len().try_into()?;
         let bytecode_data = module.data.add(DataKind::Passive, bytecode);
 
@@ -155,7 +146,7 @@ impl DynamicGenerator {
                 &[],
             );
             let (invoke_fn, _) =
-                module.add_import_func(&self.import_namespace, "invoke", invoke_type);
+                module.add_import_func(&self.provider.import_namespace(), "invoke", invoke_type);
 
             let fn_name_ptr_local = module.locals.add(ValType::I32);
             for export in &self.function_exports {
@@ -311,6 +302,8 @@ fn print_wat(_wasm_binary: &[u8]) -> Result<()> {
 
 #[cfg(test)]
 mod test {
+    use crate::providers::Provider;
+
     use super::DynamicGenerator;
     use super::WitOptions;
     use anyhow::Result;
@@ -319,7 +312,7 @@ mod test {
     fn default_values() -> Result<()> {
         let gen = DynamicGenerator::new();
         assert!(gen.source_compression);
-        assert_eq!(gen.import_namespace, "");
+        assert!(matches!(gen.provider, Provider::Default));
         assert_eq!(gen.wit_opts, WitOptions::default());
 
         Ok(())

--- a/crates/cli/src/js.rs
+++ b/crates/cli/src/js.rs
@@ -24,7 +24,7 @@ use swc_core::{
     },
 };
 
-use crate::bytecode;
+use crate::providers::Provider;
 
 #[derive(Clone, Debug)]
 pub struct JS {
@@ -50,23 +50,9 @@ impl JS {
         self.source_code.as_bytes()
     }
 
-    /// Compiles a JavaScript source to bytecode using the QuickJS provider.
-    pub fn compile(&self) -> Result<Vec<u8>> {
-        bytecode::compile_source(
-            bytecode::QUICKJS_PROVIDER_MODULE,
-            self.source_code.as_bytes(),
-        )
-    }
-
-    /// Similar to [`Self::compile`]. Instead of using the most up to date
-    /// provider, it uses the v2 provider.
-    ///
-    /// NB that this is temporary until the `compile` command is deprecated.
-    pub fn compile_legacy(&self) -> Result<Vec<u8>> {
-        bytecode::compile_source(
-            bytecode::QUICKJS_PROVIDER_V2_MODULE,
-            self.source_code.as_bytes(),
-        )
+    /// Compiles a JavaScript source to bytecode using a QuickJS provider.
+    pub fn compile(&self, provider: &Provider) -> Result<Vec<u8>> {
+        provider.compile_source(self.source_code.as_bytes())
     }
 
     pub fn compress(&self) -> Result<Vec<u8>> {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,6 +3,7 @@ mod codegen;
 mod commands;
 mod js;
 mod option;
+mod providers;
 mod wit;
 
 use crate::codegen::WitOptions;
@@ -13,6 +14,7 @@ use codegen::{CodeGenBuilder, DynamicGenerator, StaticGenerator};
 use commands::{CodegenOptionGroup, JsOptionGroup};
 use javy_config::Config;
 use js::JS;
+use providers::Provider;
 use std::fs;
 use std::fs::File;
 use std::io::Write;
@@ -43,7 +45,7 @@ fn main() -> Result<()> {
                     opts.wit_world.clone(),
                 ))?)
                 .source_compression(!opts.no_source_compression)
-                .provider_version("2");
+                .provider(Provider::V2);
 
             let config = Config::default();
             let mut gen = if opts.dynamic {
@@ -64,7 +66,7 @@ fn main() -> Result<()> {
             builder
                 .wit_opts(codegen.wit)
                 .source_compression(codegen.source_compression)
-                .provider_version("3");
+                .provider(Provider::Default);
 
             let js_opts: JsOptionGroup = opts.js.clone().into();
             let mut gen = if codegen.dynamic {
@@ -86,6 +88,6 @@ fn emit_provider(opts: &EmitProviderCommandOpts) -> Result<()> {
         Some(path) => Box::new(File::create(path)?),
         _ => Box::new(std::io::stdout()),
     };
-    file.write_all(bytecode::QUICKJS_PROVIDER_MODULE)?;
+    file.write_all(Provider::Default.as_bytes())?;
     Ok(())
 }

--- a/crates/cli/src/providers.rs
+++ b/crates/cli/src/providers.rs
@@ -1,0 +1,41 @@
+use crate::bytecode;
+use anyhow::Result;
+
+const QUICKJS_PROVIDER_MODULE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/provider.wasm"));
+
+/// Use the legacy provider when using the `compile -d` command.
+const QUICKJS_PROVIDER_V2_MODULE: &[u8] = include_bytes!("./javy_quickjs_provider_v2.wasm");
+
+/// Different providers that are available.
+#[derive(Debug)]
+pub enum Provider {
+    /// The default provider.
+    Default,
+    /// A provider for use with the `compile` to maintain backward compatibility.
+    V2,
+}
+
+impl Provider {
+    /// Returns the provider Wasm module as a byte slice.
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            Self::Default => QUICKJS_PROVIDER_MODULE,
+            Self::V2 => QUICKJS_PROVIDER_V2_MODULE,
+        }
+    }
+
+    /// Uses the provider to generate QuickJS bytecode.
+    pub fn compile_source(&self, js_source_code: &[u8]) -> Result<Vec<u8>> {
+        bytecode::compile_source(self, js_source_code)
+    }
+
+    /// The import namespace to use for this provider.
+    pub fn import_namespace(&self) -> String {
+        let prefix = "javy_quickjs_provider_v";
+        let version = match self {
+            Self::Default => 3,
+            Self::V2 => 2,
+        };
+        format!("{prefix}{version}")
+    }
+}


### PR DESCRIPTION
## Description of the change

I'm adding a `Provider` abstraction which provides methods that need to be polymorphic over a provider.

## Why am I making this change?

As part of #768 I'll need to thread a plugin module through a bunch of the code. This refactoring front-loads some of those changes.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
