### PR TITLE
Allow plugins when building static modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,12 @@ jobs:
           name: plugin
           path: target/wasm32-wasip1/release/
 
+      - name: Build test-plugin
+        run: |
+          cargo build --package=javy-test-plugin --release --target=wasm32-wasip1
+          CARGO_PROFILE_RELEASE_LTO=off cargo build --package=javy-cli --release
+          target/release/javy init-plugin target/wasm32-wasip1/release/test_plugin.wasm -o crates/runner/test_plugin.wasm
+
       - name: Test CLI
         run: CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-cli --release -- --nocapture
 

--- a/.github/workflows/cli-features.yml
+++ b/.github/workflows/cli-features.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           os: linux
 
+      - name: Build test-plugin
+        run: |
+          cargo build --package=javy-test-plugin --release --target=wasm32-wasip1
+          CARGO_PROFILE_RELEASE_LTO=off cargo build --package=javy-cli --release
+          target/release/javy init-plugin target/wasm32-wasip1/release/test_plugin.wasm -o crates/runner/test_plugin.wasm
+
       - name: Test `experimental_event_loop`
         run: |
           cargo build --package=javy-plugin --target=wasm32-wasip1 --release --features=experimental_event_loop

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,6 +1632,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "javy-test-plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "javy-plugin-api",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "crates/plugin",
   "crates/plugin-api",
   "crates/test-macros",
+  "crates/test-plugin",
   "crates/runner",
   "fuzz",
 ]

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ cli: plugin
 plugin:
 	cargo build --package=javy-plugin --release --target=wasm32-wasip1 --features=$(PLUGIN_FEATURES)
 
+build-test-plugin: cli
+	cargo build --package=javy-test-plugin --release --target=wasm32-wasip1
+	target/release/javy init-plugin target/wasm32-wasip1/release/test_plugin.wasm -o crates/runner/test_plugin.wasm
+
 docs:
 	cargo doc --package=javy-cli --open
 	cargo doc --package=javy-plugin --open --target=wasm32-wasip1
@@ -33,7 +37,7 @@ test-plugin:
 # Test in release mode to skip some debug assertions
 # Note: to make this faster, the engine should be optimized beforehand (wasm-strip + wasm-opt).
 # Disabling LTO substantially improves compile time
-test-cli: plugin
+test-cli: plugin build-test-plugin
 	CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-cli --release --features=$(CLI_FEATURES) -- --nocapture
 
 test-runner:

--- a/crates/cli/src/codegen/builder.rs
+++ b/crates/cli/src/codegen/builder.rs
@@ -88,6 +88,11 @@ impl CodeGenBuilder {
             if js_runtime_config.has_configs() {
                 bail!("Cannot set JS runtime options when building a dynamic module")
             }
+            // This is temporary. So I can make the change for dynamic modules
+            // separately because it will be a breaking change.
+            if let Plugin::User { .. } = self.plugin {
+                bail!("Cannot use plugins for building dynamic modules")
+            }
         }
         let mut generator = Generator::new(ty, js_runtime_config, self.plugin);
         generator.source_compression = self.source_compression;

--- a/crates/cli/src/codegen/builder.rs
+++ b/crates/cli/src/codegen/builder.rs
@@ -88,11 +88,6 @@ impl CodeGenBuilder {
             if js_runtime_config.has_configs() {
                 bail!("Cannot set JS runtime options when building a dynamic module")
             }
-            // This is temporary. So I can make the change for dynamic modules
-            // separately because it will be a breaking change.
-            if let Plugin::User { .. } = self.plugin {
-                bail!("Cannot use plugins for building dynamic modules")
-            }
         }
         let mut generator = Generator::new(ty, js_runtime_config, self.plugin);
         generator.source_compression = self.source_compression;

