### PR TITLE
Refactor to set a default provider

### DIFF
--- a/crates/cli/src/codegen/builder.rs
+++ b/crates/cli/src/codegen/builder.rs
@@ -51,7 +51,7 @@ impl WitOptions {
 #[derive(Default)]
 pub(crate) struct CodeGenBuilder {
     /// The provider to use.
-    provider: Option<Provider>,
+    provider: Provider,
     /// WIT options for code generation.
     wit_opts: WitOptions,
     /// Whether to compress the original JS source.
@@ -66,7 +66,7 @@ impl CodeGenBuilder {
 
     /// Set the provider.
     pub fn provider(&mut self, provider: Provider) -> &mut Self {
-        self.provider = Some(provider);
+        self.provider = provider;
         self
     }
 
@@ -110,15 +110,8 @@ impl CodeGenBuilder {
     fn build_dynamic(self) -> Result<Box<dyn CodeGen>> {
         let mut dynamic_gen = Box::new(DynamicGenerator::new());
         dynamic_gen.source_compression = self.source_compression;
-
-        if let Some(p) = self.provider {
-            dynamic_gen.provider = p
-        } else {
-            bail!("Provider version not specified")
-        }
-
+        dynamic_gen.provider = self.provider;
         dynamic_gen.wit_opts = self.wit_opts;
-
         Ok(dynamic_gen)
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -65,8 +65,7 @@ fn main() -> Result<()> {
             let mut builder = CodeGenBuilder::new();
             builder
                 .wit_opts(codegen.wit)
-                .source_compression(codegen.source_compression)
-                .provider(Provider::Default);
+                .source_compression(codegen.source_compression);
 
             let js_opts: JsOptionGroup = opts.js.clone().into();
             let mut gen = if codegen.dynamic {

--- a/crates/cli/src/providers.rs
+++ b/crates/cli/src/providers.rs
@@ -16,6 +16,12 @@ pub enum Provider {
     V2,
 }
 
+impl Default for Provider {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
 impl Provider {
     /// Returns the provider Wasm module as a byte slice.
     pub fn as_bytes(&self) -> &[u8] {


### PR DESCRIPTION
## Description of the change

Makes `Provider` implement the `Default` trait and removes some superfluous code as a result.

## Why am I making this change?

A refactoring to reduce the scope of the changes introduced in unifying static and dynamic codegen.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
