### PR TITLE
add messagepack feature to javy-plugin-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "3.0.1-alpha.1"
+version = "3.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "javy",

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,9 +8,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added `messagepack` feature exposing javy/messagepack feature
+
 ## [3.0.0] - 2025r-01-08
 
-### Removed 
+### Removed
 
 - `javy` dependency updated to 4.0.0 which removes `javy_json` method on
   `javy_plugin_api::Config` and removes support for `Javy.JSON.fromStdin` and
@@ -18,7 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.0.0] - 2024-11-27
 
-### Changed 
+### Changed
 
 - `initialize_runtime` accepts a `javy_plugin_api::Config` instead of a
   `javy_plugin_api::javy::Config`

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "3.0.1-alpha.1"
+version = "3.1.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -15,3 +15,4 @@ javy = { workspace = true, features = ["export_alloc_fns"] }
 
 [features]
 json = ["javy/json"]
+messagepack = ["javy/messagepack"]

--- a/crates/plugin-api/src/lib.rs
+++ b/crates/plugin-api/src/lib.rs
@@ -32,6 +32,7 @@
 //!
 //! # Features
 //! * `json` - enables the `json` feature in the `javy` crate.
+//! * `messagepack` - enables the `messagepack` feature in the `javy` crate.
 
 // Allow these in this file because we only run this program single threaded
 // and we can safely reason about the accesses to the Javy Runtime. We also


### PR DESCRIPTION
## Description of the change
Adds the messagepack feature from `javy/messagepack` to the javy-plugin-api

## Why am I making this change?
We have a plugin where we'd like to use the messagepack functions from [javy/messagepack](https://github.com/bytecodealliance/javy/blob/main/crates/javy/src/messagepack.rs)

## Checklist

- [X] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [X] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [X] I've updated documentation including crate documentation if necessary.
