### PR TITLE
Reducing some noise in the Generator

### DIFF
--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -83,6 +83,7 @@ pub(crate) mod wit;
 pub use crate::js::JS;
 pub use crate::plugin::Plugin;
 pub use crate::wit::WitOptions;
+use crate::{exports::Exports, plugin::PluginKind};
 
 use transform::SourceCodeSection;
 use walrus::{
@@ -153,17 +154,17 @@ impl BytecodeMetadata {
 #[derive(Default, Clone)]
 pub struct Generator {
     /// Plugin to use.
-    pub(crate) plugin: plugin::Plugin,
+    pub(crate) plugin: Plugin,
     /// What kind of linking to use when generating a module.
     pub(crate) linking: LinkingKind,
     /// Whether to embed the compressed JS source in the generated module.
     pub(crate) source_compression: bool,
     /// WIT options for code generation.
-    pub(crate) wit_opts: wit::WitOptions,
+    pub(crate) wit_opts: WitOptions,
     /// JavaScript function exports.
-    pub(crate) function_exports: exports::Exports,
+    pub(crate) function_exports: Exports,
     /// The kind of plugin a generator will link.
-    plugin_kind: plugin::PluginKind,
+    plugin_kind: PluginKind,
     /// An optional JS runtime config provided as JSON bytes.
     js_runtime_config: Vec<u8>,
     /// The version string to include in the producers custom section.
@@ -201,9 +202,9 @@ impl Generator {
     /// Set true if linking with a default plugin module.
     pub fn linking_default_plugin(&mut self, value: bool) -> &mut Self {
         self.plugin_kind = if value {
-            plugin::PluginKind::Default
+            PluginKind::Default
         } else {
-            plugin::PluginKind::User
+            PluginKind::User
         };
 
         self
@@ -213,9 +214,9 @@ impl Generator {
     /// Set true if linking with a V2 plugin module.
     pub fn linking_v2_plugin(&mut self, value: bool) -> &mut Self {
         self.plugin_kind = if value {
-            plugin::PluginKind::V2
+            PluginKind::V2
         } else {
-            plugin::PluginKind::User
+            PluginKind::User
         };
 
         self
@@ -319,18 +320,16 @@ impl Generator {
                 // User plugins also won't have an `eval_bytecode` function to
                 // import. We want to remove `eval_bytecode` from the default
                 // plugin so we don't want to emit more uses of it.
-                let eval_bytecode_fn_id = match self.plugin_kind {
-                    plugin::PluginKind::V2 => {
-                        let eval_bytecode_type =
-                            module.types.add(&[ValType::I32, ValType::I32], &[]);
-                        let (eval_bytecode_fn_id, _) = module.add_import_func(
-                            &import_namespace,
-                            "eval_bytecode",
-                            eval_bytecode_type,
-                        );
-                        Some(eval_bytecode_fn_id)
-                    }
-                    _ => None,
+                let eval_bytecode_fn_id = if self.plugin_kind == PluginKind::V2 {
+                    let eval_bytecode_type = module.types.add(&[ValType::I32, ValType::I32], &[]);
+                    let (eval_bytecode_fn_id, _) = module.add_import_func(
+                        &import_namespace,
+                        "eval_bytecode",
+                        eval_bytecode_type,
+                    );
+                    Some(eval_bytecode_fn_id)
+                } else {
+                    None
                 };
 
                 let invoke_type = module.types.add(
@@ -399,7 +398,7 @@ impl Generator {
             // support calling `invoke` with a null function. The default
             // plugin and user plugins do accept null functions.
             assert!(
-                !matches!(self.plugin_kind, plugin::PluginKind::V2),
+                self.plugin_kind != PluginKind::V2,
                 "Using invoke with null function not supported for v2 plugin"
             );
             instructions
@@ -480,10 +479,7 @@ impl Generator {
                 module.exports.remove("canonical_abi_realloc")?;
 
                 // Only internal plugins expose eval_bytecode function.
-                if matches!(
-                    self.plugin_kind,
-                    plugin::PluginKind::Default | plugin::PluginKind::V2
-                ) {
+                if self.plugin_kind == PluginKind::Default || self.plugin_kind == PluginKind::V2 {
                     module.exports.remove("eval_bytecode")?;
                 }
 


### PR DESCRIPTION
## Description of the change

Very basic cleanup of some code in `Generator`. Mostly changing struct types to use un-prefixed versions and using equality checks for plugin kinds. There shouldn't be any functional changes as a result.

## Why am I making this change?

I'll likely have to make some changes in this file for #962 and I would like if the code has a little less noise and is consistent.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
