### PR TITLE
Remove implementations of Intrinsic

### DIFF
--- a/crates/javy/src/apis/mod.rs
+++ b/crates/javy/src/apis/mod.rs
@@ -1,8 +1,6 @@
 //! A collection of APIs for Javy.
 //!
-//! APIs are enabled through the the [`Config`](crate::Config) and are defined
-//! in term of the [`Intrinsic`](rquickjs::context::Intrinsic) provided by
-//! rquickjs.
+//! APIs are enabled through the the [`Config`](crate::Config).
 //!
 //! Example usage:
 //! ```rust
@@ -62,10 +60,3 @@ pub(crate) mod json;
 pub(crate) mod random;
 pub(crate) mod stream_io;
 pub(crate) mod text_encoding;
-
-pub(crate) use console::*;
-#[cfg(feature = "json")]
-pub(crate) use json::*;
-pub(crate) use random::*;
-pub(crate) use stream_io::*;
-pub(crate) use text_encoding::*;

--- a/crates/javy/src/apis/random/mod.rs
+++ b/crates/javy/src/apis/random/mod.rs
@@ -1,15 +1,9 @@
-use crate::quickjs::{context::Intrinsic, prelude::Func, qjs, Ctx, Object};
+use crate::quickjs::{prelude::Func, Ctx, Object};
 use anyhow::{Error, Result};
 
-pub struct Random;
-
-impl Intrinsic for Random {
-    unsafe fn add_intrinsic(ctx: std::ptr::NonNull<qjs::JSContext>) {
-        register(Ctx::from_raw(ctx)).expect("`Random` APIs to succeed")
-    }
-}
-
-fn register(cx: Ctx) -> Result<()> {
+/// Register a `random` object on the global object that seeds itself at first
+/// execution.
+pub(crate) fn register(cx: Ctx) -> Result<()> {
     let globals = cx.globals();
     let math: Object<'_> = globals.get("Math").expect("Math global to be defined");
     math.set("random", Func::from(fastrand::f64))?;

--- a/crates/javy/src/apis/stream_io/mod.rs
+++ b/crates/javy/src/apis/stream_io/mod.rs
@@ -3,19 +3,13 @@ use std::io::{Read, Stdin, Write};
 
 use crate::{
     hold, hold_and_release,
-    quickjs::{context::Intrinsic, qjs, qjs::JS_GetArrayBuffer, Ctx, Function, Object, Value},
+    quickjs::{qjs::JS_GetArrayBuffer, Ctx, Function, Object, Value},
     to_js_error, Args,
 };
 
-pub struct StreamIO;
-
-impl Intrinsic for StreamIO {
-    unsafe fn add_intrinsic(ctx: std::ptr::NonNull<qjs::JSContext>) {
-        register(Ctx::from_raw(ctx)).expect("Registering StreamIO functions to succeed");
-    }
-}
-
-fn register(this: Ctx<'_>) -> Result<()> {
+/// Register `Javy.IO.readSync` and `Javy.IO.writeSync` functions on the
+/// global object.
+pub(crate) fn register(this: Ctx<'_>) -> Result<()> {
     let globals = this.globals();
     if globals.get::<_, Object>("Javy").is_err() {
         globals.set("Javy", Object::new(this.clone())?)?

--- a/crates/javy/src/apis/text_encoding/mod.rs
+++ b/crates/javy/src/apis/text_encoding/mod.rs
@@ -3,22 +3,14 @@ use std::str;
 use crate::{
     hold, hold_and_release,
     quickjs::{
-        context::{EvalOptions, Intrinsic},
-        qjs, Ctx, Exception, Function, String as JSString, TypedArray, Value,
+        context::EvalOptions, Ctx, Exception, Function, String as JSString, TypedArray, Value,
     },
     to_js_error, to_string_lossy, Args,
 };
 use anyhow::{anyhow, bail, Error, Result};
 
-pub struct TextEncoding;
-
-impl Intrinsic for TextEncoding {
-    unsafe fn add_intrinsic(ctx: std::ptr::NonNull<qjs::JSContext>) {
-        register(Ctx::from_raw(ctx)).expect("Register TextEncoding APIs to succeed");
-    }
-}
-
-fn register(this: Ctx<'_>) -> Result<()> {
+/// Register `TextDecoder` and `TextEncoder` classes.
+pub(crate) fn register(this: Ctx<'_>) -> Result<()> {
     let globals = this.globals();
     globals.set(
         "__javy_decodeUtf8BufferToString",


### PR DESCRIPTION
## Description of the change

Removes implementations of `rquickjs`'s `Intrinsic` trait and inlines the implementations at their call sites.

There shouldn't be anything that impacts the crate's public API or the crate's users so I'm not going to add a CHANGELOG entry.

## Why am I making this change?

`Intrinsic` was and is meant to be an internal trait of `rquickjs`. They made a change to require all implementations of `Intrinsic` to also implement `Sealed` which can't be implemented by crates outside of rquickjs with the intention of blocking crates using rquickjs from implementing `Intrinsic`. So I'm removing our implementations of `Intrinsic` from our codebase so we can update rquickjs versions.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
