### PR TITLE
Add suffixes to javy and javy-plugin-api crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "3.1.0"
+version = "3.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "2.0.0"
+version = "2.0.1-alpha.1"
 dependencies = [
  "anyhow",
  "javy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ wasmtime = "23"
 wasmtime-wasi = "23"
 wasi-common = "23"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "3.1.0" }
+javy = { path = "crates/javy", version = "3.1.1-alpha.1" }
 tempfile = "3.13.0"
 uuid = { version = "1.11", features = ["v4"] }
 serde = { version = "1.0", default-features = false }

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "3.1.0"
+version = "3.1.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "2.0.0"
+version = "2.0.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Bumping patch versions and adding `-alpha.1` suffixes to `javy` and `javy-plugin-api` crate versions.

## Why am I making this change?

This is following the versioning policy.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
