### PR TITLE
Remove support for Javy.JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "3.1.1-alpha.1"
+version = "4.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "2.0.1-alpha.1"
+version = "3.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "javy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ wasmtime = "23"
 wasmtime-wasi = "23"
 wasi-common = "23"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "3.1.1-alpha.1" }
+javy = { path = "crates/javy", version = "4.0.0-alpha.1" }
 tempfile = "3.15.0"
 uuid = { version = "1.11", features = ["v4"] }
 serde = { version = "1.0", default-features = false }

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -375,7 +375,6 @@ mod tests {
     fn js_config_from_config_values() -> Result<()> {
         let group = JsConfig::from_group_values(&Plugin::Default, vec![])?;
         assert_eq!(group.get("redirect-stdout-to-stderr"), None);
-        assert_eq!(group.get("javy-json"), None);
         assert_eq!(group.get("javy-stream-io"), None);
         assert_eq!(group.get("simd-json-builtins"), None);
         assert_eq!(group.get("text-encoding"), None);
@@ -397,24 +396,6 @@ mod tests {
             })],
         )?;
         assert_eq!(group.get("redirect-stdout-to-stderr"), Some(true));
-
-        let group = JsConfig::from_group_values(
-            &Plugin::Default,
-            vec![JsGroupValue::Option(JsGroupOption {
-                name: "javy-json".to_string(),
-                enabled: false,
-            })],
-        )?;
-        assert_eq!(group.get("javy-json"), Some(false));
-
-        let group = JsConfig::from_group_values(
-            &Plugin::Default,
-            vec![JsGroupValue::Option(JsGroupOption {
-                name: "javy-json".to_string(),
-                enabled: true,
-            })],
-        )?;
-        assert_eq!(group.get("javy-json"), Some(true));
 
         let group = JsConfig::from_group_values(
             &Plugin::Default,
@@ -478,10 +459,6 @@ mod tests {
                     enabled: false,
                 }),
                 JsGroupValue::Option(JsGroupOption {
-                    name: "javy-json".to_string(),
-                    enabled: false,
-                }),
-                JsGroupValue::Option(JsGroupOption {
                     name: "javy-stream-io".to_string(),
                     enabled: false,
                 }),
@@ -496,7 +473,6 @@ mod tests {
             ],
         )?;
         assert_eq!(group.get("redirect-stdout-to-stderr"), Some(false));
-        assert_eq!(group.get("javy-json"), Some(false));
         assert_eq!(group.get("javy-stream-io"), Some(false));
         assert_eq!(group.get("simd-json-builtins"), Some(false));
         assert_eq!(group.get("text-encoding"), Some(false));

--- a/crates/cli/tests/dynamic-linking-scripts/javy-json-id.js
+++ b/crates/cli/tests/dynamic-linking-scripts/javy-json-id.js
@@ -1,1 +1,0 @@
-console.log(Javy.JSON.toStdout(Javy.JSON.fromStdin()));

--- a/crates/cli/tests/dynamic_linking_test.rs
+++ b/crates/cli/tests/dynamic_linking_test.rs
@@ -114,25 +114,6 @@ fn test_using_runtime_flag_with_dynamic_triggers_error(builder: &mut Builder) ->
     Ok(())
 }
 
-#[javy_cli_test(
-    dyn = true,
-    root = "tests/dynamic-linking-scripts",
-    commands(not(Compile))
-)]
-fn javy_json_identity(builder: &mut Builder) -> Result<()> {
-    let mut runner = builder.input("javy-json-id.js").build()?;
-
-    let input = "{\"x\":5}";
-
-    let bytes = String::from(input).into_bytes();
-    let (out, logs, _) = runner.exec(&bytes)?;
-
-    assert_eq!(String::from_utf8(out)?, input);
-    assert_eq!(String::from_utf8(logs)?, "undefined\n");
-
-    Ok(())
-}
-
 #[javy_cli_test(dyn = true, commands(not(Compile)))]
 fn test_using_plugin_with_dynamic_works(builder: &mut Builder) -> Result<()> {
     let plugin = Plugin::User;

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -84,7 +84,7 @@ fn test_logging_with_compile(builder: &mut Builder) -> Result<()> {
         "hello world from console.log\nhello world from console.error\n",
         logs.as_str(),
     );
-    assert_fuel_consumed_within_threshold(36_071, fuel_consumed);
+    assert_fuel_consumed_within_threshold(35_042, fuel_consumed);
     Ok(())
 }
 
