### PR TITLE
Rename emit-provider subcommand to emit-plugin

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -46,7 +46,7 @@ pub enum Command {
     Build(BuildCommandOpts),
     /// Emits the plugin binary that is required to run dynamically
     /// linked WebAssembly modules.
-    EmitProvider(EmitProviderCommandOpts),
+    EmitPlugin(EmitPluginCommandOpts),
     /// Initializes a plugin binary.
     #[command(arg_required_else_help = true)]
     InitPlugin(InitPluginCommandOpts),
@@ -64,7 +64,7 @@ pub struct CompileCommandOpts {
 
     #[arg(short)]
     /// Creates a smaller module that requires a dynamically linked QuickJS
-    /// plugin Wasm module to execute (see `emit-provider` command).
+    /// plugin Wasm module to execute (see `emit-plugin` command).
     pub dynamic: bool,
 
     #[structopt(long)]
@@ -107,7 +107,7 @@ pub struct BuildCommandOpts {
 }
 
 #[derive(Debug, Parser)]
-pub struct EmitProviderCommandOpts {
+pub struct EmitPluginCommandOpts {
     #[structopt(short, long)]
     /// Output path for the plugin binary (default is stdout).
     pub out: Option<PathBuf>,
@@ -196,7 +196,7 @@ option_group! {
     #[derive(Clone, Debug)]
     pub enum CodegenOption {
         /// Creates a smaller module that requires a dynamically linked QuickJS
-        /// plugin Wasm module to execute (see `emit-provider` command).
+        /// plugin Wasm module to execute (see `emit-plugin` command).
         Dynamic(bool),
         /// Optional path to WIT file describing exported functions. Only
         /// supports function exports with no arguments and no return values.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,7 +8,7 @@ mod plugins;
 mod wit;
 
 use crate::codegen::WitOptions;
-use crate::commands::{Cli, Command, EmitProviderCommandOpts};
+use crate::commands::{Cli, Command, EmitPluginCommandOpts};
 use anyhow::Result;
 use clap::Parser;
 use codegen::{CodeGenBuilder, CodeGenType};
@@ -24,7 +24,7 @@ fn main() -> Result<()> {
     let args = Cli::parse();
 
     match &args.command {
-        Command::EmitProvider(opts) => emit_plugin(opts),
+        Command::EmitPlugin(opts) => emit_plugin(opts),
         Command::Compile(opts) => {
             eprintln!(
                 r#"
@@ -99,7 +99,7 @@ fn main() -> Result<()> {
     }
 }
 
-fn emit_plugin(opts: &EmitProviderCommandOpts) -> Result<()> {
+fn emit_plugin(opts: &EmitPluginCommandOpts) -> Result<()> {
     let mut file: Box<dyn Write> = match opts.out.as_ref() {
         Some(path) => Box::new(File::create(path)?),
         _ => Box::new(std::io::stdout()),

--- a/docs/docs-using-dynamic-linking.md
+++ b/docs/docs-using-dynamic-linking.md
@@ -24,7 +24,7 @@ bytecode representation.
 The `plugin.wasm` module is available as an asset on the Javy
 release you are using. 
 
-It can also be obtained by running `javy emit-provider -o
+It can also be obtained by running `javy emit-plugin -o
 <path>` to write the module into `<path>`.
 
 #### Creating and running a dynamically linked module througy the CLI
@@ -34,7 +34,7 @@ Run:
 ```
 $ echo 'console.log("hello world!");' > my_code.js
 $ javy build -C dynamic -o my_code.wasm my_code.js
-$ javy emit-provider -o plugin.wasm
+$ javy emit-plugin -o plugin.wasm
 $ wasmtime run --preload javy_quickjs_provider_v3=plugin.wasm my_code.wasm
 hello world!
 ```

--- a/docs/docs-using-nodejs.md
+++ b/docs/docs-using-nodejs.md
@@ -17,7 +17,7 @@ javy build -C dynamic -o embedded.wasm embedded.js
 ```
 2. Next emit the Javy plugin
 ```shell
-javy emit-provider -o plugin.wasm
+javy emit-plugin -o plugin.wasm
 ```
 3. Then we can run `host.mjs`
 ```shell


### PR DESCRIPTION
## Description of the change

Renames `javy emit-provider` to `javy emit-plugin`. This is a breaking change of Javy's command line interface.

## Why am I making this change?

Part of #768. This will keep the terminology consistent in Javy.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
