### PR TITLE
Remove console.log redirect to stderr

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -374,29 +374,10 @@ mod tests {
     #[test]
     fn js_config_from_config_values() -> Result<()> {
         let group = JsConfig::from_group_values(&Plugin::Default, vec![])?;
-        assert_eq!(group.get("redirect-stdout-to-stderr"), None);
         assert_eq!(group.get("javy-json"), None);
         assert_eq!(group.get("javy-stream-io"), None);
         assert_eq!(group.get("simd-json-builtins"), None);
         assert_eq!(group.get("text-encoding"), None);
-
-        let group = JsConfig::from_group_values(
-            &Plugin::Default,
-            vec![JsGroupValue::Option(JsGroupOption {
-                name: "redirect-stdout-to-stderr".to_string(),
-                enabled: false,
-            })],
-        )?;
-        assert_eq!(group.get("redirect-stdout-to-stderr"), Some(false));
-
-        let group = JsConfig::from_group_values(
-            &Plugin::Default,
-            vec![JsGroupValue::Option(JsGroupOption {
-                name: "redirect-stdout-to-stderr".to_string(),
-                enabled: true,
-            })],
-        )?;
-        assert_eq!(group.get("redirect-stdout-to-stderr"), Some(true));
 
         let group = JsConfig::from_group_values(
             &Plugin::Default,
@@ -474,10 +455,6 @@ mod tests {
             &Plugin::Default,
             vec![
                 JsGroupValue::Option(JsGroupOption {
-                    name: "redirect-stdout-to-stderr".to_string(),
-                    enabled: false,
-                }),
-                JsGroupValue::Option(JsGroupOption {
                     name: "javy-json".to_string(),
                     enabled: false,
                 }),
@@ -495,7 +472,6 @@ mod tests {
                 }),
             ],
         )?;
-        assert_eq!(group.get("redirect-stdout-to-stderr"), Some(false));
         assert_eq!(group.get("javy-json"), Some(false));
         assert_eq!(group.get("javy-stream-io"), Some(false));
         assert_eq!(group.get("simd-json-builtins"), Some(false));

--- a/crates/cli/tests/dylib_test.rs
+++ b/crates/cli/tests/dylib_test.rs
@@ -4,7 +4,7 @@ use std::str;
 
 #[test]
 fn test_dylib() -> Result<()> {
-    let js_src = "console.log(42);";
+    let js_src = "console.error(42);";
     let mut runner = Runner::with_dylib(plugin_module()?)?;
 
     let (_, logs, _) = runner.exec_through_dylib(js_src, UseExportedFn::EvalBytecode)?;
@@ -15,7 +15,7 @@ fn test_dylib() -> Result<()> {
 
 #[test]
 fn test_dylib_with_invoke_with_no_fn_name() -> Result<()> {
-    let js_src = "console.log(42);";
+    let js_src = "console.error(42);";
     let mut runner = Runner::with_dylib(plugin_module()?)?;
 
     let (_, logs, _) = runner.exec_through_dylib(js_src, UseExportedFn::Invoke(None))?;
@@ -46,7 +46,7 @@ fn test_dylib_with_error() -> Result<()> {
 
 #[test]
 fn test_dylib_with_exported_func() -> Result<()> {
-    let js_src = "export function foo() { console.log('In foo'); }; console.log('Toplevel');";
+    let js_src = "export function foo() { console.error('In foo'); }; console.error('Toplevel');";
 
     let mut runner = Runner::with_dylib(plugin_module()?)?;
 

--- a/crates/cli/tests/dynamic-linking-scripts/console.js
+++ b/crates/cli/tests/dynamic-linking-scripts/console.js
@@ -1,1 +1,1 @@
-console.log(42);
+console.error(42);

--- a/crates/cli/tests/dynamic-linking-scripts/javy-json-id.js
+++ b/crates/cli/tests/dynamic-linking-scripts/javy-json-id.js
@@ -1,1 +1,1 @@
-console.log(Javy.JSON.toStdout(Javy.JSON.fromStdin()));
+console.error(Javy.JSON.toStdout(Javy.JSON.fromStdin()));

--- a/crates/cli/tests/dynamic-linking-scripts/linking-arrow-func.js
+++ b/crates/cli/tests/dynamic-linking-scripts/linking-arrow-func.js
@@ -1,1 +1,1 @@
-export default () => console.log(42)
+export default () => console.error(42)

--- a/crates/cli/tests/dynamic-linking-scripts/linking-with-func-without-flag.js
+++ b/crates/cli/tests/dynamic-linking-scripts/linking-with-func-without-flag.js
@@ -1,5 +1,5 @@
 export function foo() {
-  console.log('In foo');
+  console.error('In foo');
 };
 
-console.log('Toplevel');
+console.error('Toplevel');

--- a/crates/cli/tests/dynamic-linking-scripts/linking-with-func.js
+++ b/crates/cli/tests/dynamic-linking-scripts/linking-with-func.js
@@ -1,5 +1,5 @@
 export function fooBar() {
-  console.log('In foo'); 
+  console.error('In foo');
 }; 
 
-console.log('Toplevel');
+console.error('Toplevel');

--- a/crates/cli/tests/dynamic_linking_test.rs
+++ b/crates/cli/tests/dynamic_linking_test.rs
@@ -104,13 +104,10 @@ fn test_producers_section_present(builder: &mut Builder) -> Result<()> {
     commands(not(Compile))
 )]
 fn test_using_runtime_flag_with_dynamic_triggers_error(builder: &mut Builder) -> Result<()> {
-    let build_result = builder
-        .input("console.js")
-        .redirect_stdout_to_stderr(false)
-        .build();
-    assert!(build_result.is_err_and(|e| e.to_string().contains(
-        "error: Property redirect-stdout-to-stderr is not supported for runtime configuration"
-    )));
+    let build_result = builder.input("console.js").text_encoding(false).build();
+    assert!(build_result.is_err_and(|e| e
+        .to_string()
+        .contains("error: Property text-encoding is not supported for runtime configuration")));
     Ok(())
 }
 

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -21,7 +21,7 @@ fn test_identity(builder: &mut Builder) -> Result<()> {
 
     let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 42);
     assert_eq!(42, output);
-    assert_fuel_consumed_within_threshold(47_773, fuel_consumed);
+    assert_fuel_consumed_within_threshold(46_797, fuel_consumed);
     Ok(())
 }
 
@@ -41,7 +41,7 @@ fn test_recursive_fib(builder: &mut Builder) -> Result<()> {
 
     let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 5);
     assert_eq!(8, output);
-    assert_fuel_consumed_within_threshold(69_306, fuel_consumed);
+    assert_fuel_consumed_within_threshold(67_869, fuel_consumed);
     Ok(())
 }
 

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -74,48 +74,14 @@ fn test_encoding(builder: &mut Builder) -> Result<()> {
     Ok(())
 }
 
-#[javy_cli_test(commands(not(Build)))]
-fn test_logging_with_compile(builder: &mut Builder) -> Result<()> {
+#[javy_cli_test]
+fn test_console_log(builder: &mut Builder) -> Result<()> {
     let mut runner = builder.input("logging.js").build()?;
-
-    let (output, logs, fuel_consumed) = run(&mut runner, &[]);
-    assert!(output.is_empty());
-    assert_eq!(
-        "hello world from console.log\nhello world from console.error\n",
-        logs.as_str(),
-    );
-    assert_fuel_consumed_within_threshold(36_071, fuel_consumed);
-    Ok(())
-}
-
-#[javy_cli_test(commands(not(Compile)))]
-fn test_logging_without_redirect(builder: &mut Builder) -> Result<()> {
-    let mut runner = builder
-        .input("logging.js")
-        .redirect_stdout_to_stderr(false)
-        .build()?;
 
     let (output, logs, fuel_consumed) = run(&mut runner, &[]);
     assert_eq!(b"hello world from console.log\n".to_vec(), output);
     assert_eq!("hello world from console.error\n", logs.as_str());
     assert_fuel_consumed_within_threshold(36_641, fuel_consumed);
-    Ok(())
-}
-
-#[javy_cli_test(commands(not(Compile)))]
-fn test_logging_with_redirect(builder: &mut Builder) -> Result<()> {
-    let mut runner = builder
-        .input("logging.js")
-        .redirect_stdout_to_stderr(true)
-        .build()?;
-
-    let (output, logs, fuel_consumed) = run(&mut runner, &[]);
-    assert!(output.is_empty());
-    assert_eq!(
-        "hello world from console.log\nhello world from console.error\n",
-        logs.as_str(),
-    );
-    assert_fuel_consumed_within_threshold(35_007, fuel_consumed);
     Ok(())
 }
 

--- a/crates/cli/tests/sample-scripts/exported-default-arrow-fn.js
+++ b/crates/cli/tests/sample-scripts/exported-default-arrow-fn.js
@@ -1,1 +1,1 @@
-export default () => console.log(42)
+export default () => console.error(42)

--- a/crates/cli/tests/sample-scripts/exported-default-fn.js
+++ b/crates/cli/tests/sample-scripts/exported-default-fn.js
@@ -1,3 +1,3 @@
 export default function () {
-    console.log(42);
+    console.error(42);
 }

--- a/crates/cli/tests/sample-scripts/exported-fn-no-semicolon.js
+++ b/crates/cli/tests/sample-scripts/exported-fn-no-semicolon.js
@@ -1,3 +1,3 @@
 export function foo() {
-    console.log("Hello from bar!");
+    console.error("Hello from bar!");
 }

--- a/crates/cli/tests/sample-scripts/exported-fn.js
+++ b/crates/cli/tests/sample-scripts/exported-fn.js
@@ -1,13 +1,13 @@
 export function bar() {
-    console.log("Hello from bar!");
+    console.error("Hello from bar!");
 }
 
 export function foo() {
-    console.log("Hello from foo");
+    console.error("Hello from foo");
 }
 
 export function fooBar() {
-    console.log("Hello from fooBar");
+    console.error("Hello from fooBar");
 }
 
-console.log("Hello from top-level");
+console.error("Hello from top-level");

--- a/crates/cli/tests/sample-scripts/exported-promise-fn.js
+++ b/crates/cli/tests/sample-scripts/exported-promise-fn.js
@@ -1,7 +1,7 @@
 export async function foo() {
-    console.log(await Promise.resolve("inside foo"));
+    console.error(await Promise.resolve("inside foo"));
 }
 
 (async function () {
-    console.log(await Promise.resolve("Top-level"));
+    console.error(await Promise.resolve("Top-level"));
 })();

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -17,10 +17,8 @@ pub extern "C" fn initialize_runtime() {
     // variable in subsequent invocations so a different value can't be used to
     // initialize a runtime with a different configuration.
     let mut config = Config::default();
-    // Preserve defaults that used to be passed from the Javy CLI.
     config
         .text_encoding(true)
-        .redirect_stdout_to_stderr(true)
         .javy_stream_io(true)
         .simd_json_builtins(true)
         .javy_json(true);

--- a/crates/plugin/src/shared_config/mod.rs
+++ b/crates/plugin/src/shared_config/mod.rs
@@ -13,8 +13,6 @@ runtime_config! {
     #[derive(Debug, Default, Deserialize)]
     #[serde(deny_unknown_fields, rename_all = "kebab-case")]
     pub struct SharedConfig {
-        /// Whether to redirect the output of console.log to standard error.
-        redirect_stdout_to_stderr: Option<bool>,
         /// Whether to enable the `Javy.JSON` builtins.
         javy_json: Option<bool>,
         /// Whether to enable the `Javy.readSync` and `Javy.writeSync` builtins.
@@ -37,9 +35,6 @@ impl SharedConfig {
     }
 
     pub fn apply_to_config(&self, config: &mut Config) {
-        if let Some(enable) = self.redirect_stdout_to_stderr {
-            config.redirect_stdout_to_stderr(enable);
-        }
         if let Some(enable) = self.javy_json {
             config.javy_json(enable);
         }

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -72,8 +72,6 @@ pub struct Builder {
     wit: Option<PathBuf>,
     /// The name of the wit world.
     world: Option<String>,
-    /// Whether console.log should write to stderr.
-    redirect_stdout_to_stderr: Option<bool>,
     /// Whether to enable the `Javy.JSON` builtins.
     javy_json: Option<bool>,
     /// Whether to enable the `Javy.IO` builtins.
@@ -106,7 +104,6 @@ impl Default for Builder {
             built: false,
             preload: None,
             command: JavyCommand::Build,
-            redirect_stdout_to_stderr: None,
             javy_stream_io: None,
             javy_json: None,
             simd_json_builtins: None,
@@ -145,11 +142,6 @@ impl Builder {
 
     pub fn preload(&mut self, ns: String, wasm: impl Into<PathBuf>) -> &mut Self {
         self.preload = Some((ns, wasm.into()));
-        self
-    }
-
-    pub fn redirect_stdout_to_stderr(&mut self, enabled: bool) -> &mut Self {
-        self.redirect_stdout_to_stderr = Some(enabled);
         self
     }
 
@@ -205,7 +197,6 @@ impl Builder {
             wit,
             world,
             root,
-            redirect_stdout_to_stderr,
             javy_json,
             javy_stream_io,
             simd_json_builtins,
@@ -233,7 +224,6 @@ impl Builder {
                 input,
                 wit,
                 world,
-                redirect_stdout_to_stderr,
                 javy_json,
                 javy_stream_io,
                 simd_json_builtins,
@@ -310,7 +300,6 @@ impl Runner {
         source: impl AsRef<Path>,
         wit: Option<PathBuf>,
         world: Option<String>,
-        redirect_stdout_to_stderr: Option<bool>,
         javy_json: Option<bool>,
         javy_stream_io: Option<bool>,
         override_json_parse_and_stringify: Option<bool>,
@@ -332,7 +321,6 @@ impl Runner {
             &wit_file,
             &world,
             preload.is_some(),
-            &redirect_stdout_to_stderr,
             &javy_json,
             &javy_stream_io,
             &override_json_parse_and_stringify,
@@ -561,7 +549,6 @@ impl Runner {
         wit: &Option<PathBuf>,
         world: &Option<String>,
         dynamic: bool,
-        redirect_stdout_to_stderr: &Option<bool>,
         javy_json: &Option<bool>,
         javy_stream_io: &Option<bool>,
         simd_json_builtins: &Option<bool>,
@@ -586,14 +573,6 @@ impl Runner {
         if dynamic {
             args.push("-C".to_string());
             args.push("dynamic".to_string());
-        }
-
-        if let Some(redirect_stdout_to_stderr) = *redirect_stdout_to_stderr {
-            args.push("-J".to_string());
-            args.push(format!(
-                "redirect-stdout-to-stderr={}",
-                if redirect_stdout_to_stderr { "y" } else { "n" }
-            ));
         }
 
         if let Some(enabled) = *javy_json {


### PR DESCRIPTION
## Description of the change

Changes the default Javy plugin to use the default `javy` crate setting of `false` for redirecting `console.log` to the standard error stream and removes the `redirect-stdout-to-stderr` configuration option from the default plugin and the CLI. So `console.log` now writes to standard output.

## Why am I making this change?

The behaviour of writing `console.log` to standard error is unusual and users found it confusing. If someone wants to have `console.log` write to standard error, they can use a Javy plugin to get that behaviour.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
