### PR TITLE
Remove cmake from build requirements

### DIFF
--- a/docs/docs-contributing-building.md
+++ b/docs/docs-contributing-building.md
@@ -4,9 +4,6 @@
 - [rustup](https://rustup.rs/)
 - Stable Rust, installed via `rustup install stable && rustup default stable`
 - wasm32-wasip1, can be installed via `rustup target add wasm32-wasip1`
-- cmake, depending on your operating system and architecture, it might not be
-  installed by default. On MacOS it can be installed with `homebrew` via `brew
-  install cmake`. On Ubuntu, `sudo apt-get install cmake`.
 - Rosetta 2 if running MacOS on Apple Silicon, can be installed via
   `softwareupdate --install-rosetta`
 


### PR DESCRIPTION
## Description of the change

Removing `cmake` from the list of things that need to be installed to build Javy.

## Why am I making this change?

`cmake` does not appear to be necessary. Or at least I was able to build Javy on a fresh Ubuntu 24.04 without it.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
