### PR TITLE
Fix wasm-opt invocation for build assets

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Wizen and archive wizened plugin
         run: |
-          wasm-opt target/wasm32-wasip1/release/plugin.wasm target/wasm32-wasip1/release/plugin_optimized.wasm
+          wasm-opt target/wasm32-wasip1/release/plugin.wasm -O3 --shrink-level 0 -o target/wasm32-wasip1/release/plugin_optimized.wasm
           wizer target/wasm32-wasip1/release/plugin_optimized.wasm --allow-wasi --init-func initialize_runtime --wasm-bulk-memory true -o target/wasm32-wasip1/release/plugin_wizened.wasm
           gzip -k -f target/wasm32-wasip1/release/plugin_wizened.wasm && mv target/wasm32-wasip1/release/plugin_wizened.wasm.gz plugin.wasm.gz
 


### PR DESCRIPTION
## Description of the change

Fix #900 by providing the arguments correctly.

## Why am I making this change?

I had pushed this version of the change to my personal fork of Javy but forgot to push it to this repo before opening the PR and didn't double-check the arguments in the diff 🤦.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
