### PR TITLE
Remove wasi-common from runner crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,7 +1640,6 @@ dependencies = [
  "anyhow",
  "tempfile",
  "uuid",
- "wasi-common",
  "wasmparser 0.226.0",
  "wasmtime",
  "wasmtime-wasi",

--- a/crates/cli/tests/dynamic_linking_test.rs
+++ b/crates/cli/tests/dynamic_linking_test.rs
@@ -6,7 +6,7 @@ use javy_test_macros::javy_cli_test;
 pub fn test_dynamic_linking(builder: &mut Builder) -> Result<()> {
     let mut runner = builder.input("console.js").build()?;
 
-    let (_, logs, _) = runner.exec(&[])?;
+    let (_, logs, _) = runner.exec(vec![])?;
     assert_eq!("42\n", String::from_utf8(logs)?);
     Ok(())
 }
@@ -19,7 +19,7 @@ pub fn test_dynamic_linking_with_func(builder: &mut Builder) -> Result<()> {
         .world("foo-test")
         .build()?;
 
-    let (_, logs, _) = runner.exec_func("foo-bar", &[])?;
+    let (_, logs, _) = runner.exec_func("foo-bar", vec![])?;
 
     assert_eq!("Toplevel\nIn foo\n", String::from_utf8(logs)?);
     Ok(())
@@ -29,7 +29,7 @@ pub fn test_dynamic_linking_with_func(builder: &mut Builder) -> Result<()> {
 pub fn test_dynamic_linking_with_func_without_flag(builder: &mut Builder) -> Result<()> {
     let mut runner = builder.input("linking-with-func-without-flag.js").build()?;
 
-    let res = runner.exec_func("foo", &[]);
+    let res = runner.exec_func("foo", vec![]);
 
     assert_eq!(
         "failed to find function export `foo`",
@@ -46,7 +46,7 @@ fn test_errors_in_exported_functions_are_correctly_reported(builder: &mut Builde
         .world("foo-test")
         .build()?;
 
-    let res = runner.exec_func("foo", &[]);
+    let res = runner.exec_func("foo", vec![]);
 
     assert!(res
         .err()
@@ -86,7 +86,7 @@ pub fn test_dynamic_linking_with_arrow_fn(builder: &mut Builder) -> Result<()> {
         .world("exported-arrow")
         .build()?;
 
-    let (_, logs, _) = runner.exec_func("default", &[])?;
+    let (_, logs, _) = runner.exec_func("default", vec![])?;
 
     assert_eq!("42\n", String::from_utf8(logs)?);
     Ok(())
@@ -120,7 +120,7 @@ fn test_using_plugin_with_dynamic_works(builder: &mut Builder) -> Result<()> {
         .input("plugin.js")
         .build()?;
 
-    let result = runner.exec(&[]);
+    let result = runner.exec(vec![]);
     assert!(result.is_ok());
 
     Ok(())

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 [dependencies]
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
-wasi-common = { workspace = true }
 anyhow = { workspace = true }
 tempfile = { workspace = true }
 uuid = { workspace = true }


### PR DESCRIPTION
## Description of the change

Switch from `wasi-common` to `wasmtime-wasi` in `runner` crate. This change includes taking stdin in tests as `Vec<u8>` instead of a byte slice because `MemoryInputStream::new` takes a `Vec<u8>` instead of a byte slice. I've also deleted `LogWriter` because `MemoryOutputStream` accepts a capacity limit as an argument.

## Why am I making this change?

We want to standardize on using `wasmtime-wasi`.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
