### PR TITLE
v4.1.0 for javy and v3.2.0 for javy-plugin-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "4.1.0-alpha.1"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "3.2.0-alpha.1"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "javy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ wasmtime = "31"
 wasmtime-wasi = "31"
 wasm-opt = "0.116.1"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "4.1.0-alpha.1" }
+javy = { path = "crates/javy", version = "4.1.0" }
 tempfile = "3.20.0"
 uuid = { version = "1.17", features = ["v4"] }
 serde = { version = "1.0", default-features = false }

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [4.1.0] - 2025-07-21
+## [4.1.0] - 2025-07-24
 
 ### Added
 

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.1.0] - 2025-07-21
+
 ### Added
 
 - `Config` now supports setting a `log_stream` and `err_stream` to configure

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "4.1.0-alpha.1"
+version = "4.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [3.2.0] - 2025-07-21
+## [3.2.0] - 2025-07-24
 
 ### Added
 

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.2.0] - 2025-07-21
+
 ### Added
 
 - `javy` dependency updated to 4.1.0 which adds `log_stream` and `err_stream`

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "3.2.0-alpha.1"
+version = "3.2.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

- v4.1.0 for `javy`
- v3.2.0 for `javy-plugin-api`

## Why am I making this change?

I want to publish crates with the new APIs I've added.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
