### PR TITLE
Update docs on JS API support

### DIFF
--- a/docs/docs-using-js-api-support.md
+++ b/docs/docs-using-js-api-support.md
@@ -26,7 +26,3 @@ functionality:
 
 * `IO`: provides `readSync` and `writeSync`, analogous to [Node's `fs`
   API](https://nodejs.org/api/fs.html).
-
-* `JSON`: provides `fromStdin()` and `toStdout()`. Which are helpers to read or
-  write from and to a file descriptor when working with `JSON`.
-


### PR DESCRIPTION
These seem to no longer be supported:

https://github.com/bytecodealliance/javy/pull/872

Would it make sense to update docs to reflect? (feel free to close PR if you disagree)