### PR TITLE
Switch plugin to build on Linux

### DIFF
--- a/.github/actions/ci-shared-setup/action.yml
+++ b/.github/actions/ci-shared-setup/action.yml
@@ -1,9 +1,5 @@
 name: "Shared CI setup"
 description: "Common setup for CI pipeline workflow jobs"
-inputs:
-  os:
-    description: "The operating system for downloading binaries"
-    required: true
 runs:
   using: "composite"
   steps:
@@ -11,19 +7,19 @@ runs:
       uses: actions/cache@v3
       with:
         path: ~/.cargo
-        key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+        key: cargo-${{ hashFiles('Cargo.toml') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
-          ${{ runner.os }}-cargo
+          cargo-${{ hashFiles('Cargo.toml') }}
+          cargo
 
     - name: Cargo Target Cache
       uses: actions/cache@v3
       with:
         path: target
-        key: ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}
+        key: cargo-target-${{ hashFiles('Cargo.toml') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.toml') }}
-          ${{ runner.os }}-cargo-target
+          cargo-target-${{ hashFiles('Cargo.toml') }}
+          cargo-target
 
     - name: Read wasmtime version
       id: wasmtime_version
@@ -35,7 +31,7 @@ runs:
     - name: Install wasmtime-cli
       shell: bash
       run: |
-        wget -nv 'https://github.com/bytecodealliance/wasmtime/releases/download/v${{ steps.wasmtime_version.outputs.wasmtime_version }}/wasmtime-v${{ steps.wasmtime_version.outputs.wasmtime_version }}-x86_64-${{ inputs.os }}.tar.xz' -O /tmp/wasmtime.tar.xz
+        wget -nv 'https://github.com/bytecodealliance/wasmtime/releases/download/v${{ steps.wasmtime_version.outputs.wasmtime_version }}/wasmtime-v${{ steps.wasmtime_version.outputs.wasmtime_version }}-x86_64-linux.tar.xz' -O /tmp/wasmtime.tar.xz
         mkdir /tmp/wasmtime
         tar xvf /tmp/wasmtime.tar.xz --strip-components=1 -C /tmp/wasmtime
         echo "/tmp/wasmtime" >> $GITHUB_PATH

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   compile_plugin:
     name: compile_plugin
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -34,7 +34,7 @@ jobs:
       - name: Install wizer
         shell: bash
         run: |
-          wget -nv https://github.com/bytecodealliance/wizer/releases/download/v${{ steps.wizer_version.outputs.WIZER_VERSION }}/wizer-v${{ steps.wizer_version.outputs.WIZER_VERSION }}-x86_64-macos.tar.xz -O /tmp/wizer.tar.xz
+          wget -nv https://github.com/bytecodealliance/wizer/releases/download/v${{ steps.wizer_version.outputs.WIZER_VERSION }}/wizer-v${{ steps.wizer_version.outputs.WIZER_VERSION }}-x86_64-linux.tar.xz -O /tmp/wizer.tar.xz
           mkdir /tmp/wizer
           tar xvf /tmp/wizer.tar.xz --strip-components=1 -C /tmp/wizer
           echo "/tmp/wizer" >> $GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,20 +9,13 @@ on:
 jobs:
   plugin:
     name: test_plugin
-    # We test on `macos-latest` to accurately reflect
-    # the plugin Wasm binary that we attach to the releases,
-    # which is built on the latest macOS too.
-    # This is also helpful for testing fuel
-    # consumption in tests.
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
 
       - uses: ./.github/actions/ci-shared-setup
-        with:
-          os: macos
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
@@ -65,8 +58,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/ci-shared-setup
-        with:
-          os: linux
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/cli-features.yml
+++ b/.github/workflows/cli-features.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/ci-shared-setup
-        with:
-          os: linux
 
       - name: Build test-plugin
         run: |

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -16,8 +16,6 @@ jobs:
           submodules: true
 
       - uses: ./.github/actions/ci-shared-setup
-        with:
-          os: linux
 
       - name: WPT
         run: |


### PR DESCRIPTION
## Description of the change

Switches the plugin to build on Linux.

## Why am I making this change?

It looks like plugins produced with Linux use slightly fewer instructions than when produced with MacOS. Also GitHub Actions seems to be able to find Linux runners faster and they seem to compile and test faster than MacOS runners.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
