### PR TITLE
Add plugin-processing crate to handle plugin initialization

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,6 @@
 
 ## Checklist
 
-- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
+- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
 - [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
 - [ ] I've updated documentation including crate documentation if necessary.

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -24,33 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Read wizer version
-        id: wizer_version
-        shell: bash
-        run: |
-          VERSION=$(cargo metadata --format-version=1 --locked | jq '.packages[] | select(.name == "wizer") | .version' -r)
-          echo "WIZER_VERSION=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Install wizer
-        shell: bash
-        run: |
-          wget -nv https://github.com/bytecodealliance/wizer/releases/download/v${{ steps.wizer_version.outputs.WIZER_VERSION }}/wizer-v${{ steps.wizer_version.outputs.WIZER_VERSION }}-x86_64-linux.tar.xz -O /tmp/wizer.tar.xz
-          mkdir /tmp/wizer
-          tar xvf /tmp/wizer.tar.xz --strip-components=1 -C /tmp/wizer
-          echo "/tmp/wizer" >> $GITHUB_PATH
-
-      - name: Read wasm-opt version
-        id: wasm_opt_version
-        shell: bash
-        run: |
-          VERSION=$(cargo metadata --format-version=1 --locked | jq '.packages[] | select(.name == "wasm-opt") | .version' -r)
-          echo "WASMOPT_VERSION=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Install wasm-opt
-        shell: bash
-        run: |
-          cargo install --locked wasm-opt@${{ steps.wasm_opt_version.outputs.WASMOPT_VERSION }}
-
       - name: Make plugin
         run: make plugin
 
@@ -62,8 +35,7 @@ jobs:
 
       - name: Wizen and archive wizened plugin
         run: |
-          wasm-opt target/wasm32-wasip1/release/plugin.wasm -O3 --shrink-level 0 -o target/wasm32-wasip1/release/plugin_optimized.wasm
-          wizer target/wasm32-wasip1/release/plugin_optimized.wasm --allow-wasi --init-func initialize_runtime --wasm-bulk-memory true -o target/wasm32-wasip1/release/plugin_wizened.wasm
+          cargo run --package=javy-plugin-processing target/wasm32-wasip1/release/plugin.wasm target/wasm32-wasip1/release/plugin_wizened.wasm
           gzip -k -f target/wasm32-wasip1/release/plugin_wizened.wasm && mv target/wasm32-wasip1/release/plugin_wizened.wasm.gz plugin.wasm.gz
 
       - name: Upload archived plugin to artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,14 @@ jobs:
       - name: Test
         env:
           CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime --dir=.
-        run: cargo hack test --target=wasm32-wasip1 --workspace --exclude=javy-cli --exclude=javy-codegen --exclude=javy-runner --exclude=javy-test-plugin --each-feature -- --nocapture
+        run: |
+          cargo hack test --workspace \
+          --exclude=javy-cli \
+          --exclude=javy-codegen \
+          --exclude=javy-plugin-processing \
+          --exclude=javy-runner \
+          --exclude=javy-test-plugin \
+          --target=wasm32-wasip1 --each-feature -- --nocapture
 
       - name: Test Runner
         run: cargo test --package=javy-runner
@@ -67,6 +74,7 @@ jobs:
           cargo clippy --workspace \
           --exclude=javy-cli \
           --exclude=javy-codegen \
+          --exclude=javy-plugin-processing \
           --exclude=javy-runner \
           --exclude=javy-fuzz \
           --target=wasm32-wasip1 --all-targets -- -D warnings
@@ -90,6 +98,10 @@ jobs:
           target/release/javy emit-plugin -o crates/codegen/default_plugin.wasm
           CARGO_PROFILE_RELEASE_LTO=off cargo hack test --package=javy-codegen --release --each-feature -- --nocapture
 
+      - name: Test plugin processing
+        run: |
+          cargo test --package=javy-plugin-processing -- --nocapture
+
       - name: Check benchmarks
         run: CARGO_PROFILE_RELEASE_LTO=off cargo check --package=javy-cli --release --benches
 
@@ -102,6 +114,11 @@ jobs:
         run: |
           cargo fmt -- --check
           CARGO_PROFILE_RELEASE_LTO=off cargo hack clippy --package=javy-codegen --release --all-targets --each-feature -- -D warnings
+
+      - name: Lint plugin processing
+        run: |
+          cargo fmt --package=javy-plugin-processing -- --check
+          cargo clippy --package=javy-plugin-processing --all-targets -- -D warnings
 
       - name: WPT
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,6 +1728,7 @@ dependencies = [
  "clap",
  "criterion",
  "javy-codegen",
+ "javy-plugin-processing",
  "javy-runner",
  "javy-test-macros",
  "num-format",
@@ -1739,7 +1740,6 @@ dependencies = [
  "wasmparser 0.235.0",
  "wasmtime",
  "wasmtime-wasi",
- "wizer",
 ]
 
 [[package]]
@@ -1786,6 +1786,18 @@ version = "3.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "javy",
+]
+
+[[package]]
+name = "javy-plugin-processing"
+version = "5.0.4"
+dependencies = [
+ "anyhow",
+ "clap",
+ "tempfile",
+ "wasm-opt",
+ "wasmtime-wasi",
+ "wizer",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "crates/javy",
   "crates/plugin",
   "crates/plugin-api",
+  "crates/plugin-processing",
   "crates/test-macros",
   "crates/test-plugin",
   "crates/runner",
@@ -19,6 +20,7 @@ edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 
 [workspace.dependencies]
+clap = { version = "4.5.40", features = ["derive"] }
 wizer = "9.0.0"
 wasmtime = "31"
 wasmtime-wasi = "31"

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ cli: plugin
 
 plugin:
 	cargo build --package=javy-plugin --release --target=wasm32-wasip1 --features=$(PLUGIN_FEATURES)
+	cargo run --package=javy-plugin-processing target/wasm32-wasip1/release/plugin.wasm target/wasm32-wasip1/release/plugin_wizened.wasm
 
 build-test-plugin: cli
 	cargo build --package=javy-test-plugin --release --target=wasm32-wasip1
@@ -34,6 +35,9 @@ test-plugin-api:
 test-plugin:
 	CARGO_TARGET_WASM32_WASIP1_RUNNER="wasmtime" cargo test --package=javy-plugin --target=wasm32-wasip1 -- --nocapture
 
+test-plugin-processing:
+	cargo test --package=javy-plugin-processing -- --nocapture
+
 test-codegen: cli
 	target/release/javy emit-plugin -o crates/codegen/default_plugin.wasm
 	CARGO_PROFILE_RELEASE_LTO=off cargo hack test --package=javy-codegen --release --each-feature -- --nocapture
@@ -51,9 +55,9 @@ test-wpt: cli
 	npm install --prefix wpt
 	npm test --prefix wpt
 
-tests: test-javy test-plugin-api test-plugin test-runner test-codegen test-cli test-wpt
+tests: test-javy test-plugin-api test-plugin test-plugin-processing test-runner test-codegen test-cli test-wpt
 
-fmt: fmt-javy fmt-plugin-api fmt-plugin fmt-cli fmt-codegen
+fmt: fmt-javy fmt-plugin-api fmt-plugin fmt-plugin-processing fmt-cli fmt-codegen
 
 fmt-javy:
 	cargo fmt --package=javy -- --check
@@ -66,6 +70,10 @@ fmt-plugin-api:
 fmt-plugin:
 	cargo fmt --package=javy-plugin -- --check
 	cargo clippy --package=javy-plugin --target=wasm32-wasip1 --all-targets -- -D warnings
+
+fmt-plugin-processing:
+	cargo fmt --package=javy-plugin-processing -- --check
+	cargo clippy --package=javy-plugin-processing --all-targets -- -D warnings
 
 # Use `--release` on CLI clippy to align with `test-cli`.
 # This reduces the size of the target directory which improves CI stability.

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,17 +11,16 @@ name = "javy"
 path = "src/main.rs"
 
 [dependencies]
-wizer = { workspace = true }
 anyhow = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 walrus = "0.23.3"
-wasm-opt = "0.116.1"
 tempfile = { workspace = true }
-clap = { version = "4.5.40", features = ["derive"] }
+clap = { workspace = true }
 serde = { workspace = true, default-features = false }
 serde_json = { workspace = true }
 javy-codegen = { path = "../codegen/", features = ["plugin_internal"] }
+javy-plugin-processing = { path = "../plugin-processing" }
 
 [dev-dependencies]
 criterion = "0.6"
@@ -32,9 +31,9 @@ javy-test-macros = { path = "../test-macros/" }
 
 [build-dependencies]
 anyhow = { workspace = true }
+javy-plugin-processing = { path = "../plugin-processing" }
 tempfile = { workspace = true }
 wasm-opt = { workspace = true }
-wizer = { workspace = true }
 
 [[bench]]
 name = "benchmark"

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -26,5 +26,5 @@ swc_core = { version = "16.10.0", features = [
 ] }
 wit-parser = "0.212.0"
 convert_case = "0.8.0"
-wasm-opt = "0.116.1"
+wasm-opt = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/plugin-processing/Cargo.toml
+++ b/crates/plugin-processing/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "javy-plugin-processing"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Logic for initializing Javy plugins"
+homepage = "https://github.com/bytecodealliance/javy/tree/main/crates/plugin-processing"
+repository = "https://github.com/bytecodealliance/javy/tree/main/crates/plugin-processing"
+categories = ["wasm"]
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+tempfile = { workspace = true }
+wasm-opt = { workspace = true }
+wasmtime-wasi = { workspace = true }
+wizer = { workspace = true }

--- a/crates/plugin-processing/src/lib.rs
+++ b/crates/plugin-processing/src/lib.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use std::{fs, rc::Rc};
+use wasmtime_wasi::WasiCtxBuilder;
+use wizer::{wasmtime::Module, Linker, Wizer};
+
+/// Uses wasm-opt and Wizer to initialize a plugin.
+pub fn initialize_plugin(wasm_bytes: &[u8]) -> Result<Vec<u8>> {
+    // Re-encode overlong indexes with wasm-opt before running Wizer.
+    let wasm_bytes = optimize_module(wasm_bytes)?;
+    let wasm_bytes = preinitialize_module(&wasm_bytes)?;
+    Ok(wasm_bytes)
+}
+
+fn optimize_module(wasm_bytes: &[u8]) -> Result<Vec<u8>> {
+    let temp_dir = tempfile::tempdir()?;
+    let infile = temp_dir.path().join("infile.wasm");
+    fs::write(&infile, wasm_bytes)?;
+    let outfile = temp_dir.path().join("outfile.wasm");
+    wasm_opt::OptimizationOptions::new_opt_level_3() // Aggressively optimize for speed.
+        .shrink_level(wasm_opt::ShrinkLevel::Level0) // Don't optimize for size at the expense of performance.
+        .debug_info(false)
+        .run(&infile, &outfile)?;
+    let optimized_wasm_bytes = fs::read(outfile)?;
+    Ok(optimized_wasm_bytes)
+}
+
+fn preinitialize_module(wasm_bytes: &[u8]) -> Result<Vec<u8>> {
+    let mut wizer = Wizer::new();
+    let owned_wasm_bytes = wasm_bytes.to_vec();
+    wizer
+        .init_func("initialize_runtime")
+        .keep_init_func(true)
+        .make_linker(Some(Rc::new(move |engine| {
+            let mut linker = Linker::new(engine);
+            wasmtime_wasi::preview1::add_to_linker_sync(&mut linker, |ctx| {
+                if ctx.wasi_ctx.is_none() {
+                    ctx.wasi_ctx = Some(WasiCtxBuilder::new().inherit_stderr().build_p1());
+                }
+                ctx.wasi_ctx.as_mut().unwrap()
+            })?;
+            linker.define_unknown_imports_as_traps(&Module::new(engine, &owned_wasm_bytes)?)?;
+            Ok(linker)
+        })))?
+        .run(wasm_bytes)
+}

--- a/crates/plugin-processing/src/main.rs
+++ b/crates/plugin-processing/src/main.rs
@@ -1,0 +1,22 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::Result;
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(about = "Initialize a Javy plugin")]
+struct Args {
+    #[arg(help = "Path to the uninitialized Javy plugin")]
+    input: PathBuf,
+
+    #[arg(help = "Output path for the initialized Javy plugin")]
+    output: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let wasm_bytes = fs::read(&args.input)?;
+    let wasm_bytes = javy_plugin_processing::initialize_plugin(&wasm_bytes)?;
+    fs::write(&args.output, wasm_bytes)?;
+    Ok(())
+}

--- a/docs/docs-contributing-architecture.md
+++ b/docs/docs-contributing-architecture.md
@@ -124,6 +124,11 @@ You should gate your feature with a cargo feature if your feature/change:
 
 A Rust crate for compiling JS to Wasm.
 
+### `javy-plugin-processing`
+
+Contains the logic for initializing a Javy plugin. Used to build the default
+plugin and also be the Javy CLI for its plugin initialization logic.
+
 ### `javy-plugin`
 
 Gets compiled to `plugin.wasm` for use by the CLI and in environments for

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -34,6 +34,9 @@ audit-as-crates-io = false
 [policy.javy-plugin-api]
 audit-as-crates-io = false
 
+[policy.javy-plugin-processing]
+audit-as-crates-io = false
+
 [[exemptions.Inflector]]
 version = "0.11.4"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Description of the change

Adds a new crate called `javy-plugin-processing` that performs the `wasm-opt` and wizening operations on plugins to initialize them. There shouldn't be any functional changes as a result of this.

## Why am I making this change?

We perform the same plugin initialization process in a few different places at the moment:
1. In the Makefile
2. As part of the Javy CLI's build script
3. As part of the build assets GitHub workflow
4. In the Javy CLI's plugin initialization command

So this lets us centralize that logic. Also if we opt to adopt #962 and some form of #958, there aren't existing library or command line tool equivalents for extracting a particular core module from a Wasm component so we'll need some sort of library and command line tool to perform those operations and this change would provide a natural place to add that logic.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
