### PR TITLE
Speed up cli features GitHub Actions workflow

### DIFF
--- a/.github/workflows/cli-features.yml
+++ b/.github/workflows/cli-features.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Build test-plugin
         # Need to build Javy default plugin and Javy CLI to run `javy init-plugin` on the test plugin.
         run: |
-          cargo build --package=javy-plugin --release --target=wasm32-wasip1
-          CARGO_PROFILE_RELEASE_LTO=off cargo build --package=javy-cli --release
+          cargo build --package=javy-plugin --target=wasm32-wasip1 --release --features=experimental_event_loop
+          CARGO_PROFILE_RELEASE_LTO=off cargo build --package=javy-cli --release --features=experimental_event_loop
           cargo build --package=javy-test-plugin --release --target=wasm32-wasip1
           target/release/javy init-plugin target/wasm32-wasip1/release/test_plugin.wasm -o crates/runner/test_plugin.wasm
 


### PR DESCRIPTION
## Description of the change

Uses the same feature configuration for building the default Javy plugin and Javy CLI when building the test plugin.

The really fast way to do this might be to have some way to skip the test plugin integration tests for this workflow.

Another thought that comes to mind is we might be busting the cargo target cache unintentionally since we're always emitting a build with the feature flag enabled as the last build step that runs. We could configure the `ci-shared-setup` to use a slightly different cache key for the Cargo target cache for this workflow.

## Why am I making this change?

This workflow runs quite a bit slower because we have to compile the plugin and the CLI twice because they have different features enabled. Using the same features means it should be able to re-use the build artifacts across steps.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
