### PR TITLE
Allow configuring console streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "4.0.1-alpha.1"
+version = "4.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ wasmtime = "31"
 wasmtime-wasi = "31"
 wasm-opt = "0.116.1"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "4.0.1-alpha.1" }
+javy = { path = "crates/javy", version = "4.1.0-alpha.1" }
 tempfile = "3.20.0"
 uuid = { version = "1.17", features = ["v4"] }
 serde = { version = "1.0", default-features = false }

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `Config` now supports setting a `log_stream` and `err_stream` to configure
+  the destinations for `console.log` and `console.err`.
+
 ## [4.0.0] - 2025-01-08
 
 ### Removed

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "4.0.1-alpha.1"
+version = "4.1.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -13,10 +13,7 @@ use rquickjs::{
     context::{intrinsic, Intrinsic},
     Context, Module, Runtime as QRuntime,
 };
-use std::{
-    io::{stderr, stdout},
-    mem::ManuallyDrop,
-};
+use std::mem::ManuallyDrop;
 
 /// A JavaScript Runtime.
 ///
@@ -136,13 +133,8 @@ impl Runtime {
                     .expect("registering TextEncoding APIs to succeed");
             }
 
-            if cfg.redirect_stdout_to_stderr {
-                console::register(ctx.clone(), stderr(), stderr())
-                    .expect("registering console to succeed");
-            } else {
-                console::register(ctx.clone(), stdout(), stderr())
-                    .expect("registering console to succeed");
-            }
+            console::register(ctx.clone(), cfg.log_stream, cfg.err_stream)
+                .expect("registering console to succeed");
 
             if javy_intrinsics.contains(JavyIntrinsics::STREAM_IO) {
                 stream_io::register(ctx.clone())


### PR DESCRIPTION
## Description of the change

Adds `log_stream` and `err_stream` methods to `Config` to allow setting arbitrary streams for `console.log` and `console.error`.

`redirect_stdout_to_stderr` continues to exist but it's setter implementation has been updated to set `log_stream` appropriate instead to avoid making this a breaking API change.

## Why am I making this change?

I have a use case where I want to send `console.log` and `console.error` output to a stream that is not stdout or stderr.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
