### PR TITLE
Update wording about javy compile in help text

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -33,8 +33,7 @@ pub enum Command {
     ///
     /// NOTICE:
     ///
-    /// This command will be deprecated in
-    /// the next major release of the CLI (v4.0.0)
+    /// This command is deprecated and will be removed.
     ///
     /// Refer to https://github.com/bytecodealliance/javy/issues/702 for
     /// details.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -28,8 +28,7 @@ fn main() -> Result<()> {
         Command::Compile(opts) => {
             eprintln!(
                 r#"
-                The `compile` command will be deprecated in the next major
-                release of the CLI (v4.0.0)
+                The `compile` command is deprecated and will be removed.
 
                 Refer to https://github.com/bytecodealliance/javy/issues/702 for
                 details.

--- a/crates/test-macros/src/lib.rs
+++ b/crates/test-macros/src/lib.rs
@@ -285,9 +285,9 @@ fn expand_cli_tests(test_config: &CliTestConfig, func: syn::ItemFn) -> Result<To
         );
 
         let preload_setup = if test_config.dynamic {
-            // The compile commmand will remain frozen until it becomes
-            // deprecated in Javy v4.0.0. Until then we test with a frozen
-            // artifact downloaded from the releases.
+            // The compile commmand will remain frozen until it is deleted.
+            // Until then we test with a frozen artifact downloaded from the
+            // releases.
             if command_name == "Compile" {
                 quote! {
                     let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Description of the change

Updating the wording in the help text for `javy compile` to indicate we don't have a firm deletion date.

## Why am I making this change?

We don't have a firm timeline for when we will delete the command.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
