### PR TITLE
Set the version in the producers custom section to the CLI version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "javy-codegen"
-version = "1.0.1-alpha.1"
+version = "1.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "brotli",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -61,6 +61,7 @@ fn main() -> Result<()> {
                 ))?)
                 .source_compression(!opts.no_source_compression)
                 .js_runtime_config(JsConfig::default().to_json()?);
+            set_producer_version(&mut generator);
 
             let wasm = generator.generate(&js)?;
 
@@ -91,6 +92,7 @@ fn main() -> Result<()> {
                 .wit_opts(codegen_opts.wit)
                 .source_compression(!codegen_opts.source_compression)
                 .js_runtime_config(js_opts.to_json()?);
+            set_producer_version(&mut generator);
 
             if codegen_opts.dynamic {
                 generator.linking(LinkingKind::Dynamic);
@@ -126,4 +128,8 @@ fn emit_plugin(opts: &EmitPluginCommandOpts) -> Result<()> {
     };
     file.write_all(PLUGIN_MODULE)?;
     Ok(())
+}
+
+fn set_producer_version(generator: &mut Generator) {
+    generator.producer_version(env!("CARGO_PKG_VERSION").to_string());
 }

--- a/crates/codegen/CHANGELOG.md
+++ b/crates/codegen/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `Generator` now has a `producer_version` method so the version in the
+  producers custom section can be set.
+
 ## [1.0.0] - 2025-03-10
 
 Initial release

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-codegen"
-version = "1.0.1-alpha.1"
+version = "1.1.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -166,6 +166,8 @@ pub struct Generator {
     plugin_kind: plugin::PluginKind,
     /// An optional JS runtime config provided as JSON bytes.
     js_runtime_config: Vec<u8>,
+    /// The version string to include in the producers custom section.
+    producer_version: Option<String>,
 }
 
 impl Generator {
@@ -223,6 +225,12 @@ impl Generator {
     /// Set the JS runtime configuration options to pass to the module.
     pub fn js_runtime_config(&mut self, js_runtime_config: Vec<u8>) -> &mut Self {
         self.js_runtime_config = js_runtime_config;
+        self
+    }
+
+    /// Sets the version string to use in the producers custom section.
+    pub fn producer_version(&mut self, producer_version: String) -> &mut Self {
+        self.producer_version = Some(producer_version);
         self
     }
 }
@@ -572,7 +580,12 @@ impl Generator {
         let bc_metadata = self.generate_main(&mut module, js, &identifiers)?;
         self.generate_exports(&mut module, &identifiers, &bc_metadata)?;
 
-        transform::add_producers_section(&mut module.producers);
+        transform::add_producers_section(
+            &mut module.producers,
+            self.producer_version
+                .as_deref()
+                .unwrap_or(env!("CARGO_PKG_VERSION")),
+        );
         if !self.source_compression {
             module.customs.add(SourceCodeSection::uncompressed(js)?);
         } else {

--- a/crates/codegen/src/transform.rs
+++ b/crates/codegen/src/transform.rs
@@ -40,8 +40,8 @@ pub(crate) fn module_config() -> ModuleConfig {
     config
 }
 
-pub(crate) fn add_producers_section(producers: &mut ModuleProducers) {
+pub(crate) fn add_producers_section(producers: &mut ModuleProducers, version: &str) {
     producers.clear(); // removes Walrus and Rust
     producers.add_language("JavaScript", "ES2020");
-    producers.add_processed_by("Javy", env!("CARGO_PKG_VERSION"));
+    producers.add_processed_by("Javy", version);
 }


### PR DESCRIPTION
## Description of the change

Adds a `producers_version` method to `Generator` in `javy-codegen` and has the CLI call it with the current package version.

## Why am I making this change?

Fixes #937.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
