### PR TITLE
Add init-plugin subcommand

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -48,6 +48,9 @@ pub enum Command {
     /// Emits the plugin binary that is required to run dynamically
     /// linked WebAssembly modules.
     EmitProvider(EmitProviderCommandOpts),
+    /// Initializes a plugin binary.
+    #[command(arg_required_else_help = true)]
+    InitPlugin(InitPluginCommandOpts),
 }
 
 #[derive(Debug, Parser)]
@@ -108,6 +111,16 @@ pub struct BuildCommandOpts {
 pub struct EmitProviderCommandOpts {
     #[structopt(short, long)]
     /// Output path for the plugin binary (default is stdout).
+    pub out: Option<PathBuf>,
+}
+
+#[derive(Debug, Parser)]
+pub struct InitPluginCommandOpts {
+    #[arg(value_name = "PLUGIN", required = true)]
+    /// Path to the plugin to initialize.
+    pub plugin: PathBuf,
+    #[arg(short, long = "out")]
+    /// Output path for the initialized plugin binary (default is stdout).
     pub out: Option<PathBuf>,
 }
 

--- a/crates/cli/src/plugins.rs
+++ b/crates/cli/src/plugins.rs
@@ -1,12 +1,15 @@
 use crate::bytecode;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use serde::Deserialize;
 use std::{
+    fs,
     io::{Read, Seek},
     str,
 };
+use walrus::{ExportItem, ValType};
 use wasi_common::{pipe::WritePipe, sync::WasiCtxBuilder};
 use wasmtime::{AsContextMut, Engine, Linker};
+use wizer::Wizer;
 
 const PLUGIN_MODULE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/plugin.wasm"));
 
@@ -116,8 +119,171 @@ impl Plugin {
     }
 }
 