@@ -98,7 +98,7 @@ fn test_logging_without_redirect(builder: &mut Builder) -> Result<()> {
     let (output, logs, fuel_consumed) = run(&mut runner, &[]);
     assert_eq!(b"hello world from console.log\n".to_vec(), output);
     assert_eq!("hello world from console.error\n", logs.as_str());
-    assert_fuel_consumed_within_threshold(36_641, fuel_consumed);
+    assert_fuel_consumed_within_threshold(35_860, fuel_consumed);
     Ok(())
 }
 
@@ -116,32 +116,6 @@ fn test_logging_with_redirect(builder: &mut Builder) -> Result<()> {
         logs.as_str(),
     );
     assert_fuel_consumed_within_threshold(35_007, fuel_consumed);
-    Ok(())
-}
-
-#[javy_cli_test(commands(not(Compile)), root = "tests/dynamic-linking-scripts")]
-fn test_javy_json_enabled(builder: &mut Builder) -> Result<()> {
-    let mut runner = builder.input("javy-json-id.js").build()?;
-
-    let input = "{\"x\":5}";
-    let (output, logs, _) = run(&mut runner, input.as_bytes());
-
-    assert_eq!(logs, "undefined\n");
-    assert_eq!(String::from_utf8(output)?, input);
-
-    Ok(())
-}
-
-#[javy_cli_test(commands(not(Compile)), root = "tests/dynamic-linking-scripts")]
-fn test_javy_json_disabled(builder: &mut Builder) -> Result<()> {
-    let mut runner = builder
-        .input("javy-json-id.js")
-        .simd_json_builtins(false)
-        .build()?;
-
-    let result = runner.exec(&[]);
-    assert!(result.is_err());
-
     Ok(())
 }
 

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Removed
+
+- `Javy.JSON.fromStdin` and `Javy.JSON.toStdout` APIs and `javy_json` method on
+  `javy::Config`.
+
 ## [3.1.0] - 2024-11-27
 
 ### Added

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "3.1.1-alpha.1"
+version = "4.0.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -37,7 +37,6 @@ bitflags! {
     /// moved out.
     pub(crate) struct JavyIntrinsics: u32 {
         const STREAM_IO = 1;
-        const JSON = 1 << 1;
     }
 }
 
@@ -178,15 +177,6 @@ impl Config {
     /// Disabled by default.
     pub fn javy_stream_io(&mut self, enable: bool) -> &mut Self {
         self.javy_intrinsics.set(JavyIntrinsics::STREAM_IO, enable);
-        self
-    }
-
-    /// Whether the `Javy.JSON` intrinsic will be available.
-    /// Disabled by default.
-    /// This setting requires the `json` crate feature to be enabled.
-    #[cfg(feature = "json")]
-    pub fn javy_json(&mut self, enable: bool) -> &mut Self {
-        self.javy_intrinsics.set(JavyIntrinsics::JSON, enable);
         self
     }
 

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -148,12 +148,6 @@ impl Runtime {
                 stream_io::register(ctx.clone())
                     .expect("registering StreamIO functions to succeed");
             }
-
-            #[cfg(feature = "json")]
-            if javy_intrinsics.contains(JavyIntrinsics::JSON) {
-                json::register_javy_json(ctx.clone())
-                    .expect("registering Javy.JSON builtins to succeed");
-            }
         });
 
         Ok(ManuallyDrop::new(context))

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Removed 
+
+- `javy` dependency updated to 4.0.0 which removes `javy_json` method on
+  `javy_plugin_api::Config` and removes support for `Javy.JSON.fromStdin` and
+  `Javy.JSON.toStdout`.
+
 ## [2.0.0] - 2024-11-27
 
 ### Changed 

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "2.0.1-alpha.1"
+version = "3.0.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -22,8 +22,7 @@ pub extern "C" fn initialize_runtime() {
         .text_encoding(true)
         .redirect_stdout_to_stderr(true)
         .javy_stream_io(true)
