### PR TITLE
Remove wasmtime-wasi when fetching supported config

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,7 +13,6 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 wasmtime = { workspace = true }
-wasmtime-wasi = { workspace = true }
 walrus = { workspace = true }
 tempfile = { workspace = true }
 clap = { workspace = true }
@@ -29,6 +28,7 @@ num-format = "0.4.4"
 wasmparser = { workspace = true }
 javy-runner = { path = "../runner/" }
 javy-test-macros = { path = "../test-macros/" }
+wasmtime-wasi = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
## Description of the change

Stops linking WASI preview 1 when fetching JS config.

## Why am I making this change?

We don't need it for this function export.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
