### PR TITLE
Refactor to minimize dependence on codegen trait

### DIFF
--- a/crates/cli/src/codegen/builder.rs
+++ b/crates/cli/src/codegen/builder.rs
@@ -83,11 +83,8 @@ impl CodeGenBuilder {
     }
 
     /// Build a [`CodeGenerator`].
-    pub fn build<T>(self, js_runtime_config: Config) -> Result<Box<dyn CodeGen>>
-    where
-        T: CodeGen,
-    {
-        match T::classify() {
+    pub fn build(self, ty: CodeGenType, js_runtime_config: Config) -> Result<Box<dyn CodeGen>> {
+        match ty {
             CodeGenType::Static => self.build_static(js_runtime_config),
             CodeGenType::Dynamic => {
                 if js_runtime_config != Config::default() {

--- a/crates/cli/src/codegen/dynamic.rs
+++ b/crates/cli/src/codegen/dynamic.rs
@@ -1,6 +1,6 @@
 use super::transform::{self, SourceCodeSection};
 use crate::{
-    codegen::{exports, CodeGen, CodeGenType, Exports, WitOptions},
+    codegen::{exports, CodeGen, Exports, WitOptions},
     js::JS,
     providers::Provider,
 };
@@ -279,10 +279,6 @@ impl CodeGen for DynamicGenerator {
         let wasm = module.emit_wasm();
         print_wat(&wasm)?;
         Ok(wasm)
-    }
-
-    fn classify() -> CodeGenType {
-        CodeGenType::Dynamic
     }
 }
 

--- a/crates/cli/src/codegen/mod.rs
+++ b/crates/cli/src/codegen/mod.rs
@@ -61,8 +61,4 @@ pub(crate) enum CodeGenType {
 pub(crate) trait CodeGen {
     /// Generate Wasm from a given JS source.
     fn generate(&mut self, source: &JS) -> anyhow::Result<Vec<u8>>;
-    /// Classify the [`CodeGen`] type.
-    fn classify() -> CodeGenType
-    where
-        Self: Sized;
 }

--- a/crates/cli/src/codegen/static.rs
+++ b/crates/cli/src/codegen/static.rs
@@ -12,7 +12,7 @@ use crate::{
     codegen::{
         exports,
         transform::{self, SourceCodeSection},
-        CodeGen, CodeGenType, Exports, WitOptions,
+        CodeGen, Exports, WitOptions,
     },
     js::JS,
 };
@@ -147,10 +147,6 @@ impl CodeGen for StaticGenerator {
         }
         transform::add_producers_section(&mut module.producers);
         Ok(module.emit_wasm())
-    }
-
-    fn classify() -> CodeGenType {
-        CodeGenType::Static
     }
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -10,7 +10,7 @@ use crate::codegen::WitOptions;
 use crate::commands::{Cli, Command, EmitProviderCommandOpts};
 use anyhow::Result;
 use clap::Parser;
-use codegen::{CodeGenBuilder, DynamicGenerator, StaticGenerator};
+use codegen::{CodeGenBuilder, CodeGenType};
 use commands::{CodegenOptionGroup, JsOptionGroup};
 use javy_config::Config;
 use js::JS;
@@ -49,9 +49,9 @@ fn main() -> Result<()> {
 
             let config = Config::default();
             let mut gen = if opts.dynamic {
-                builder.build::<DynamicGenerator>(config)?
+                builder.build(CodeGenType::Dynamic, config)?
             } else {
-                builder.build::<StaticGenerator>(config)?
+                builder.build(CodeGenType::Static, config)?
             };
 
             let wasm = gen.generate(&js)?;
@@ -70,9 +70,9 @@ fn main() -> Result<()> {
 
             let js_opts: JsOptionGroup = opts.js.clone().into();
             let mut gen = if codegen.dynamic {
-                builder.build::<DynamicGenerator>(js_opts.into())?
+                builder.build(CodeGenType::Dynamic, js_opts.into())?
             } else {
-                builder.build::<StaticGenerator>(js_opts.into())?
+                builder.build(CodeGenType::Static, js_opts.into())?
             };
 
             let wasm = gen.generate(&js)?;


### PR DESCRIPTION
## Description of the change

Switching to using `CodeGenType` enum instead of names of generators to determine linking behaviour.

## Why am I making this change?

Unifying the codegen will involve switching to a single codegen struct instead of two so we won't be able to use the name of the struct to determine linking behaviour and it'll make sense to delete the `Codegen` trait since there will only be a single implementation of it so this will minimize how much we depend on those details.

I'm considering if it makes sense to change `CodegenType` to a name like `LinkingType` too.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
