### PR TITLE
v5.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "5.0.3"
+version = "5.0.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "5.0.3"
+version = "5.0.4"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "javy-test-macros"
-version = "5.0.3"
+version = "5.0.4"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.3"
+version = "5.0.4"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
## Description of the change

Bumping version of CLI to v5.0.4.

## Why am I making this change?

I want to release the bugfix for the providers custom section containing the wrong version.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
