### PR TITLE
Re-add suffix to javy-plugin-api version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,10 +1236,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1310,16 +1308,6 @@ checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
-]
-
-[[package]]
-name = "halfbrown"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
-dependencies = [
- "hashbrown 0.14.5",
- "serde",
 ]
 
 [[package]]
@@ -1700,26 +1688,6 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10119b9ea70e813d800b3a3a734ec91ae1c2cdf9846c52f8a7a426ea1331ce5c"
-dependencies = [
- "anyhow",
- "bitflags",
- "fastrand",
- "quickcheck",
- "rmp-serde",
- "rquickjs",
- "rquickjs-core",
- "rquickjs-sys",
- "serde",
- "serde-transcode",
- "serde_json",
- "simd-json 0.14.3",
-]
-
-[[package]]
-name = "javy"
 version = "4.0.1-alpha.1"
 dependencies = [
  "anyhow",
@@ -1734,7 +1702,7 @@ dependencies = [
  "serde",
  "serde-transcode",
  "serde_json",
- "simd-json 0.15.0",
+ "simd-json",
 ]
 
 [[package]]
@@ -1782,7 +1750,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "arbitrary-json",
- "javy 4.0.1-alpha.1",
+ "javy",
  "libfuzzer-sys",
  "serde_json",
 ]
@@ -1799,10 +1767,10 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "3.1.0"
+version = "3.1.1-alpha.1"
 dependencies = [
  "anyhow",
- "javy 4.0.0",
+ "javy",
 ]
 
 [[package]]
@@ -2778,32 +2746,17 @@ dependencies = [
 
 [[package]]
 name = "simd-json"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2bcf6c6e164e81bc7a5d49fc6988b3d515d9e8c07457d7b74ffb9324b9cd40"
-dependencies = [
- "getrandom 0.2.15",
- "halfbrown 0.2.5",
- "ref-cast",
- "serde",
- "serde_json",
- "simdutf8",
- "value-trait 0.10.1",
-]
-
-[[package]]
-name = "simd-json"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10b5602e4f1f7d358956f94cac1eff59220f34cf9e26d49f5fde5acef851cbed"
 dependencies = [
  "getrandom 0.3.1",
- "halfbrown 0.3.0",
+ "halfbrown",
  "ref-cast",
  "serde",
  "serde_json",
  "simdutf8",
- "value-trait 0.11.0",
+ "value-trait",
 ]
 
 [[package]]
@@ -3472,24 +3425,12 @@ dependencies = [
 
 [[package]]
 name = "value-trait"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9170e001f458781e92711d2ad666110f153e4e50bfd5cbd02db6547625714187"
-dependencies = [
- "float-cmp",
- "halfbrown 0.2.5",
- "itoa",
- "ryu",
-]
-
-[[package]]
-name = "value-trait"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0508fce11ad19e0aab49ce20b6bec7f8f82902ded31df1c9fc61b90f0eb396b8"
 dependencies = [
  "float-cmp",
- "halfbrown 0.3.0",
+ "halfbrown",
  "itoa",
  "ryu",
 ]

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "3.1.0"
+version = "3.1.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -11,7 +11,7 @@ categories = ["wasm"]
 
 [dependencies]
 anyhow = { workspace = true }
-javy = { version = "4.0.0", features = ["export_alloc_fns"] }
+javy = { workspace = true, features = ["export_alloc_fns"] }
 
 [features]
 json = ["javy/json"]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -279,10 +279,6 @@ version = "0.31.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.halfbrown]]
-version = "0.2.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.halfbrown]]
 version = "0.3.0"
 criteria = "safe-to-deploy"
 
@@ -316,10 +312,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.itertools]]
 version = "0.10.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.javy]]
-version = "4.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.jobserver]]
@@ -519,10 +511,6 @@ version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.simd-json]]
-version = "0.14.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.simd-json]]
 version = "0.15.0"
 criteria = "safe-to-deploy"
 
@@ -652,10 +640,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
 version = "1.16.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.value-trait]]
-version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.value-trait]]


### PR DESCRIPTION
## Description of the change

Re-adds the `-alpha.1` suffix to the `javy-plugin-api` version and uses the in-tree version of the `javy` crate.

## Why am I making this change?

To align with the versioning policy.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
