### PR TITLE
Switch everything to wasmtime-wasi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,10 +1578,10 @@ dependencies = [
  "serde_json",
  "tempfile",
  "walrus",
- "wasi-common",
  "wasm-opt",
  "wasmparser 0.226.0",
  "wasmtime",
+ "wasmtime-wasi",
  "wizer",
 ]
 
@@ -1595,7 +1595,6 @@ dependencies = [
  "swc_core",
  "tempfile",
  "walrus",
- "wasi-common",
  "wasm-opt",
  "wasmtime",
  "wasmtime-wasi",
@@ -3113,7 +3112,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3351,31 +3349,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
 dependencies = [
  "wit-bindgen-rt",
-]
-
-[[package]]
-name = "wasi-common"
-version = "29.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3101bd34deeb64225431f8b1b1793c87e7cad94383464878b3f90da6995977"
-dependencies = [
- "anyhow",
- "bitflags",
- "cap-fs-ext",
- "cap-rand",
- "cap-std",
- "cap-time-ext",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
- "log",
- "rustix",
- "system-interface",
- "thiserror",
- "tracing",
- "wasmtime",
- "wiggle",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ license = "Apache-2.0 WITH LLVM-exception"
 wizer = "8.0.0"
 wasmtime = "29"
 wasmtime-wasi = "29"
-wasi-common = "29"
 wasm-opt = "0.116.1"
 anyhow = "1.0"
 javy = { path = "crates/javy", version = "4.0.1-alpha.1" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,10 +11,10 @@ name = "javy"
 path = "src/main.rs"
 
 [dependencies]
-wasi-common = { workspace = true }
 wizer = { workspace = true }
 anyhow = { workspace = true }
 wasmtime = { workspace = true }
+wasmtime-wasi = { workspace = true }
 walrus = "0.23.3"
 wasm-opt = "0.116.1"
 tempfile = { workspace = true }

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -1,8 +1,8 @@
 use anyhow::{bail, Result};
 use javy_runner::{Builder, Plugin, Runner, RunnerError};
 use std::{path::PathBuf, process::Command, str};
-use wasi_common::sync::WasiCtxBuilder;
 use wasmtime::{AsContextMut, Engine, Linker, Module, Store};
+use wasmtime_wasi::WasiCtxBuilder;
 
 use javy_test_macros::javy_cli_test;
 
@@ -271,8 +271,8 @@ fn test_init_plugin() -> Result<()> {
     // `compile-src` on this module should succeed.
     let engine = Engine::default();
     let mut linker = Linker::new(&engine);
-    wasi_common::sync::add_to_linker(&mut linker, |s| s)?;
-    let wasi = WasiCtxBuilder::new().build();
+    wasmtime_wasi::preview1::add_to_linker_sync(&mut linker, |s| s)?;
+    let wasi = WasiCtxBuilder::new().build_p1();
     let mut store = Store::new(&engine, wasi);
 
     let uninitialized_plugin = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = { workspace = true }
 brotli = "7.0.0"
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
-wasi-common = { workspace = true }
 walrus = "0.23.3"
 swc_core = { version = "10.7.0", features = [
   "common_sourcemap",


### PR DESCRIPTION
## Description of the change

Removing the last uses of wasi-common in favour of wasmtime-wasi.

I'm opting not to update the CHANGELOG for `javy-codegen` since there is nothing about this code change that should be user-facing.

## Why am I making this change?

We want to standardize on wasmtime-wasi.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
