### PR TITLE
Add some derive debug tags

### DIFF
--- a/crates/cli/benches/benchmark.rs
+++ b/crates/cli/benches/benchmark.rs
@@ -211,12 +211,13 @@ fn execute_javy(index_js: &Path, wasm: &Path, linking: &Linking) -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug)]
 enum Compilation {
     AheadOfTime,
     JustInTime,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 enum Linking {
     Static,
     Dynamic,

--- a/crates/cli/src/plugin.rs
+++ b/crates/cli/src/plugin.rs
@@ -9,6 +9,7 @@ pub const QUICKJS_PROVIDER_V2_MODULE: &[u8] = include_bytes!("./javy_quickjs_pro
 
 /// Represents the kind of a plugin.
 // This is an internal detail of this module.
+#[derive(Debug)]
 pub(crate) enum PluginKind {
     User,
     Default,
@@ -17,6 +18,7 @@ pub(crate) enum PluginKind {
 /// Represents a Plugin as well as it's kind
 /// for use within the Javy CLI crate.
 // This is an internal detail of this module.
+#[derive(Debug)]
 pub(crate) struct CliPlugin {
     pub(crate) plugin: Plugin,
     pub(crate) kind: PluginKind,
@@ -37,6 +39,7 @@ impl CliPlugin {
 }
 
 /// A validated but uninitialized plugin.
+#[derive(Debug)]
 pub(crate) struct UninitializedPlugin<'a> {
     bytes: &'a [u8],
 }

--- a/crates/codegen/src/exports.rs
+++ b/crates/codegen/src/exports.rs
@@ -7,7 +7,7 @@ use crate::wit;
 
 pub(crate) type Exports = Vec<Export>;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct Export {
     pub wit: String,
     pub js: String,

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -97,7 +97,7 @@ use anyhow::Result;
 static STDIN_PIPE: OnceLock<MemoryInputPipe> = OnceLock::new();
 
 /// The kind of linking to use.
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub enum LinkingKind {
     #[default]
     /// Static linking
@@ -108,6 +108,7 @@ pub enum LinkingKind {
 
 /// Identifiers used by the generated module.
 // This is an internal detail of this module.
+#[derive(Debug)]
 pub(crate) struct Identifiers {
     canonical_abi_realloc: FunctionId,
     eval_bytecode: Option<FunctionId>,
@@ -133,6 +134,7 @@ impl Identifiers {
 
 /// Helper struct to keep track of bytecode metadata.
 // This is an internal detail of this module.
+#[derive(Debug)]
 pub(crate) struct BytecodeMetadata {
     ptr: LocalId,
     len: i32,
@@ -150,7 +152,7 @@ impl BytecodeMetadata {
 }
 
 /// Generator used to produce Wasm binaries from JS source code.
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Generator {
     /// Plugin to use.
     pub(crate) plugin: plugin::Plugin,

--- a/crates/codegen/src/plugin.rs
+++ b/crates/codegen/src/plugin.rs
@@ -5,7 +5,7 @@ use super::bytecode;
 
 /// The kind of a plugin.
 // This is an internal detail of this module.
-#[derive(Default, PartialEq, Copy, Clone)]
+#[derive(Debug, Default, PartialEq, Copy, Clone)]
 #[allow(dead_code)] // Suppresses warnings for feature-gated variants
 pub(crate) enum PluginKind {
     #[default]

--- a/crates/javy/src/apis/console/mod.rs
+++ b/crates/javy/src/apis/console/mod.rs
@@ -190,7 +190,7 @@ mod tests {
         Ok(())
     }
 
-    #[derive(Clone)]
+    #[derive(Debug, Clone)]
     struct SharedStream {
         buffer: Rc<RefCell<Vec<u8>>>,
         capacity: usize,

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -3,6 +3,7 @@ use bitflags::bitflags;
 
 bitflags! {
     /// Flags to represent available JavaScript features.
+    #[derive(Debug)]
     pub(crate) struct JSIntrinsics: u32  {
         const DATE = 1;
         const EVAL = 1 << 1;
@@ -35,6 +36,7 @@ bitflags! {
     /// users to extend the runtime with non-standard functionality directly
     /// from the CLI, at this point many, if not most, of these APIs will be
     /// moved out.
+    #[derive(Debug)]
     pub(crate) struct JavyIntrinsics: u32 {
         const STREAM_IO = 1;
     }
@@ -44,6 +46,7 @@ bitflags! {
 ///
 /// These are the global configuration options to create a [`Runtime`](crate::Runtime),
 /// and customize its behavior.
+#[derive(Debug)]
 pub struct Config {
     /// JavaScript features.
     pub(crate) intrinsics: JSIntrinsics,

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -11,13 +11,13 @@ use wasmtime::{AsContextMut, Config, Engine, Instance, Linker, Module, OptLevel,
 use wasmtime_wasi::pipe::{MemoryInputPipe, MemoryOutputPipe};
 use wasmtime_wasi::{preview1::WasiP1Ctx, WasiCtxBuilder};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum JavyCommand {
     Build,
     Compile,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum Plugin {
     V2,
     Default,
@@ -59,7 +59,7 @@ impl Plugin {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Builder {
     /// The JS source.
     input: PathBuf,
@@ -276,6 +276,7 @@ impl StoreContext {
     }
 }
 
+#[derive(Debug)]
 pub enum UseExportedFn {
     EvalBytecode,
     Invoke(Option<&'static str>),

--- a/crates/test-macros/src/lib.rs
+++ b/crates/test-macros/src/lib.rs
@@ -17,6 +17,7 @@ use quote::quote;
 use std::{env, path::PathBuf};
 use syn::{meta::ParseNestedMeta, parse_macro_input, Ident, LitBool, LitStr, Result, ReturnType};
 
+#[derive(Debug)]
 struct Config262 {
     root: PathBuf,
 }
@@ -178,6 +179,7 @@ fn gen_tests(
     }
 }
 
+#[derive(Debug)]
 struct CliTestConfig {
     /// Root directory to load test scripts from, relative to the crate's
     /// directory (i.e., `CARGO_MANIFEST_DIR`)


### PR DESCRIPTION
## Description of the change

Adds `#[derive(Debug)]` to a few different places.

## Why am I making this change?

I ran into a couple cases while debugging things where I was not able to use the `dbg!` macro without tagging some structs. I figured why not tag the structs to make it easier to debug things without having to make code changes.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
