### PR TITLE
Fix tests and lints for new version of Rust

### DIFF
--- a/crates/cli/src/codegen/mod.rs
+++ b/crates/cli/src/codegen/mod.rs
@@ -33,6 +33,12 @@
 //! as well as ensuring that any features available in the plugin match the
 //! features requsted by the JavaScript bytecode.
 
+// Wizer doesn't provide a good API to set a custom WASI context so we put our
+// WASI context in a static global variable and instruct the closure for
+// getting the WASI context to use a mutable reference to it. There are never
+// concurrent mutable references to the static WASI context so this is safe.
+#![allow(static_mut_refs)]
+
 mod builder;
 use std::{fs, rc::Rc, sync::OnceLock};
 

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -115,7 +115,7 @@ fn test_logging_with_redirect(builder: &mut Builder) -> Result<()> {
         "hello world from console.log\nhello world from console.error\n",
         logs.as_str(),
     );
-    assert_fuel_consumed_within_threshold(36_042, fuel_consumed);
+    assert_fuel_consumed_within_threshold(35_007, fuel_consumed);
     Ok(())
 }
 

--- a/crates/javy/src/serde/de.rs
+++ b/crates/javy/src/serde/de.rs
@@ -123,7 +123,7 @@ impl<'js> Deserializer<'js> {
     }
 }
 
-impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
+impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
@@ -307,7 +307,7 @@ impl<'a, 'de> MapAccess<'a, 'de> {
     }
 }
 
-impl<'a, 'de> de::MapAccess<'de> for MapAccess<'a, 'de> {
+impl<'de> de::MapAccess<'de> for MapAccess<'_, 'de> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
@@ -422,7 +422,7 @@ impl<'a, 'de: 'a> SeqAccess<'a, 'de> {
     }
 }
 
-impl<'a, 'de> de::SeqAccess<'de> for SeqAccess<'a, 'de> {
+impl<'de> de::SeqAccess<'de> for SeqAccess<'_, 'de> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>

--- a/crates/javy/src/serde/ser.rs
+++ b/crates/javy/src/serde/ser.rs
@@ -36,7 +36,7 @@ impl<'js> Serializer<'js> {
     }
 }
 
-impl<'a> ser::Serializer for &'a mut Serializer<'_> {
+impl ser::Serializer for &mut Serializer<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -219,7 +219,7 @@ impl<'a> ser::Serializer for &'a mut Serializer<'_> {
     }
 }
 
-impl<'a> ser::SerializeSeq for &'a mut Serializer<'_> {
+impl ser::SerializeSeq for &mut Serializer<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -243,7 +243,7 @@ impl<'a> ser::SerializeSeq for &'a mut Serializer<'_> {
     }
 }
 
-impl<'a> ser::SerializeTuple for &'a mut Serializer<'_> {
+impl ser::SerializeTuple for &mut Serializer<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -268,7 +268,7 @@ impl<'a> ser::SerializeTuple for &'a mut Serializer<'_> {
     }
 }
 
-impl<'a> ser::SerializeTupleStruct for &'a mut Serializer<'_> {
+impl ser::SerializeTupleStruct for &mut Serializer<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -292,7 +292,7 @@ impl<'a> ser::SerializeTupleStruct for &'a mut Serializer<'_> {
     }
 }
 
-impl<'a> ser::SerializeTupleVariant for &'a mut Serializer<'_> {
+impl ser::SerializeTupleVariant for &mut Serializer<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -317,7 +317,7 @@ impl<'a> ser::SerializeTupleVariant for &'a mut Serializer<'_> {
     }
 }
 
-impl<'a> ser::SerializeMap for &'a mut Serializer<'_> {
+impl ser::SerializeMap for &mut Serializer<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -354,7 +354,7 @@ impl<'a> ser::SerializeMap for &'a mut Serializer<'_> {
     }
 }
 
-impl<'a> ser::SerializeStruct for &'a mut Serializer<'_> {
+impl ser::SerializeStruct for &mut Serializer<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -379,7 +379,7 @@ impl<'a> ser::SerializeStruct for &'a mut Serializer<'_> {
     }
 }
 
-impl<'a> ser::SerializeStructVariant for &'a mut Serializer<'_> {
+impl ser::SerializeStructVariant for &mut Serializer<'_> {
     type Ok = ();
     type Error = Error;
 

--- a/crates/plugin-api/src/lib.rs
+++ b/crates/plugin-api/src/lib.rs
@@ -33,6 +33,10 @@
 //! # Features
 //! * `json` - enables the `json` feature in the `javy` crate.
 
+// Allow these in this file because we only run this program single threaded
+// and we can safely reason about the accesses to the Javy Runtime. We also
+// don't want to introduce overhead from taking unnecessary mutex locks.
+#![allow(static_mut_refs)]
 use anyhow::{anyhow, bail, Error, Result};
 pub use config::Config;
 use javy::quickjs::{self, Ctx, Error as JSError, Function, Module, Value};


### PR DESCRIPTION
## Description of the change

The update to Rust 1.83 seems to have resulted in some parts of CI failing. This makes a few changes to get it passing:
- Elide some lifetimes
- Adjust target fuel slightly lower
- Add `#![allow(static_mut_refs)]` to a couple modules

## Why am I making this change?

We need CI to pass. For the `#![allow(static_mut_refs)]`, I looked into some alternatives but wasn't able to find a satisfying alternative. In the plugin, using another approach is going to introduce some overhead. In the codegen, I tried moving setting up the WASI context into the closure used to add WASI p1 to the linker in `make_linker` but that causes building modules to hang and apparently that's not unexpected (see https://github.com/bytecodealliance/wasmtime/issues/9723). I also tried using an "immutable" static `RefCell` but the Rust compiler complains that `WasiCtx` doesn't implement `'sync`. And trying to put a mutex around the `RefCell` or using an `RwLock` doesn't work because the closure needs to return a mutable reference but has to drop the lock when it returns which invalidates the reference. `Arc`'s also aren't supported as a top-level type for statics.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
