### PR TITLE
v5.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,7 +1565,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "javy-test-macros"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.1"
+version = "5.0.2"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
## Description of the change

v5.0.2

## Why am I making this change?

I'd like to release a version of Javy that can accept plugins with overlong index encodings.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
