### PR TITLE
v4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "javy-test-macros"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.2.0"
+version = "4.0.0"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
## Description of the change

Update the version of the CLI in preparation for a v4.0.0 release. This includes breaking changes to the CLI (`emit-provider` becoming `emit-plugin` and `javy build -C dynamic` requiring a plugin).

## Why am I making this change?

I want to release the support for plugins for dynamically linked modules.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
