### PR TITLE
Use string for RunnerError instead of byte vector

### DIFF
--- a/crates/cli/tests/dylib_test.rs
+++ b/crates/cli/tests/dylib_test.rs
@@ -41,7 +41,7 @@ fn test_dylib_with_error() -> Result<()> {
     let expected_log_output = "Error:1:24 foo error\n    at foo (function.mjs:1:24)\n    at <anonymous> (function.mjs:1:50)\n\n";
     assert_eq!(
         expected_log_output,
-        String::from_utf8(e.downcast_ref::<RunnerError>().unwrap().stderr.clone())?
+        e.downcast_ref::<RunnerError>().unwrap().stderr
     );
 
     Ok(())

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -190,9 +190,7 @@ fn test_promises(builder: &mut Builder) -> Result<()> {
     let mut runner = builder.input("promise.js").build()?;
     let res = runner.exec(&[]);
     let err = res.err().unwrap().downcast::<RunnerError>().unwrap();
-    assert!(str::from_utf8(&err.stderr)
-        .unwrap()
-        .contains("Pending jobs in the event queue."));
+    assert!(err.stderr.contains("Pending jobs in the event queue."));
 
     Ok(())
 }
@@ -272,7 +270,7 @@ fn test_error_handling(builder: &mut Builder) -> Result<()> {
 
     let expected_log_output = "Error:2:9 error\n    at error (function.mjs:2:9)\n    at <anonymous> (function.mjs:5:1)\n\n";
 
-    assert_eq!(expected_log_output, str::from_utf8(&err.stderr).unwrap());
+    assert_eq!(expected_log_output, err.stderr);
     Ok(())
 }
 

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -224,7 +224,7 @@ pub struct Runner {
 #[derive(Debug)]
 pub struct RunnerError {
     pub stdout: Vec<u8>,
-    pub stderr: Vec<u8>,
+    pub stderr: String,
     pub err: anyhow::Error,
 }
 
@@ -234,7 +234,7 @@ impl Display for RunnerError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "error: {:?}, stdout: {:?}, stderr: {:?}",
+            "error: {:?}, stdout: {:?}, stderr: {}",
             self.err, self.stdout, self.stderr
         )
     }
@@ -809,7 +809,7 @@ impl Runner {
             Ok(_) => Ok((output, logs, fuel_consumed)),
             Err(err) => Err(RunnerError {
                 stdout: output,
-                stderr: logs,
+                stderr: String::from_utf8(logs).unwrap(),
                 err,
             }
             .into()),


### PR DESCRIPTION
## Description of the change

Changes `RunnerError` in the test suite to represent the `stderr` output as a string instead of a `Vec<u8>`.

## Why am I making this change?

It makes runtime errors much easier to debug since the error messages are presented as strings instead of byte arrays. We don't have any test cases where we put non-utf-8 data on the stderr stream in an error case.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
