### PR TITLE
Refactor to remove bytecode indirection

### DIFF
--- a/crates/codegen/src/js.rs
+++ b/crates/codegen/src/js.rs
@@ -24,8 +24,6 @@ use swc_core::{
     },
 };
 
-use crate::plugin::Plugin;
-
 /// JS source code.
 #[derive(Clone, Debug)]
 pub struct JS {
@@ -52,11 +50,6 @@ impl JS {
     /// Get source code as bytes.
     pub fn as_bytes(&self) -> &[u8] {
         self.source_code.as_bytes()
-    }
-
-    /// Compiles a JavaScript source to bytecode using a QuickJS plugin.
-    pub(crate) fn compile(&self, plugin: &Plugin) -> Result<Vec<u8>> {
-        plugin.compile_source(self.source_code.as_bytes())
     }
 
     /// Get Brotli compressed JS source code as bytes.

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -368,7 +368,7 @@ impl Generator {
         js: &js::JS,
         imports: &Identifiers,
     ) -> Result<BytecodeMetadata> {
-        let bytecode = js.compile(&self.plugin)?;
+        let bytecode = bytecode::compile_source(self.plugin.as_bytes(), js.as_bytes())?;
         let bytecode_len: i32 = bytecode.len().try_into()?;
         let bytecode_data = module.data.add(DataKind::Passive, bytecode);
 

--- a/crates/codegen/src/plugin.rs
+++ b/crates/codegen/src/plugin.rs
@@ -1,8 +1,6 @@
 use anyhow::{anyhow, Result};
 use std::{borrow::Cow, fs, path::Path, str};
 
-use super::bytecode;
-
 /// The kind of a plugin.
 // This is an internal detail of this module.
 #[derive(Debug, Default, PartialEq, Copy, Clone)]
@@ -61,10 +59,5 @@ impl Plugin {
     /// Returns the [`Plugin`] as bytes
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes
-    }
-
-    /// Generate valid QuickJS bytecode from Javascript source code.
-    pub(crate) fn compile_source(&self, js_source_code: &[u8]) -> Result<Vec<u8>> {
-        bytecode::compile_source(self.as_bytes(), js_source_code)
     }
 }


### PR DESCRIPTION
## Description of the change

Refactor to remove some indirection around how we get bytecode into the generator.

## Why am I making this change?

As part of the PR implementing the RFC, I'm going to need to pass a `PluginKind` into the bytecode generation logic which kind of breaks the existing abstractions so I figure we may as well get rid of the indirection involved since it's not really adding any value.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
