### PR TITLE
v5.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "javy-test-macros"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "4.0.0"
+version = "5.0.0"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
## Description of the change

Bumps version of Javy CLI to 5.0.0.

## Why am I making this change?

I want to perform a release.

There are two breaking changes:
1. Removal of the `-J javy-json` option
2. Removal of the `-J redirect-stdout-to-stderr` option

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
