### PR TITLE
v1.0.0 of javy-codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "javy-codegen"
-version = "1.0.0-alpha.1"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "brotli",

--- a/crates/codegen/CHANGELOG.md
+++ b/crates/codegen/CHANGELOG.md
@@ -6,6 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2025-03-07
+## [1.0.0] - 2025-03-10
 
 Initial release

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-codegen"
-version = "1.0.0-alpha.1"
+version = "1.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

v1.0.0 of `javy-codgen` crate.

## Why am I making this change?

We should publish this crate.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
