### PR TITLE
Return anyhow error instead of IO error

### DIFF
--- a/crates/codegen/src/plugin.rs
+++ b/crates/codegen/src/plugin.rs
@@ -1,11 +1,5 @@
 use anyhow::{anyhow, Result};
-use std::{
-    borrow::Cow,
-    fs,
-    io::{self},
-    path::Path,
-    str,
-};
+use std::{borrow::Cow, fs, path::Path, str};
 
 use super::bytecode;
 
@@ -60,7 +54,7 @@ impl Plugin {
     }
 
     /// Constructs a new instance of Plugin from a given path.
-    pub fn new_from_path<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+    pub fn new_from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
         let bytes = fs::read(path)?;
         Ok(Self::new(bytes.into()))
     }
@@ -69,9 +63,7 @@ impl Plugin {
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes
     }
-}
 
-impl Plugin {
     /// Generate valid QuickJS bytecode from Javascript using a Plugin.
     pub(crate) fn compile_source(&self, js_source_code: &[u8]) -> Result<Vec<u8>> {
         bytecode::compile_source(self.as_bytes(), js_source_code)


### PR DESCRIPTION
## Description of the change

Have `plugin::new_from_path` return an `anyhow::Error` instead of an `io::Error`.

## Why am I making this change?

Mostly consistency with the rest of the API.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
