### PR TITLE
Fix help text for plugin codegen option

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -207,9 +207,9 @@ option_group! {
         /// Enable source code compression, which generates smaller WebAssembly
         /// files at the cost of increased compile time.
         SourceCompression(bool),
-        /// Optional path to Javy plugin Wasm module. Not supported for
-        /// dynamically linked modules. JavaScript config options are also not
-        /// supported when using this parameter.
+        /// Path to Javy plugin Wasm module. Optional for statically linked
+        /// modules and required for dynamically linked modules. JavaScript
+        /// config options are not supported when using this parameter.
         Plugin(PathBuf),
     }
 }


### PR DESCRIPTION
## Description of the change

Fixes the help text for the `-C plugin` option.

## Why am I making this change?

The existing text is no longer accurate.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
