### PR TITLE
Adjust fuzzing configs to match what's in QuickJS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "3.0.3-alpha.1"
+version = "3.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ wasmtime = "23"
 wasmtime-wasi = "23"
 wasi-common = "23"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "3.0.3-alpha.1" }
+javy = { path = "crates/javy", version = "3.1.0-alpha.1" }
 tempfile = "3.13.0"
 uuid = { version = "1.11", features = ["v4"] }
 serde = { version = "1.0", default-features = false }

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `gc_threshold`, `memory_limit`, and `max_stack_size` properties for `Config`.
+
 ## [3.0.2] - 2024-11-12
 
 ### Changed

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "3.0.3-alpha.1"
+version = "3.1.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -59,6 +59,14 @@ pub struct Config {
     /// This setting requires the `JSON` intrinsic to be enabled, and the `json`
     /// crate feature to be enabled as well.
     pub(crate) simd_json_builtins: bool,
+    /// The threshold to trigger garbage collection. Default is usize::MAX.
+    pub(crate) gc_threshold: usize,
+    /// The limit on the max amount of memory the runtime will use. Default is
+    /// unlimited.
+    pub(crate) memory_limit: usize,
+    /// The limit on the max size of stack the runtime will use. Default is
+    /// 256 * 1024.
+    pub(crate) max_stack_size: usize,
 }
 
 impl Default for Config {
@@ -71,6 +79,9 @@ impl Default for Config {
             javy_intrinsics: JavyIntrinsics::empty(),
             redirect_stdout_to_stderr: false,
             simd_json_builtins: false,
+            gc_threshold: usize::MAX,
+            memory_limit: usize::MAX,
+            max_stack_size: 256 * 1024, // from rquickjs
         }
     }
 }
@@ -195,6 +206,27 @@ impl Config {
     #[cfg(feature = "json")]
     pub fn simd_json_builtins(&mut self, enable: bool) -> &mut Self {
         self.simd_json_builtins = enable;
+        self
+    }
+
+    /// The number of bytes to use to trigger garbage collection.
+    /// The default is usize::MAX.
+    pub fn gc_threshold(&mut self, bytes: usize) -> &mut Self {
+        self.gc_threshold = bytes;
+        self
+    }
+
+    /// The limit on the max amount of memory the runtime will use. Default is
+    /// unlimited.
+    pub fn memory_limit(&mut self, bytes: usize) -> &mut Self {
+        self.memory_limit = bytes;
+        self
+    }
+
+    /// The limit on the max size of stack the runtime will use. Default is
+    /// 256 * 1024.
+    pub fn max_stack_size(&mut self, bytes: usize) -> &mut Self {
+        self.max_stack_size = bytes;
         self
     }
 

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -44,8 +44,6 @@ impl Runtime {
     pub fn new(config: Config) -> Result<Self> {
         let rt = ManuallyDrop::new(QRuntime::new()?);
 
-        // See comment above about configuring GC behaviour.
-        rt.set_gc_threshold(usize::MAX);
         let context = Self::build_from_config(&rt, config)?;
         Ok(Self { inner: rt, context })
     }

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -54,6 +54,11 @@ impl Runtime {
         let cfg = cfg.validate()?;
         let intrinsics = &cfg.intrinsics;
         let javy_intrinsics = &cfg.javy_intrinsics;
+
+        rt.set_gc_threshold(cfg.gc_threshold);
+        rt.set_memory_limit(cfg.memory_limit);
+        rt.set_max_stack_size(cfg.max_stack_size);
+
         // We always set Random given that the principles around snapshotting and
         // random are applicable when using Javy from the CLI (the usage of
         // Wizer from the CLI is not optional).


### PR DESCRIPTION
## Description of the change

Adding some parameters to the Javy library crate's `Config` so we can set them to non-default values when fuzzing. Also updating the fuzzer to set those parameters. Also throwing any fuzzing inputs with more than 350 `{` characters.

Note that the fuzzer still crashes with out of memory errors with this change.

## Why am I making this change?

We see out of memory errors when running the fuzzer continuously. This updates a few configs to match what's in QuickJS's fuzzer. I also don't try to run strings with more than 350 `{` characters because that trips the maximum stack size. We should consider investigating that further but I'd like to at least get the fuzzer running continuously.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