--- a/crates/cli/src/codegen/mod.rs
+++ b/crates/cli/src/codegen/mod.rs
@@ -279,7 +279,7 @@ impl Generator {
             // tests are executed with Javy built with the release profile so
             // `debug_assert!`s are stripped out.
             assert!(
-                matches!(self.plugin, Plugin::User { .. }),
+                self.plugin.is_user_plugin(),
                 "Using invoke with null function only supported for user plugins"
             );
             instructions
@@ -358,9 +358,9 @@ impl Generator {
             CodeGenType::Static => {
                 // Remove no longer necessary exports.
                 module.exports.remove("canonical_abi_realloc")?;
-                // `eval_bytecode` is not present in user plugins and `remove`
-                // returns an error if the export is not present.
-                if module.exports.get_func("eval_bytecode").is_ok() {
+                // User plugins won't have an `eval_bytecode` function that
+                // Javy "owns".
+                if !self.plugin.is_user_plugin() {
                     module.exports.remove("eval_bytecode")?;
                 }
                 module.exports.remove("invoke")?;

--- a/crates/cli/src/codegen/mod.rs
+++ b/crates/cli/src/codegen/mod.rs
@@ -66,7 +66,7 @@ pub(crate) enum CodeGenType {
 // This is an internal detail of this module.
 pub(crate) struct Identifiers {
     canonical_abi_realloc: FunctionId,
-    eval_bytecode: FunctionId,
+    eval_bytecode: Option<FunctionId>,
     invoke: FunctionId,
     memory: MemoryId,
 }
@@ -74,7 +74,7 @@ pub(crate) struct Identifiers {
 impl Identifiers {
     fn new(
         canonical_abi_realloc: FunctionId,
-        eval_bytecode: FunctionId,
+        eval_bytecode: Option<FunctionId>,
         invoke: FunctionId,
         memory: MemoryId,
     ) -> Self {
@@ -173,7 +173,7 @@ impl Generator {
         match self.ty {
             CodeGenType::Static => {
                 let canonical_abi_realloc_fn = module.exports.get_func("canonical_abi_realloc")?;
-                let eval_bytecode = module.exports.get_func("eval_bytecode")?;
+                let eval_bytecode = module.exports.get_func("eval_bytecode").ok();
                 let invoke = module.exports.get_func("invoke")?;
                 let ExportItem::Memory(memory) = module
                     .exports
@@ -226,7 +226,7 @@ impl Generator {
 
                 Ok(Identifiers::new(
                     canonical_abi_realloc_fn_id,
-                    eval_bytecode_fn_id,
+                    Some(eval_bytecode_fn_id),
                     invoke_fn_id,
                     memory_id,
                 ))
@@ -247,7 +247,8 @@ impl Generator {
 
         let mut main = FunctionBuilder::new(&mut module.types, &[], &[]);
         let bytecode_ptr_local = module.locals.add(ValType::I32);
-        main.func_body()
+        let mut instructions = main.func_body();
+        instructions
             // Allocate memory in plugin instance for bytecode array.
             .i32_const(0) // orig ptr
             .i32_const(0) // orig size
@@ -259,11 +260,35 @@ impl Generator {
             .i32_const(0) // offset into data segment for mem.init
             .i32_const(bytecode_len) // size to copy from data segment
             // top-2: dest addr, top-1: offset into source, top-0: size of memory region in bytes.
-            .memory_init(imports.memory, bytecode_data)
-            // Evaluate bytecode.
-            .local_get(bytecode_ptr_local) // ptr to bytecode
-            .i32_const(bytecode_len)
-            .call(imports.eval_bytecode);
+            .memory_init(imports.memory, bytecode_data);
+        // Evaluate top level scope.
+        if let Some(eval_bytecode) = imports.eval_bytecode {
+            instructions
+                .local_get(bytecode_ptr_local) // ptr to bytecode
+                .i32_const(bytecode_len)
+                .call(eval_bytecode);
+        } else {
+            // Assert we're not emitting a call with a null function to
+            // invoke for `javy_quickjs_provider_v*`.
+            // `javy_quickjs_provider_v2` will never support calling `invoke`
+            // with a null function. Older `javy_quickjs_provider_v3`'s do not
+            // support being called with a null function. User plugins and
+            // newer `javy_quickjs_provider_v3`s do support being called with a
+            // null function.
+            // Using `assert!` instead of `debug_assert!` because integration
+            // tests are executed with Javy built with the release profile so
+            // `debug_assert!`s are stripped out.
+            assert!(
+                matches!(self.plugin, Plugin::User { .. }),
+                "Using invoke with null function only supported for user plugins"
+            );
+            instructions
+                .local_get(bytecode_ptr_local) // ptr to bytecode
+                .i32_const(bytecode_len)
+                .i32_const(0) // set function name ptr to null
+                .i32_const(0) // set function name len to 0
+                .call(imports.invoke);
+        }
         let main = main.finish(vec![], &mut module.funcs);
 
         module.exports.add("_start", main);
@@ -333,7 +358,11 @@ impl Generator {
             CodeGenType::Static => {
                 // Remove no longer necessary exports.
                 module.exports.remove("canonical_abi_realloc")?;
-                module.exports.remove("eval_bytecode")?;
+                // `eval_bytecode` is not present in user plugins and `remove`
+                // returns an error if the export is not present.
+                if module.exports.get_func("eval_bytecode").is_ok() {
+                    module.exports.remove("eval_bytecode")?;
+                }
                 module.exports.remove("invoke")?;
                 module.exports.remove("compile_src")?;
 

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -105,6 +105,10 @@ pub struct BuildCommandOpts {
     /// JavaScript runtime options.
     /// Use `-J help` for more details.
     pub js: Vec<JsGroupValue>,
+
+    #[arg(short, long)]
+    /// Path of the plugin.
+    pub plugin: Option<PathBuf>,
 }
 
 #[derive(Debug, Parser)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -63,12 +63,16 @@ fn main() -> Result<()> {
         Command::Build(opts) => {
             let js = JS::from_file(&opts.input)?;
             let codegen: CodegenOptionGroup = opts.codegen.clone().try_into()?;
+            let plugin = match &opts.plugin {
+                Some(path) => Plugin::new_user_plugin(path)?,
+                None => Plugin::Default,
+            };
+            let js_opts = JsConfig::from_group_values(&plugin, opts.js.clone())?;
             let mut builder = CodeGenBuilder::new();
             builder
                 .wit_opts(codegen.wit)
-                .source_compression(codegen.source_compression);
-
-            let js_opts = JsConfig::from_group_values(&Plugin::Default, opts.js.clone())?;
+                .source_compression(codegen.source_compression)
+                .plugin(plugin);
             let mut gen = if codegen.dynamic {
                 builder.build(CodeGenType::Dynamic, js_opts)?
             } else {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -63,8 +63,8 @@ fn main() -> Result<()> {
         Command::Build(opts) => {
             let js = JS::from_file(&opts.input)?;
             let codegen: CodegenOptionGroup = opts.codegen.clone().try_into()?;
-            let plugin = match &opts.plugin {
-                Some(path) => Plugin::new_user_plugin(path)?,
+            let plugin = match codegen.plugin {
+                Some(path) => Plugin::new_user_plugin(&path)?,
                 None => Plugin::Default,
             };
             let js_opts = JsConfig::from_group_values(&plugin, opts.js.clone())?;

--- a/crates/cli/src/plugins.rs
+++ b/crates/cli/src/plugins.rs
@@ -45,10 +45,16 @@ impl Default for Plugin {
 }
 
 impl Plugin {
+    /// Creates a new user plugin.
     pub fn new_user_plugin(path: &Path) -> Result<Self> {
         Ok(Self::User {
             bytes: fs::read(path)?,
         })
+    }
+
+    /// Returns true if the plugin is a user plugin.
+    pub fn is_user_plugin(&self) -> bool {
+        matches!(&self, Plugin::User { .. })
     }
 
     /// Returns the plugin Wasm module as a byte slice.

--- a/crates/cli/tests/dynamic_linking_test.rs
+++ b/crates/cli/tests/dynamic_linking_test.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use javy_runner::Builder;
+use javy_runner::{Builder, Plugin};
 use javy_test_macros::javy_cli_test;
 
 #[javy_cli_test(dyn = true, root = "tests/dynamic-linking-scripts")]
@@ -126,6 +126,17 @@ fn javy_json_identity(builder: &mut Builder) -> Result<()> {
 
     assert_eq!(String::from_utf8(out)?, input);
     assert_eq!(String::from_utf8(logs)?, "undefined\n");
+
+    Ok(())
+}
+
+#[javy_cli_test(dyn = true, commands(not(Compile)))]
+fn test_using_plugin_with_dynamic_build_fails(builder: &mut Builder) -> Result<()> {
+    let result = builder.plugin(Plugin::User).input("plugin.js").build();
+    let err = result.err().unwrap();
+    assert!(err
+        .to_string()
+        .contains("Cannot use plugins for building dynamic modules"));
 
     Ok(())
 }

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use javy_runner::{Builder, Runner, RunnerError};
+use javy_runner::{Builder, Plugin, Runner, RunnerError};
 use std::{path::PathBuf, process::Command, str};
 use wasi_common::sync::WasiCtxBuilder;
 use wasmtime::{AsContextMut, Engine, Linker, Module, Store};
@@ -132,6 +132,32 @@ fn test_javy_json_disabled(builder: &mut Builder) -> Result<()> {
 
     let result = runner.exec(&[]);
     assert!(result.is_err());
+
+    Ok(())
+}
+
+#[javy_cli_test(commands(not(Compile)))]
+fn test_using_plugin_with_static_build(builder: &mut Builder) -> Result<()> {
+    let mut runner = builder.plugin(Plugin::User).input("plugin.js").build()?;
+
+    let result = runner.exec(&[]);
+    assert!(result.is_ok());
+
+    Ok(())
+}
+
+#[javy_cli_test(commands(not(Compile)))]
+fn test_using_plugin_with_static_build_fails_with_runtime_config(
+    builder: &mut Builder,
+) -> Result<()> {
+    let result = builder
+        .plugin(Plugin::User)
+        .simd_json_builtins(true)
+        .build();
+    let err = result.err().unwrap();
+    assert!(err
+        .to_string()
+        .contains("Property simd-json-builtins is not supported for runtime configuration"));
 
     Ok(())
 }

--- a/crates/cli/tests/sample-scripts/plugin.js
+++ b/crates/cli/tests/sample-scripts/plugin.js
@@ -1,0 +1,3 @@
+if (plugin !== true) {
+    throw new Error("Not using the test_plugin");
+}

--- a/crates/runner/.gitignore
+++ b/crates/runner/.gitignore
@@ -1,0 +1,1 @@
+test_plugin.wasm

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -588,8 +588,11 @@ impl Runner {
         }
 
         if let Plugin::User = plugin {
-            args.push("-p".to_string());
-            args.push(Self::plugin_path().to_str().unwrap().to_string());
+            args.push("-C".to_string());
+            args.push(format!(
+                "plugin={}",
+                Self::plugin_path().to_str().unwrap().to_string()
+            ));
         }
 
         args

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -22,6 +22,7 @@ pub enum JavyCommand {
 pub enum Plugin {
     V2,
     Default,
+    User,
 }
 
 impl Plugin {
@@ -31,6 +32,7 @@ impl Plugin {
             // Could try and derive this but not going to for now since tests
             // will break if it changes.
             Self::Default => "javy_quickjs_provider_v3",
+            Self::User { .. } => "test_plugin",
         }
     }
 }
@@ -205,6 +207,7 @@ impl Builder {
                 simd_json_builtins,
                 text_encoding,
                 preload,
+                plugin,
             ),
         }
     }
@@ -280,6 +283,7 @@ impl Runner {
         override_json_parse_and_stringify: Option<bool>,
         text_encoding: Option<bool>,
         preload: Option<(String, PathBuf)>,
+        plugin: Plugin,
     ) -> Result<Self> {
         // This directory is unique and will automatically get deleted
         // when `tempdir` goes out of scope.
@@ -299,6 +303,7 @@ impl Runner {
             &javy_stream_io,
             &override_json_parse_and_stringify,
             &text_encoding,
+            &plugin,
         );
 
         Self::exec_command(bin, root, args)?;
@@ -527,6 +532,7 @@ impl Runner {
         javy_stream_io: &Option<bool>,
         simd_json_builtins: &Option<bool>,
         text_encoding: &Option<bool>,
+        plugin: &Plugin,
     ) -> Vec<String> {
         let mut args = vec![
             "build".to_string(),
@@ -579,6 +585,11 @@ impl Runner {
         if let Some(enabled) = *text_encoding {
             args.push("-J".to_string());
             args.push(format!("text-encoding={}", if enabled { "y" } else { "n" }));
+        }
+
+        if let Plugin::User = plugin {
+            args.push("-p".to_string());
+            args.push(Self::plugin_path().to_str().unwrap().to_string());
         }
 
         args
@@ -803,6 +814,10 @@ impl Runner {
             }
             .into()),
         }
+    }
+
+    fn plugin_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_plugin.wasm")
     }
 }
 

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -589,10 +589,7 @@ impl Runner {
 
         if let Plugin::User = plugin {
             args.push("-C".to_string());
-            args.push(format!(
-                "plugin={}",
-                Self::plugin_path().to_str().unwrap().to_string()
-            ));
+            args.push(format!("plugin={}", Self::plugin_path().to_str().unwrap()));
         }
 
         args

--- a/crates/test-plugin/Cargo.toml
+++ b/crates/test-plugin/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "javy-test-plugin"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+name = "test_plugin"
+crate-type = ["cdylib"]
+
+[dependencies]
+anyhow = { workspace = true }
+javy-plugin-api = { path = "../plugin-api", features = ["json"] }

--- a/crates/test-plugin/src/lib.rs
+++ b/crates/test-plugin/src/lib.rs
@@ -1,0 +1,19 @@
+//! Plugin used for testing. We need a plugin with slightly different behavior
+//! to validate a plugin is actually used when it should be.
+
+use javy_plugin_api::{import_namespace, javy::Config};
+
+import_namespace!("test_plugin");
+
+#[export_name = "initialize_runtime"]
+pub extern "C" fn initialize_runtime() {
+    let config = Config::default();
+    javy_plugin_api::initialize_runtime(config, |runtime| {
+        runtime
+            .context()
+            .with(|ctx| ctx.globals().set("plugin", true))
+            .unwrap();
+        runtime
+    })
+    .unwrap();
+}


### PR DESCRIPTION
## Description of the change

Add a `-p` or `--plugin` flag to `javy build` to support using a user-provided plugin. I've disabled allowing plugins on dynamically linked modules in this PR since I want to make that a required parameter and that would represent a breaking change. I also don't want a version of Javy shipped where it is an optional parameter.

I've also added a test-plugin crate for use by the CLI tests so the tests can verify the plugin is being actually used by the generated Wasm module.

## Why am I making this change?

Part of #768. This enables using plugins for statically linked modules.

I opted to compile the test plugin as part of the Makefile and CI steps but I'm open to switching it so we commit the final artifact if that would be preferrable.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