+/// A validated but uninitialized plugin.
+pub(super) struct UninitializedPlugin<'a> {
+    bytes: &'a [u8],
+}
+
+impl<'a> UninitializedPlugin<'a> {
+    /// Creates a validated but uninitialized plugin.
+    pub fn new(bytes: &'a [u8]) -> Result<Self> {
+        Self::validate(bytes)?;
+        Ok(Self { bytes })
+    }
+
+    fn validate(plugin_bytes: &'a [u8]) -> Result<()> {
+        let mut errors = vec![];
+
+        let module = walrus::Module::from_buffer(plugin_bytes)?;
+
+        if let Err(err) = Self::validate_exported_func(&module, "initialize_runtime", &[], &[]) {
+            errors.push(err);
+        }
+        if let Err(err) = Self::validate_exported_func(
+            &module,
+            "compile_src",
+            &[ValType::I32, ValType::I32],
+            &[ValType::I32],
+        ) {
+            errors.push(err);
+        }
+        if let Err(err) = Self::validate_exported_func(
+            &module,
+            "invoke",
+            &[ValType::I32, ValType::I32, ValType::I32, ValType::I32],
+            &[],
+        ) {
+            errors.push(err);
+        }
+
+        let has_memory = module
+            .exports
+            .iter()
+            .any(|export| export.name == "memory" && matches!(export.item, ExportItem::Memory(_)));
+        if !has_memory {
+            errors.push("missing exported memory named `memory`".to_string());
+        }
+
+        let has_import_namespace = module
+            .customs
+            .iter()
+            .any(|(_, section)| section.name() == "import_namespace");
+        if !has_import_namespace {
+            errors.push("missing custom section named `import_namespace`".to_string());
+        }
+
+        if !errors.is_empty() {
+            bail!("Problems with module: {}", errors.join(", "))
+        }
+        Ok(())
+    }
+
+    /// Initializes the plugin.
+    pub fn initialize(&self) -> Result<Vec<u8>> {
+        let initialized_plugin = Wizer::new()
+            .allow_wasi(true)?
+            .init_func("initialize_runtime")
+            .keep_init_func(true)
+            .wasm_bulk_memory(true)
+            .run(self.bytes)?;
+
+        let tempdir = tempfile::tempdir()?;
+        let in_tempfile_path = tempdir.path().join("in_temp.wasm");
+        let out_tempfile_path = tempdir.path().join("out_temp.wasm");
+        fs::write(&in_tempfile_path, initialized_plugin)?;
+        wasm_opt::OptimizationOptions::new_opt_level_3() // Aggressively optimize for speed.
+            .shrink_level(wasm_opt::ShrinkLevel::Level0) // Don't optimize for size at the expense of performance.
+            .debug_info(false)
+            .run(&in_tempfile_path, &out_tempfile_path)?;
+        Ok(fs::read(out_tempfile_path)?)
+    }
+
+    fn validate_exported_func(
+        module: &walrus::Module,
+        name: &str,
+        expected_params: &[ValType],
+        expected_results: &[ValType],
+    ) -> Result<(), String> {
+        let func_id = module
+            .exports
+            .get_func(name)
+            .map_err(|_| format!("missing export for function named `{name}`"))?;
+        let function = module.funcs.get(func_id);
+        let ty_id = function.ty();
+        let ty = module.types.get(ty_id);
+        let params = ty.params();
+        let has_correct_params = params == expected_params;
+        let results = ty.results();
+        let has_correct_results = results == expected_results;
+        if !has_correct_params || !has_correct_results {
+            return Err(format!("type for function `{name}` is incorrect"));
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ConfigSchema {
     supported_properties: Vec<JsConfigProperty>,
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use walrus::{FunctionBuilder, ModuleConfig, ValType};
+
+    use crate::plugins::UninitializedPlugin;
+
+    #[test]
+    fn test_validate_plugin_with_everything_missing() -> Result<()> {
+        let mut empty_module = walrus::Module::with_config(ModuleConfig::default());
+        let plugin_bytes = empty_module.emit_wasm();
+        let error = UninitializedPlugin::new(&plugin_bytes).err().unwrap();
+        assert_eq!(
+            error.to_string(),
+            "Problems with module: missing export for function named \
+            `initialize_runtime`, missing export for function named \
+            `compile_src`, missing export for function named `invoke`, \
+            missing exported memory named `memory`, missing custom section \
+            named `import_namespace`"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_validate_plugin_with_wrong_params_for_initialize_runtime() -> Result<()> {
+        let mut module = walrus::Module::with_config(ModuleConfig::default());
+        let initialize_runtime = FunctionBuilder::new(&mut module.types, &[ValType::I32], &[])
+            .finish(vec![], &mut module.funcs);
+        module.exports.add("initialize_runtime", initialize_runtime);
+
+        let plugin_bytes = module.emit_wasm();
+        let error = UninitializedPlugin::new(&plugin_bytes).err().unwrap();
+        let expected_part_of_error =
+            "Problems with module: type for function `initialize_runtime` is incorrect,";
+        if !error.to_string().contains(expected_part_of_error) {
+            panic!("Expected error to contain '{expected_part_of_error}' but it did not. Full error is: '{error}'");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_validate_plugin_with_wrong_results_for_initialize_runtime() -> Result<()> {
+        let mut module = walrus::Module::with_config(ModuleConfig::default());
+        let mut initialize_runtime = FunctionBuilder::new(&mut module.types, &[], &[ValType::I32]);
+        initialize_runtime.func_body().i32_const(0);
+        let initialize_runtime = initialize_runtime.finish(vec![], &mut module.funcs);
+        module.exports.add("initialize_runtime", initialize_runtime);
+
+        let plugin_bytes = module.emit_wasm();
+        let error = UninitializedPlugin::new(&plugin_bytes).err().unwrap();
+        let expected_part_of_error =
+            "Problems with module: type for function `initialize_runtime` is incorrect,";
+        if !error.to_string().contains(expected_part_of_error) {
+            panic!("Expected error to contain '{expected_part_of_error}' but it did not. Full error is: '{error}'");
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Description of the change

Adds a new subcommand called `init-plugin`. This subcommand will validate a Javy plugin and then initialize it by running Wizer on the `initialize_runtime` exported function and output the wizened module. It also runs `wasm-opt` on the resulting module. This does not include documentation changes as I want to tackle documentation changes more holistically to take into account all of the steps involved.

## Why am I making this change?

Part of #768. Out-of-the-box plugins will not have a Javy runtime present in their runtime `OnceCell` so trying to run `compile_src` or `invoke` will fail. We had three options for how to tackle this: (1) add an initialization command to Javy, (2) invoke `initialize_runtime`, or (3) expect plugin developers to run `wizer` themselves with the correct arguments. (2) imposes an unacceptable performance penalty and (3) is prone to human error, so we've opted to go with (1).

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
