### PR TITLE
Add support for plugins to dynamically linked modules

### DIFF
--- a/crates/cli/src/codegen/builder.rs
+++ b/crates/cli/src/codegen/builder.rs
@@ -84,11 +84,6 @@ impl CodeGenBuilder {
 
     /// Build a [`CodeGenerator`].
     pub fn build(self, ty: CodeGenType, js_runtime_config: JsConfig) -> Result<Generator> {
-        if let CodeGenType::Dynamic = ty {
-            if js_runtime_config.has_configs() {
-                bail!("Cannot set JS runtime options when building a dynamic module")
-            }
-        }
         let mut generator = Generator::new(ty, js_runtime_config, self.plugin);
         generator.source_compression = self.source_compression;
         generator.wit_opts = self.wit_opts;

--- a/crates/cli/src/js_config.rs
+++ b/crates/cli/src/js_config.rs
@@ -11,11 +11,6 @@ impl JsConfig {
         JsConfig(configs)
     }
 
-    /// Returns true if any configs are set.
-    pub(crate) fn has_configs(&self) -> bool {
-        !self.0.is_empty()
-    }
-
     /// Encode as JSON.
     pub(crate) fn to_json(&self) -> Result<Vec<u8>> {
         Ok(serde_json::to_vec(&self.0)?)

--- a/crates/cli/src/plugins.rs
+++ b/crates/cli/src/plugins.rs
@@ -57,6 +57,11 @@ impl Plugin {
         matches!(&self, Plugin::User { .. })
     }
 
+    /// Returns true if the plugin is the legacy v2 plugin.
+    pub fn is_v2_plugin(&self) -> bool {
+        matches!(&self, Plugin::V2)
+    }
+
     /// Returns the plugin Wasm module as a byte slice.
     pub fn as_bytes(&self) -> &[u8] {
         match self {

--- a/crates/test-macros/src/lib.rs
+++ b/crates/test-macros/src/lib.rs
@@ -299,7 +299,7 @@ fn expand_cli_tests(test_config: &CliTestConfig, func: syn::ItemFn) -> Result<To
                 }
             } else {
                 quote! {
-                    let plugin = javy_runner::Plugin::Default;
+                    let plugin = javy_runner::Plugin::DefaultAsUser;
                     builder.preload(plugin.namespace().into(), plugin.path());
                     builder.plugin(plugin);
                 }

--- a/docs/docs-using-dynamic-linking.md
+++ b/docs/docs-using-dynamic-linking.md
@@ -33,8 +33,8 @@ Run:
 
 ```
 $ echo 'console.log("hello world!");' > my_code.js
-$ javy build -C dynamic -o my_code.wasm my_code.js
 $ javy emit-provider -o plugin.wasm
+$ javy build -C dynamic -C plugin=plugin.wasm -o my_code.wasm my_code.js
 $ wasmtime run --preload javy_quickjs_provider_v3=plugin.wasm my_code.wasm
 hello world!
 ```

--- a/docs/docs-using-nodejs.md
+++ b/docs/docs-using-nodejs.md
@@ -11,15 +11,15 @@ This example shows how to use a dynamically linked Javy compiled Wasm module. We
 
 ### Steps
 
-1. The first step is to compile the `embedded.js` with Javy using dynamic linking:
-```shell
-javy build -C dynamic -o embedded.wasm embedded.js
-```
-2. Next emit the Javy plugin
+1. Emit the Javy plugin
 ```shell
 javy emit-provider -o plugin.wasm
 ```
-3. Then we can run `host.mjs`
+2. Compile the `embedded.js` with Javy using dynamic linking:
+```shell
+javy build -C dynamic -C plugin=plugin.wasm -o embedded.wasm embedded.js
+```
+3. Run `host.mjs`
 ```shell
 node --no-warnings=ExperimentalWarning host.mjs
 ```


### PR DESCRIPTION
## Description of the change

Changes from not supporting a plugin when creating dynamically linked modules to requiring a plugin when creating dynamically linked modules. This is a breaking change.

I've also updated the dynamic codegen to not emit calls to `eval_bytecode` for the default plugin.

## Why am I making this change?

Part of #768. We want to support using plugins when building dynamically linked modules. And, as I mention in a comment, we never want to assume the import namespace in the Javy CLI, so we need a plugin to be specified so we can derive the import namespace to use from it.

For the change to stop emitting calls to `eval_bytecode`, we want to remove `eval_bytecode` from the default plugin and the first step to doing that is to stop emitting new calls to `eval_bytecode`. The requirement to specify a plugin when building new dynamically linked modules means we can be sure the plugin used in any execution environment also supports calling `invoke` with a null function assuming the same or a newer plugin is used in the execution environment as is used when invoking `javy build -C dynamic -C plugin=...`.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
