### PR TITLE
Use Cow for plugin bytes instead of vector

### DIFF
--- a/crates/cli/src/codegen/plugin.rs
+++ b/crates/cli/src/codegen/plugin.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use std::{
+    borrow::Cow,
     fs,
     io::{self},
     path::Path,
@@ -48,24 +49,24 @@ impl PluginKind {
 /// Represents any valid Javy plugin.
 #[derive(Clone, Debug, Default)]
 pub struct Plugin {
-    bytes: Vec<u8>,
+    bytes: Cow<'static, [u8]>,
 }
 
 impl Plugin {
     /// Constructs a new instance of Plugin.
-    pub fn new(bytes: Vec<u8>) -> Self {
+    pub fn new(bytes: Cow<'static, [u8]>) -> Self {
         Plugin { bytes }
     }
 
     /// Constructs a new instance of Plugin from a given path.
     pub fn new_from_path<P: AsRef<Path>>(path: P) -> io::Result<Self> {
         let bytes = fs::read(path)?;
-        Ok(Self::new(bytes))
+        Ok(Self::new(bytes.into()))
     }
 
     /// Returns the plugin Wasm module as a byte slice.
     pub fn as_bytes(&self) -> &[u8] {
-        self.bytes.as_slice()
+        &self.bytes
     }
 }
 

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -379,7 +379,7 @@ mod tests {
 
     #[test]
     fn js_config_from_config_values() -> Result<()> {
-        let plugin = CliPlugin::new(Plugin::new(PLUGIN_MODULE.to_vec()), PluginKind::Default);
+        let plugin = CliPlugin::new(Plugin::new(PLUGIN_MODULE.into()), PluginKind::Default);
 
         let group = JsConfig::from_group_values(&plugin, vec![])?;
         assert_eq!(group.get("javy-stream-io"), None);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -48,12 +48,12 @@ fn main() -> Result<()> {
 
             if opts.dynamic {
                 generator
-                    .plugin(Plugin::new(QUICKJS_PROVIDER_V2_MODULE.to_vec()))
+                    .plugin(Plugin::new(QUICKJS_PROVIDER_V2_MODULE.into()))
                     .linking(LinkingKind::Dynamic)
                     .linking_v2_plugin(true);
             } else {
                 generator
-                    .plugin(Plugin::new(PLUGIN_MODULE.to_vec()))
+                    .plugin(Plugin::new(PLUGIN_MODULE.into()))
                     .linking(LinkingKind::Static)
                     .linking_default_plugin(true);
             };
@@ -71,7 +71,7 @@ fn main() -> Result<()> {
             // Always assume the default plugin if no plugin is provided.
             let cli_plugin = match &codegen_opts.plugin {
                 Some(path) => CliPlugin::new(Plugin::new_from_path(path)?, PluginKind::User),
-                None => CliPlugin::new(Plugin::new(PLUGIN_MODULE.to_vec()), PluginKind::Default),
+                None => CliPlugin::new(Plugin::new(PLUGIN_MODULE.into()), PluginKind::Default),
             };
 
             let js_opts = JsConfig::from_group_values(&cli_plugin, opts.js.clone())?;


### PR DESCRIPTION
## Description of the change

Has the plugin struct use a `Cow<'static, [u8]>` instead of a vector.

## Why am I making this change?

This will avoid an unnecessary copy. I noticed this during a review of a different PR and I must've missed it when it was introduced.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
