### PR TITLE
Bump javy-plugin-api version and CHANGELOG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "3.1.1-alpha.1"
+version = "3.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "javy",

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `javy` dependency updated to 4.1.0 which adds `log_stream` and `err_stream`
+  methods to `Config`.
+
 ## [3.1.0] - 2025-04-17
 
 ### Added

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "3.1.1-alpha.1"
+version = "3.2.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Updates the `javy-plugin-api` version and CHANGELOG to account for changes in #967 since `javy-plugin-api` re-exports the `javy` crate.

## Why am I making this change?

I forgot to bump these in #967.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
