### PR TITLE
Fix WIT world help text

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -201,8 +201,8 @@ option_group! {
         /// Optional path to WIT file describing exported functions. Only
         /// supports function exports with no arguments and no return values.
         Wit(PathBuf),
-        /// Optional path to WIT file describing exported functions. Only
-        /// supports function exports with no arguments and no return values.
+        /// Optional WIT world name for WIT file. Must be specified if WIT is
+        /// file path is specified.
         WitWorld(String),
         /// Enable source code compression, which generates smaller WebAssembly
         /// files at the cost of increased compile time.


### PR DESCRIPTION
## Description of the change

Updates the WIT world help text to match what it is.

## Why am I making this change?

I noticed the existing text seemed to be a copy of the WIT file help text.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
