### PR TITLE
Automatically select Wizer version in build-assets

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -24,11 +24,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install wizer
-        env:
-          WIZER_VERSION: 3.0.1
+      - name: Read wizer version
+        id: wizer_version
+        shell: bash
         run: |
-          wget -nv https://github.com/bytecodealliance/wizer/releases/download/v${{ env.WIZER_VERSION }}/wizer-v${{ env.WIZER_VERSION }}-x86_64-macos.tar.xz -O /tmp/wizer.tar.xz
+          VERSION=$(cargo metadata --format-version=1 --locked | jq '.packages[] | select(.name == "wizer") | .version' -r)
+          echo "WIZER_VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Install wizer
+        shell: bash
+        run: |
+          wget -nv https://github.com/bytecodealliance/wizer/releases/download/v${{ steps.wizer_version.outputs.WIZER_VERSION }}/wizer-v${{ steps.wizer_version.outputs.WIZER_VERSION }}-x86_64-macos.tar.xz -O /tmp/wizer.tar.xz
           mkdir /tmp/wizer
           tar xvf /tmp/wizer.tar.xz --strip-components=1 -C /tmp/wizer
           echo "/tmp/wizer" >> $GITHUB_PATH


### PR DESCRIPTION
## Description of the change

Changes the build asset step to use the `Cargo.toml` to select the version of Wizer to download.

## Why am I making this change?

Feedback in #799.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
