### PR TITLE
Refactor how we determine whether to use a plugin arg in tests

### DIFF
--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -57,6 +57,13 @@ impl Plugin {
                 .join("plugin_wizened.wasm"),
         }
     }
+
+    pub fn needs_plugin_arg(&self) -> bool {
+        match self {
+            Self::V2 | Self::Default => false,
+            Self::User | Self::DefaultAsUser => true,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -588,7 +595,7 @@ impl Runner {
             args.push(format!("event-loop={}", if enabled { "y" } else { "n" }));
         }
 
-        if matches!(plugin, Plugin::User | Plugin::DefaultAsUser) {
+        if plugin.needs_plugin_arg() {
             args.push("-C".to_string());
             args.push(format!("plugin={}", plugin.path().to_str().unwrap()));
         }


### PR DESCRIPTION
## Description of the change

Refactor how the test runner determines whether it's necessary to emit an argument to use a plugin.

## Why am I making this change?

I'm trying to cut down on the scope of the RFC PR.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
