### PR TITLE
Specify published version for javy dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,8 +1236,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1308,6 +1310,16 @@ checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
+]
+
+[[package]]
+name = "halfbrown"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
+dependencies = [
+ "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]
@@ -1688,6 +1700,26 @@ dependencies = [
 
 [[package]]
 name = "javy"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10119b9ea70e813d800b3a3a734ec91ae1c2cdf9846c52f8a7a426ea1331ce5c"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "fastrand",
+ "quickcheck",
+ "rmp-serde",
+ "rquickjs",
+ "rquickjs-core",
+ "rquickjs-sys",
+ "serde",
+ "serde-transcode",
+ "serde_json",
+ "simd-json 0.14.3",
+]
+
+[[package]]
+name = "javy"
 version = "4.0.1-alpha.1"
 dependencies = [
  "anyhow",
@@ -1702,7 +1734,7 @@ dependencies = [
  "serde",
  "serde-transcode",
  "serde_json",
- "simd-json",
+ "simd-json 0.15.0",
 ]
 
 [[package]]
@@ -1750,7 +1782,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "arbitrary-json",
- "javy",
+ "javy 4.0.1-alpha.1",
  "libfuzzer-sys",
  "serde_json",
 ]
@@ -1770,7 +1802,7 @@ name = "javy-plugin-api"
 version = "3.1.0"
 dependencies = [
  "anyhow",
- "javy",
+ "javy 4.0.0",
 ]
 
 [[package]]
@@ -2746,17 +2778,32 @@ dependencies = [
 
 [[package]]
 name = "simd-json"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2bcf6c6e164e81bc7a5d49fc6988b3d515d9e8c07457d7b74ffb9324b9cd40"
+dependencies = [
+ "getrandom 0.2.15",
+ "halfbrown 0.2.5",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait 0.10.1",
+]
+
+[[package]]
+name = "simd-json"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10b5602e4f1f7d358956f94cac1eff59220f34cf9e26d49f5fde5acef851cbed"
 dependencies = [
  "getrandom 0.3.1",
- "halfbrown",
+ "halfbrown 0.3.0",
  "ref-cast",
  "serde",
  "serde_json",
  "simdutf8",
- "value-trait",
+ "value-trait 0.11.0",
 ]
 
 [[package]]
@@ -3425,12 +3472,24 @@ dependencies = [
 
 [[package]]
 name = "value-trait"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9170e001f458781e92711d2ad666110f153e4e50bfd5cbd02db6547625714187"
+dependencies = [
+ "float-cmp",
+ "halfbrown 0.2.5",
+ "itoa",
+ "ryu",
+]
+
+[[package]]
+name = "value-trait"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0508fce11ad19e0aab49ce20b6bec7f8f82902ded31df1c9fc61b90f0eb396b8"
 dependencies = [
  "float-cmp",
- "halfbrown",
+ "halfbrown 0.3.0",
  "itoa",
  "ryu",
 ]

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["wasm"]
 
 [dependencies]
 anyhow = { workspace = true }
-javy = { workspace = true, features = ["export_alloc_fns"] }
+javy = { version = "4.0.0", features = ["export_alloc_fns"] }
 
 [features]
 json = ["javy/json"]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -218,10 +218,6 @@ criteria = "safe-to-deploy"
 version = "0.2.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.fastrand]]
-version = "2.3.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.float-cmp]]
 version = "0.10.0"
 criteria = "safe-to-deploy"
@@ -283,6 +279,10 @@ version = "0.31.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.halfbrown]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.halfbrown]]
 version = "0.3.0"
 criteria = "safe-to-deploy"
 
@@ -316,6 +316,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.itertools]]
 version = "0.10.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.javy]]
+version = "4.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.jobserver]]
@@ -515,6 +519,10 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.simd-json]]
+version = "0.14.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.simd-json]]
 version = "0.15.0"
 criteria = "safe-to-deploy"
 
@@ -644,6 +652,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
 version = "1.16.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.value-trait]]
+version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.value-trait]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1543,6 +1543,21 @@ this crate has to do with iterators and `Result` and such. No `unsafe` or
 anything like that, all looks good.
 """
 
+[[audits.bytecode-alliance.audits.fastrand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.0 -> 2.0.1"
+notes = """
+This update had a few doc updates but no otherwise-substantial source code
+updates.
+"""
+
+[[audits.bytecode-alliance.audits.fastrand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.1.1 -> 2.3.0"
+notes = "Minor refactoring, nothing new."
+
 [[audits.bytecode-alliance.audits.foldhash]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -1878,6 +1893,16 @@ criteria = "safe-to-deploy"
 version = "0.2.5"
 notes = "No unsafe code"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.fastrand]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.9.0"
+notes = """
+`does-not-implement-crypto` is certified because this crate explicitly says
+that the RNG here is not cryptographically secure.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.getrandom]]
 who = "David Koloski <dkoloski@google.com>"
@@ -2475,6 +2500,25 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "1.8.0 -> 1.8.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fastrand]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.9.0 -> 2.0.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fastrand]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "2.0.1 -> 2.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fastrand]]
+who = "Chris Martin <cmartin@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.1.0 -> 2.1.1"
+notes = "Fairly trivial changes, no chance of security regression."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.fnv]]


### PR DESCRIPTION
## Description of the change

Sets the `javy` dependency for `javy-plugin-api` to a published version of the Javy crate. No changes to the `javy` crate have landed in the meantime.

I'll change it back after I publish this version.

## Why am I making this change?

I can't publish the `javy-plugin-api` crate if a dependency is set to an unpublished version.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
