### PR TITLE
v3.1.0 of javy-plugin-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "3.1.0-alpha.1"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "javy",

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,11 +8,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.1.0] - 2025-04-17
+
 ### Added
 
 - Added `messagepack` feature exposing javy/messagepack feature
 
-## [3.0.0] - 2025r-01-08
+## [3.0.0] - 2025-01-08
 
 ### Removed
 

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "3.1.0-alpha.1"
+version = "3.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

v3.1.0. Only change is exposing a feature for `messagepack`.

## Why am I making this change?

I think it's worth publishing a version of the crate with this change.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
