### PR TITLE
Refactor plugin use in test infra

### DIFF
--- a/crates/test-macros/src/lib.rs
+++ b/crates/test-macros/src/lib.rs
@@ -291,11 +291,13 @@ fn expand_cli_tests(test_config: &CliTestConfig, func: syn::ItemFn) -> Result<To
             if command_name == "Compile" {
                 quote! {
                     let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+                    let plugin = javy_runner::Plugin::V2;
+                    let namespace = plugin.namespace();
+                    builder.plugin(plugin);
                     builder.preload(
-                        "javy_quickjs_provider_v2".into(),
+                        namespace.into(),
                         root.join("src").join("javy_quickjs_provider_v2.wasm")
                     );
-                    builder.plugin_version(2);
                 }
             } else {
                 quote! {
@@ -308,11 +310,10 @@ fn expand_cli_tests(test_config: &CliTestConfig, func: syn::ItemFn) -> Result<To
                             .join("release")
                             .join("plugin_wizened.wasm"),
                     );
-                    // TODO: Deriving the current plugin version could be done
-                    // automatically somehow. It's fine for now, given that if the
-                    // version changes and this is not updated, tests will fail.
-                    builder.preload("javy_quickjs_provider_v3".into(), root);
-                    builder.plugin_version(3);
+                    let plugin = javy_runner::Plugin::Default;
+                    let namespace = plugin.namespace();
+                    builder.plugin(plugin);
+                    builder.preload(namespace.into(), root);
                 }
             }
         } else {


### PR DESCRIPTION
## Description of the change

Small refactoring of test infra to use a plugin abstraction so I can slot in an additional variant when I add user plugins.

## Why am I making this change?

Part of #768. I found I needed to be fairly invasive in this code when adding support for a user plugin so I'm doing a simpler refactoring first. 

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
