### PR TITLE
Support plugins with imported functions

### DIFF
--- a/crates/cli/src/bytecode.rs
+++ b/crates/cli/src/bytecode.rs
@@ -21,6 +21,7 @@ fn create_wasm_env(plugin: &Plugin) -> Result<(Store<WasiCtx>, Instance, Memory)
         &mut linker,
         |s| s,
     )?;
+    linker.define_unknown_imports_as_traps(&module)?;
     let wasi = WasiCtxBuilder::new().inherit_stderr().build();
     let mut store = Store::new(&engine, wasi);
     let instance = linker.instantiate(store.as_context_mut(), &module)?;

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -671,6 +671,7 @@ impl Runner {
             let module = Module::from_binary(self.linker.engine(), bytes)?;
             let instance = self.linker.instantiate(store.as_context_mut(), &module)?;
             self.linker.allow_shadowing(true);
+            self.linker.define_unknown_imports_as_traps(&module)?;
             self.linker
                 .instance(store.as_context_mut(), name, instance)?;
         }

--- a/crates/test-plugin/src/lib.rs
+++ b/crates/test-plugin/src/lib.rs
@@ -1,18 +1,25 @@
 //! Plugin used for testing. We need a plugin with slightly different behavior
 //! to validate a plugin is actually used when it should be.
 
-use javy_plugin_api::{import_namespace, Config};
+use javy_plugin_api::{import_namespace, javy::quickjs::prelude::Func, Config};
 
 import_namespace!("test_plugin");
+
+#[link(wasm_import_module = "some_host")]
+extern "C" {
+    fn imported_function();
+}
 
 #[export_name = "initialize_runtime"]
 pub extern "C" fn initialize_runtime() {
     let config = Config::default();
     javy_plugin_api::initialize_runtime(config, |runtime| {
-        runtime
-            .context()
-            .with(|ctx| ctx.globals().set("plugin", true))
-            .unwrap();
+        runtime.context().with(|ctx| {
+            ctx.globals().set("plugin", true).unwrap();
+            ctx.globals()
+                .set("func", Func::from(|| unsafe { imported_function() }))
+                .unwrap();
+        });
         runtime
     })
     .unwrap();


### PR DESCRIPTION
## Description of the change

Updates the linker configuration when generating QuickJS bytecode to stub out unknown imports with traps.

Also updates the test plugin to have an imported function and updates the test runner to also stub out unknown imports with traps when executing the test cases.

## Why am I making this change?

Fixes #878.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
