### PR TITLE
docs: Explicitly state that WASI is experimental in node

### DIFF
--- a/docs/docs-using-nodejs.md
+++ b/docs/docs-using-nodejs.md
@@ -2,11 +2,20 @@
 This example demonstrates how to run Javy in a Node.js (v20+) host application.
 
 ## Warning
-This example does NOT show how to run a Node.js application in Javy. This is useful for when you want to run untrusted user generated code in a sandbox. This code is meant to be an example not production-ready code. 
+This example does NOT show how to run a Node.js application in Javy. This is
+useful for when you want to run untrusted user generated code in a sandbox. This
+code is meant to be an example not production-ready code. 
 
+It's also important to note that the WASI implementation in NodeJS is currently
+considered [experimental].
+
+[experimental]: https://nodejs.org/api/wasi.html#webassembly-system-interface-wasi
 
 ## Summary
-This example shows how to use a dynamically linked Javy compiled Wasm module. We use std in/out/error to communicate with the embedded javascript see [this blog post](https://k33g.hashnode.dev/wasi-communication-between-nodejs-and-wasm-modules-another-way-with-stdin-and-stdout) for details.
+This example shows how to use a dynamically linked Javy compiled Wasm module. We
+use std in/out/error to communicate with the embedded javascript see [this blog
+post](https://k33g.hashnode.dev/wasi-communication-between-nodejs-and-wasm-modules-another-way-with-stdin-and-stdout)
+for details.
 
 
 ### Steps


### PR DESCRIPTION
Explicitly state that WASI is considered experimental in node, to set the right expectations for anyone trying to use it for production use cases. 

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