-        .simd_json_builtins(true)
-        .javy_json(true);
+        .simd_json_builtins(true);
 
     let mut config_bytes = vec![];
     let shared_config = match io::stdin().read_to_end(&mut config_bytes) {

--- a/crates/plugin/src/shared_config/mod.rs
+++ b/crates/plugin/src/shared_config/mod.rs
@@ -15,8 +15,6 @@ runtime_config! {
     pub struct SharedConfig {
         /// Whether to redirect the output of console.log to standard error.
         redirect_stdout_to_stderr: Option<bool>,
-        /// Whether to enable the `Javy.JSON` builtins.
-        javy_json: Option<bool>,
         /// Whether to enable the `Javy.readSync` and `Javy.writeSync` builtins.
         javy_stream_io: Option<bool>,
         /// Whether to override the `JSON.parse` and `JSON.stringify`
@@ -39,9 +37,6 @@ impl SharedConfig {
     pub fn apply_to_config(&self, config: &mut Config) {
         if let Some(enable) = self.redirect_stdout_to_stderr {
             config.redirect_stdout_to_stderr(enable);
-        }
-        if let Some(enable) = self.javy_json {
-            config.javy_json(enable);
         }
         if let Some(enable) = self.javy_stream_io {
             config.javy_stream_io(enable);

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -74,8 +74,6 @@ pub struct Builder {
     world: Option<String>,
     /// Whether console.log should write to stderr.
     redirect_stdout_to_stderr: Option<bool>,
-    /// Whether to enable the `Javy.JSON` builtins.
-    javy_json: Option<bool>,
     /// Whether to enable the `Javy.IO` builtins.
     javy_stream_io: Option<bool>,
     /// Whether to override JSON.parse and JSON.stringify with a SIMD based
@@ -108,7 +106,6 @@ impl Default for Builder {
             command: JavyCommand::Build,
             redirect_stdout_to_stderr: None,
             javy_stream_io: None,
-            javy_json: None,
             simd_json_builtins: None,
             text_encoding: None,
             event_loop: None,
@@ -150,11 +147,6 @@ impl Builder {
 
     pub fn redirect_stdout_to_stderr(&mut self, enabled: bool) -> &mut Self {
         self.redirect_stdout_to_stderr = Some(enabled);
-        self
-    }
-
-    pub fn javy_json(&mut self, enabled: bool) -> &mut Self {
-        self.javy_json = Some(enabled);
         self
     }
 
@@ -206,7 +198,6 @@ impl Builder {
             world,
             root,
             redirect_stdout_to_stderr,
-            javy_json,
             javy_stream_io,
             simd_json_builtins,
             text_encoding,
@@ -234,7 +225,6 @@ impl Builder {
                 wit,
                 world,
                 redirect_stdout_to_stderr,
-                javy_json,
                 javy_stream_io,
                 simd_json_builtins,
                 text_encoding,
@@ -311,7 +301,6 @@ impl Runner {
         wit: Option<PathBuf>,
         world: Option<String>,
         redirect_stdout_to_stderr: Option<bool>,
-        javy_json: Option<bool>,
         javy_stream_io: Option<bool>,
         override_json_parse_and_stringify: Option<bool>,
         text_encoding: Option<bool>,
@@ -333,7 +322,6 @@ impl Runner {
             &world,
             preload.is_some(),
             &redirect_stdout_to_stderr,
-            &javy_json,
             &javy_stream_io,
             &override_json_parse_and_stringify,
             &text_encoding,
@@ -562,7 +550,6 @@ impl Runner {
         world: &Option<String>,
         dynamic: bool,
         redirect_stdout_to_stderr: &Option<bool>,
-        javy_json: &Option<bool>,
         javy_stream_io: &Option<bool>,
         simd_json_builtins: &Option<bool>,
         text_encoding: &Option<bool>,
@@ -594,11 +581,6 @@ impl Runner {
                 "redirect-stdout-to-stderr={}",
                 if redirect_stdout_to_stderr { "y" } else { "n" }
             ));
-        }
-
-        if let Some(enabled) = *javy_json {
-            args.push("-J".to_string());
-            args.push(format!("javy-json={}", if enabled { "y" } else { "n" }));
         }
 
         if let Some(enabled) = *javy_stream_io {

--- a/fuzz/fuzz_targets/json_differential.rs
+++ b/fuzz/fuzz_targets/json_differential.rs
@@ -22,7 +22,7 @@ fuzz_target!(|data: ArbitraryValue| {
 
         let mut config = Config::default();
         setup_config(&mut config);
-        config.simd_json_builtins(true).javy_json(true);
+        config.simd_json_builtins(true);
 
         unsafe {
             RT = Some(Runtime::new(std::mem::take(&mut config)).expect("Runtime to be created"));


### PR DESCRIPTION
## Description of the change

Removes `Javy.JSON.fromStdin` and `Javy.JSON.toStdout` APIs and associated configuration options.

## Why am I making this change?

These were non-standard APIs and can now by implemented by Javy plugins instead of inside Javy itself.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
