### PR TITLE
v3.1.0 of javy and v2.0.0 of javy-plugin-api crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "3.1.0-alpha.1"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "javy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ wasmtime = "23"
 wasmtime-wasi = "23"
 wasi-common = "23"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "3.1.0-alpha.1" }
+javy = { path = "crates/javy", version = "3.1.0" }
 tempfile = "3.13.0"
 uuid = { version = "1.11", features = ["v4"] }
 serde = { version = "1.0", default-features = false }

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.1.0] - 2024-11-26
+
 ### Added
 
 - `gc_threshold`, `memory_limit`, and `max_stack_size` properties for `Config`.

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "3.1.0-alpha.1"
+version = "3.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0] - 2024-11-26
+
 ### Changed 
 
 - `initialize_runtime` accepts a `javy_plugin_api::Config` instead of a

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Cut new version of `javy` and `javy-plugin-api` crates.

## Why am I making this change?

I want to ensure plugins have access to the new API in the `javy-plugin-api` crate.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
