### PR TITLE
Refactor plugin paths in test suite

### DIFF
--- a/crates/cli/tests/dylib_test.rs
+++ b/crates/cli/tests/dylib_test.rs
@@ -1,9 +1,6 @@
 use anyhow::Result;
-use javy_runner::{Runner, RunnerError, UseExportedFn};
-use std::path::{Path, PathBuf};
+use javy_runner::{Plugin, Runner, RunnerError, UseExportedFn};
 use std::str;
-
-static ROOT: &str = env!("CARGO_MANIFEST_DIR");
 
 #[test]
 fn test_dylib() -> Result<()> {
@@ -60,15 +57,5 @@ fn test_dylib_with_exported_func() -> Result<()> {
 }
 
 fn plugin_module() -> Result<Vec<u8>> {
-    let mut lib_path = PathBuf::from(ROOT);
-    lib_path.pop();
-    lib_path.pop();
-    lib_path = lib_path.join(
-        Path::new("target")
-            .join("wasm32-wasip1")
-            .join("release")
-            .join("plugin_wizened.wasm"),
-    );
-
-    std::fs::read(lib_path).map_err(Into::into)
+    std::fs::read(Plugin::Default.path()).map_err(Into::into)
 }

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -35,6 +35,27 @@ impl Plugin {
             Self::User { .. } => "test_plugin",
         }
     }
+
+    pub fn path(&self) -> PathBuf {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        match self {
+            Self::V2 => root
+                .join("..")
+                .join("..")
+                .join("crates")
+                .join("cli")
+                .join("src")
+                .join("javy_quickjs_provider_v2.wasm"),
+            Self::User => root.join("test_plugin.wasm"),
+            Self::Default => root
+                .join("..")
+                .join("..")
+                .join("target")
+                .join("wasm32-wasip1")
+                .join("release")
+                .join("plugin_wizened.wasm"),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -589,7 +610,7 @@ impl Runner {
 
         if let Plugin::User = plugin {
             args.push("-C".to_string());
-            args.push(format!("plugin={}", Self::plugin_path().to_str().unwrap()));
+            args.push(format!("plugin={}", plugin.path().to_str().unwrap()));
         }
 
         args
@@ -814,10 +835,6 @@ impl Runner {
             }
             .into()),
         }
-    }
-
-    fn plugin_path() -> PathBuf {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_plugin.wasm")
     }
 }
 

--- a/crates/test-macros/src/lib.rs
+++ b/crates/test-macros/src/lib.rs
@@ -290,30 +290,18 @@ fn expand_cli_tests(test_config: &CliTestConfig, func: syn::ItemFn) -> Result<To
             // releases.
             if command_name == "Compile" {
                 quote! {
-                    let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
                     let plugin = javy_runner::Plugin::V2;
-                    let namespace = plugin.namespace();
-                    builder.plugin(plugin);
                     builder.preload(
-                        namespace.into(),
-                        root.join("src").join("javy_quickjs_provider_v2.wasm")
+                        plugin.namespace().into(),
+                        plugin.path(),
                     );
+                    builder.plugin(plugin);
                 }
             } else {
                 quote! {
-                    let mut root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-                    root.pop();
-                    root.pop();
-                    root = root.join(
-                        std::path::Path::new("target")
-                            .join("wasm32-wasip1")
-                            .join("release")
-                            .join("plugin_wizened.wasm"),
-                    );
                     let plugin = javy_runner::Plugin::Default;
-                    let namespace = plugin.namespace();
+                    builder.preload(plugin.namespace().into(), plugin.path());
                     builder.plugin(plugin);
-                    builder.preload(namespace.into(), root);
                 }
             }
         } else {


### PR DESCRIPTION
## Description of the change

Refactoring to consolidate file paths to the various plugins in the test suite code.

## Why am I making this change?

I needed to reference a plugin file path in new places for an upcoming and didn't want to copy code to resolve the path.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
