### PR TITLE
Slight optimization in codegen

### DIFF
--- a/crates/cli/src/codegen/mod.rs
+++ b/crates/cli/src/codegen/mod.rs
@@ -149,16 +149,18 @@ impl Generator {
                     .make_linker(Some(Rc::new(move |engine| {
                         let mut linker = Linker::new(engine);
                         wasmtime_wasi::preview1::add_to_linker_sync(&mut linker, move |cx| {
-                            // The underlying buffer backing the pipe is an Arc
-                            // so the cloning should be fast.
-                            let config = STDIN_PIPE.get().unwrap().clone();
-                            cx.wasi_ctx = Some(
-                                WasiCtxBuilder::new()
-                                    .stdin(config)
-                                    .inherit_stdout()
-                                    .inherit_stderr()
-                                    .build_p1(),
-                            );
+                            if cx.wasi_ctx.is_none() {
+                                // The underlying buffer backing the pipe is an Arc
+                                // so the cloning should be fast.
+                                let config = STDIN_PIPE.get().unwrap().clone();
+                                cx.wasi_ctx = Some(
+                                    WasiCtxBuilder::new()
+                                        .stdin(config)
+                                        .inherit_stdout()
+                                        .inherit_stderr()
+                                        .build_p1(),
+                                );
+                            }
                             cx.wasi_ctx.as_mut().unwrap()
                         })?;
                         Ok(linker)


### PR DESCRIPTION
## Description of the change

Wrap the `WasiCtx` reinitialization in a check so the context is only initialized when it's set to `None` on the store. This will only initialize it once as opposed to every time.

## Why am I making this change?

This will be slightly faster.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
