### PR TITLE
Stop using deprecated set-output in GitHub Action workflows

### DIFF
--- a/.github/actions/ci-shared-setup/action.yml
+++ b/.github/actions/ci-shared-setup/action.yml
@@ -30,7 +30,7 @@ runs:
       shell: bash
       run: |
         VERSION=$(cargo metadata --format-version=1 --locked | jq '.packages[] | select(.name == "wasmtime") | .version' -r)
-        echo "::set-output name=wasmtime_version::$VERSION"
+        echo "wasmtime_version=$VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Install wasmtime-cli
       shell: bash

--- a/.github/workflows/check-fuzz.yml
+++ b/.github/workflows/check-fuzz.yml
@@ -1,6 +1,6 @@
 # Smoke test to build fuzz targets.
 # Deserves its own action given that it depends on nightly
-# and there's currently no way to define multiple toolchains through the 
+# and there's currently no way to define multiple toolchains through the
 # `rust-toolchain.toml` configuration file.
 name: Build Fuzz Targets
 on:
@@ -20,14 +20,14 @@ jobs:
         shell: bash
         run: |
           NIGHTLY_VERSION=$(cat pinned-nightly-version)
-          echo "::set-output name=nightly_version::$NIGHTLY_VERSION"
+          echo "nightly_version=$NIGHTLY_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Read cargo fuzz version
         id: cargo_fuzz_version
         shell: bash
         run: |
           CARGO_FUZZ_VERSION=$(cat pinned-cargo-fuzz-version)
-          echo "::set-output name=cargo_fuzz_version::$CARGO_FUZZ_VERSION"
+          echo "cargo_fuzz_version=$CARGO_FUZZ_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install nightly
         run: |


### PR DESCRIPTION
## Description of the change

Uses the updated syntax for setting step outputs.

## Why am I making this change?

We're getting deprecation warnings using the current syntax. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
