### PR TITLE
Add non-breaking Dependabot group to NPM package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 100
+    groups:
+      nonbreaking:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Description of the change

Adding a group for non-breaking changes to the NPM package. 

## Why am I making this change?

To reduce the number of PRs generated by Dependabot for the NPM package.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
