### PR TITLE
v5.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "5.0.2"
+version = "5.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "5.0.2"
+version = "5.0.3"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "javy-test-macros"
-version = "5.0.2"
+version = "5.0.3"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.2"
+version = "5.0.3"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
## Description of the change

Bumps the CLI version so we can do a release.

## Why am I making this change?

I'd like to release a version that returns errors when the same option is specified multiple times.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
