### PR TITLE
A couple minor doc comment fixes

### DIFF
--- a/crates/cli/src/codegen/mod.rs
+++ b/crates/cli/src/codegen/mod.rs
@@ -128,7 +128,7 @@ pub struct Generator {
 }
 
 impl Generator {
-    /// Create a new [`CodeGenBuilder`].
+    /// Create a new [`Generator`].
     pub(crate) fn new() -> Self {
         Self::default()
     }

--- a/crates/cli/src/codegen/plugin.rs
+++ b/crates/cli/src/codegen/plugin.rs
@@ -45,7 +45,7 @@ impl PluginKind {
     }
 }
 
-/// Represents ny valid Javy plugin.
+/// Represents any valid Javy plugin.
 #[derive(Clone, Debug, Default)]
 pub struct Plugin {
     bytes: Vec<u8>,


### PR DESCRIPTION
## Description of the change

Two small fixes to doc comments.

## Why am I making this change?

I noticed these looked off when inspecting the API docs for #890 so figured I'd fix them.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
