### PR TITLE
Add audit-as-crates-io policies for new crates

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -25,6 +25,12 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [policy.javy]
 audit-as-crates-io = false
 
+[policy.javy-plugin]
+audit-as-crates-io = false
+
+[policy.javy-plugin-api]
+audit-as-crates-io = false
+
 [[exemptions.Inflector]]
 version = "0.11.4"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Description of the change

Instructs cargo-vet to trust the local versions of the crates.

## Why am I making this change?

I'm getting an error when running `cargo vet` complaining these crates don't have defined `audit-as-crates-io` properties set.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
