### PR TITLE
Fixes for Rust 1.85

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,15 +2,8 @@
 # Cargo doesn't read directives in individual crates when invoking build
 # commands from the workspace root, hence adding it at the workspace root.
 # https://doc.rust-lang.org/cargo/reference/config.html
-# Disable reference-types since Wizer (as of version 7.0.0) does not support
-# reference-types.
 [target.wasm32-wasip1]
-rustflags = [
-    "-C",
-    "target-feature=+simd128",
-    "-C",
-    "target-feature=-reference-types",
-]
+rustflags = ["-C", "target-feature=+simd128"]
 
 # We want to ensure that all the MSVC dependencies are statically resolved and
 # included in the final CLI binary.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ wizer = "7.0.0"
 wasmtime = "23"
 wasmtime-wasi = "23"
 wasi-common = "23"
+wasm-opt = "0.116.1"
 anyhow = "1.0"
 javy = { path = "crates/javy", version = "4.0.1-alpha.1" }
 tempfile = "3.16.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,7 +29,7 @@ swc_core = { version = "10.7.0", features = [
 ] }
 wit-parser = "0.212.0"
 convert_case = "0.7.1"
-wasm-opt = "0.116.1"
+wasm-opt = { workspace = true }
 tempfile = { workspace = true }
 clap = { version = "4.5.27", features = ["derive"] }
 serde = { workspace = true, default-features = false }
@@ -43,7 +43,9 @@ javy-runner = { path = "../runner/" }
 javy-test-macros = { path = "../test-macros/" }
 
 [build-dependencies]
-anyhow = "1.0.95"
+anyhow = { workspace = true }
+tempfile = { workspace = true }
+wasm-opt = { workspace = true }
 wizer = { workspace = true }
 
 [[bench]]

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -61,7 +61,7 @@ fn test_encoding(builder: &mut Builder) -> Result<()> {
 
     let (output, _, fuel_consumed) = run(&mut runner, "hello".as_bytes());
     assert_eq!("el".as_bytes(), output);
-    assert_fuel_consumed_within_threshold(258_197, fuel_consumed);
+    assert_fuel_consumed_within_threshold(252_723, fuel_consumed);
 
     let (output, _, _) = run(&mut runner, "invalid".as_bytes());
     assert_eq!("true".as_bytes(), output);

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -783,12 +783,10 @@ impl Runner {
         )?;
         let orig_ptr = 0;
         let orig_size = 0;
-        realloc_func
-            .call(
-                store.as_context_mut(),
-                (orig_ptr, orig_size, alignment, new_size),
-            )
-            .map_err(Into::into)
+        realloc_func.call(
+            store.as_context_mut(),
+            (orig_ptr, orig_size, alignment, new_size),
+        )
     }
 
     fn extract_store_data(


### PR DESCRIPTION
## Description of the change

A collection of fixes to get Javy and tests building and passing on Rust 1.85. Specifically:
- Rely on wasm-opt to remove overlong encoded indexes instead of the `-C target-feature=-reference-types` flag. The existing use of `-C target-feature=-reference-types` no longer produces Wasm modules without overlong encoded indexes. Wizer will still return an error if a Wasm module contains reference types. Also this means Javy can initialize other plugins that use overlong encoded indexes but not reference types.
- The amount of fuel for the encoding test case appears to have dropped so reduce the target amount of fuel for that test.
- `.map_err(Into::into)` was flagged by clippy as unnecessary so I'm removing it.

## Why am I making this change?

I'd like if we can get Javy building with Rust 1.85. The change to running wasm-opt before running Wizer should also simplify what needs to be done when building Javy plugins since wasm-opt can deal with the overlong encodings instead of relying on everyone building a Javy plugin to know how to deal with removing them.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
