### PR TITLE
Fix incorrect homepage and repository URLs in plugin-api

### DIFF
--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -5,8 +5,8 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "APIs for Javy plugins"
-homepage = "https://github.com/bytecodealliance/javy/tree/main/crates/javy-plugin-api"
-repository = "https://github.com/bytecodealliance/javy/tree/main/crates/javy-plugin-api"
+homepage = "https://github.com/bytecodealliance/javy/tree/main/crates/plugin-api"
+repository = "https://github.com/bytecodealliance/javy/tree/main/crates/plugin-api"
 categories = ["wasm"]
 
 [dependencies]


### PR DESCRIPTION
## Description of the change

Changes the URLs in `javy-plugin-api`'s `Cargo.toml` to correct ones.

## Why am I making this change?

I noticed these were incorrect while making another change.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
