### PR TITLE
Fix benchmarks

### DIFF
--- a/crates/cli/benches/benchmark.rs
+++ b/crates/cli/benches/benchmark.rs
@@ -199,6 +199,8 @@ fn execute_javy(index_js: &Path, wasm: &Path, linking: &Linking) -> Result<()> {
     if let Linking::Dynamic = linking {
         args.push("-C");
         args.push("dynamic");
+        args.push("-C");
+        args.push("plugin=../../target/wasm32-wasip1/release/plugin_wizened.wasm");
     }
     let status_code = Command::new(Path::new("../../target/release/javy").to_str().unwrap())
         .args(args)


### PR DESCRIPTION
## Description of the change

Add plugin to CLI arguments when dynamically linking.

## Why am I making this change?

I forgot to update the benchmarks when I changed dynamic linking to require a plugin.

It got noticed in #890 so I'm opting to fix this here separately.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
