### PR TITLE
Fix compression bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,6 +1716,7 @@ name = "javy-cli"
 version = "5.0.4"
 dependencies = [
  "anyhow",
+ "brotli",
  "clap",
  "criterion",
  "javy-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 
 [workspace.dependencies]
+brotli = "8.0.1"
 clap = { version = "4.5.42", features = ["derive"] }
 wizer = "9.0.0"
 wasmtime = "31"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,6 +23,7 @@ javy-codegen = { path = "../codegen/", features = ["plugin_internal"] }
 javy-plugin-processing = { path = "../plugin-processing" }
 
 [dev-dependencies]
+brotli = { workspace = true }
 criterion = "0.7"
 num-format = "0.4.4"
 wasmparser = "0.236.0"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -90,7 +90,7 @@ fn main() -> Result<()> {
             // Configure the generator with the provided options.
             generator
                 .wit_opts(codegen_opts.wit)
-                .source_compression(!codegen_opts.source_compression)
+                .source_compression(codegen_opts.source_compression)
                 .js_runtime_config(js_opts.to_json()?);
             set_producer_version(&mut generator);
 

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -15,7 +15,7 @@ plugin_internal = []
 [dependencies]
 wizer = { workspace = true }
 anyhow = { workspace = true }
-brotli = "8.0.1"
+brotli = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 walrus = { workspace = true }


### PR DESCRIPTION
## Description of the change

I've inverted how the source compression codegen argument is passed to the code generator and added integration tests around the source code compression for compile and build commands.

## Why am I making this change?

Addresses a bug raised in #982.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
