### PR TITLE
Tweak Dependabot to not group QuickJS + ignore wasmtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,13 @@ updates:
     open-pull-requests-limit: 100
     groups:
       nonbreaking:
+        exclude-patterns:
+          - "rquickjs*"
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "wasmtime*"
 
   - package-ecosystem: npm
     directory: "/npm/javy"


### PR DESCRIPTION
## Description of the change

Tweaks Dependabot configuration to do two things:
- Stop grouping rquickjs updates in with the non-breaking updates. We have to be very careful with these so they should be inspected separately.
- Ignore Wasmtime updates. Wizer is generally going to pin Wasmtime to a particular version.

## Why am I making this change?

Trying to get on top of the Dependabots opened this month and one of them is for rquickjs which I want to evaluate separately.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
