### PR TITLE
Remove dump_wat feature from codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,7 +1597,6 @@ dependencies = [
  "walrus",
  "wasi-common",
  "wasm-opt",
- "wasmprinter 0.224.1",
  "wasmtime",
  "wasmtime-wasi",
  "wit-parser 0.212.0",
@@ -3565,17 +3564,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.224.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
-dependencies = [
- "bitflags",
- "indexmap 2.7.0",
- "semver 1.0.23",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.226.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc28600dcb2ba68d7e5f1c3ba4195c2bddc918c0243fd702d0b6dbd05689b681"
@@ -3596,17 +3584,6 @@ dependencies = [
  "anyhow",
  "termcolor",
  "wasmparser 0.221.3",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.224.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0095b53a3b09cbc2f90f789ea44aa1b17ecc2dad8b267e657c7391f3ded6293d"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.224.1",
 ]
 
 [[package]]
@@ -3765,7 +3742,7 @@ dependencies = [
  "target-lexicon",
  "wasm-encoder 0.221.3",
  "wasmparser 0.221.3",
- "wasmprinter 0.221.3",
+ "wasmprinter",
  "wasmtime-component-util",
 ]
 

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -11,13 +11,11 @@ categories = ["wasm"]
 
 [features]
 plugin_internal = []
-dump_wat = ["dep:wasmprinter"]
 
 [dependencies]
 wizer = { workspace = true }
 anyhow = { workspace = true }
 brotli = "7.0.0"
-wasmprinter = { version = "0.224.0", optional = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasi-common = { workspace = true }

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -498,8 +498,6 @@ impl Generator {
         }
     }
 
-    // Run the calling code with the `dump_wat` feature enabled to print the WAT to stdout
-    //
     // For the example generated WAT, the `bytecode_len` is 137
     // (module
     //    (type (;0;) (func))
@@ -581,21 +579,6 @@ impl Generator {
         }
 
         let wasm = self.postprocess(&mut module)?;
-        print_wat(&wasm)?;
         Ok(wasm)
     }
-}
-
-#[cfg(feature = "dump_wat")]
-fn print_wat(wasm_binary: &[u8]) -> Result<()> {
-    println!(
-        "Generated WAT: \n{}",
-        wasmprinter::print_bytes(wasm_binary)?
-    );
-    Ok(())
-}
-
-#[cfg(not(feature = "dump_wat"))]
-fn print_wat(_wasm_binary: &[u8]) -> Result<()> {
-    Ok(())
 }


### PR DESCRIPTION
## Description of the change

Removes the `dump_wat` feature from the codegen crate.

## Why am I making this change?

We don't really use it any more and I don't want to commit to supporting it. It simplifies the code a bit.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
