### PR TITLE
Publish v4.0.0 of javy crate and v3.0.0 of javy-plugin-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "4.0.0-alpha.1"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "javy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ wasmtime = "23"
 wasmtime-wasi = "23"
 wasi-common = "23"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "4.0.0-alpha.1" }
+javy = { path = "crates/javy", version = "4.0.0" }
 tempfile = "3.15.0"
 uuid = { version = "1.11", features = ["v4"] }
 serde = { version = "1.0", default-features = false }

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.0.0] - 2025-01-08
+
 ### Removed
 
 - `Javy.JSON.fromStdin` and `Javy.JSON.toStdout` APIs and `javy_json` method on

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "4.0.0-alpha.1"
+version = "4.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.0] - 2025r-01-08
+
 ### Removed 
 
 - `javy` dependency updated to 4.0.0 which removes `javy_json` method on

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Removes the `-alpha1` suffixes from the `javy` library crate and `javy-plugin-api` crate and updates the CHANGELOGs for both to include a release date.

## Why am I making this change?

I want to publish new versions of both crates that do not include `Javy.JSON` support.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
