### PR TITLE
Centralize walrus version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tempfile = "3.20.0"
 uuid = { version = "1.17", features = ["v4"] }
 serde = { version = "1.0", default-features = false }
 serde_json = "1.0"
+walrus = "0.23.3"
 
 [profile.release]
 lto = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
-walrus = "0.23.3"
+walrus = { workspace = true }
 tempfile = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true, default-features = false }

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = { workspace = true }
 brotli = "8.0.1"
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
-walrus = "0.23.3"
+walrus = { workspace = true }
 swc_core = { version = "16.10.0", features = [
   "common_sourcemap",
   "ecma_ast",


### PR DESCRIPTION
## Description of the change

Simple change to move `walrus` to a workspace dependency. Shouldn't be any functional impacts.

## Why am I making this change?

Noticed this wasn't done earlier when I was updating #958. We'll be introducing another use of Walrus if we go forward so may as well centralize now.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
