### PR TITLE
Fix CI

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -163,7 +163,7 @@ where
 
         for val in val.split(',') {
             opts.push(T::parse(val).map_err(|e| {
-                clap::Error::raw(clap::error::ErrorKind::InvalidValue, format!("{}", e))
+                clap::Error::raw(clap::error::ErrorKind::InvalidValue, format!("{e}"))
             })?)
         }
 

--- a/crates/cli/src/option.rs
+++ b/crates/cli/src/option.rs
@@ -17,14 +17,14 @@ pub struct OptionMeta {
 }
 
 pub fn fmt_help(cmd: &str, short: &str, meta: &[OptionMeta]) {
-    println!("Available options for {}", cmd);
+    println!("Available options for {cmd}");
     for opt in meta {
         println!();
-        print!("-{:<3}", short);
+        print!("-{short:<3}");
         print!("{:>3}", opt.name);
         println!("{}", opt.help);
         for line in opt.doc.split('\n') {
-            print!("{}", line);
+            print!("{line}");
         }
         println!();
     }

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -352,9 +352,6 @@ fn assert_fuel_consumed_within_threshold(target_fuel: u64, fuel_consumed: u64) {
 
     assert!(
         percentage_difference <= threshold,
-        "fuel_consumed ({}) was not within {:.2}% of the target_fuel value ({})",
-        fuel_consumed,
-        threshold,
-        target_fuel
+        "fuel_consumed ({fuel_consumed}) was not within {threshold:.2}% of the target_fuel value ({target_fuel})",
     );
 }

--- a/crates/test-macros/src/lib.rs
+++ b/crates/test-macros/src/lib.rs
@@ -128,7 +128,7 @@ fn gen_tests(
             let name = path.file_stem().unwrap().to_str().unwrap();
             let name = name.replace('.', "_");
             let name = name.replace('-', "_");
-            let test_name = Ident::new(&format!("test_{}_{}", prefix, name), Span::call_site());
+            let test_name = Ident::new(&format!("test_{prefix}_{name}"), Span::call_site());
             let ignore = ignore(&test_name.to_string());
 
             let attrs = if ignore {


### PR DESCRIPTION
## Description of the change

Inlining variables into format strings. This shouldn't have any impact on behaviour.

## Why am I making this change?

This should get CI passing again.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
