### PR TITLE
Move test runner config to Cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,7 @@
 # https://doc.rust-lang.org/cargo/reference/config.html
 [target.wasm32-wasip1]
 rustflags = ["-C", "target-feature=+simd128"]
+runner = "wasmtime --dir=."
 
 # We want to ensure that all the MSVC dependencies are statically resolved and
 # included in the final CLI binary.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,6 @@ jobs:
         run: cargo build -p javy-plugin --release --target=wasm32-wasip1
 
       - name: Test
-        env:
-          CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime --dir=.
         run: |
           cargo hack test --workspace \
           --exclude=javy-cli \

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,13 @@ docs:
 	cargo doc --package=javy-plugin --open --target=wasm32-wasip1
 
 test-javy:
-	CARGO_TARGET_WASM32_WASIP1_RUNNER="wasmtime --dir=." cargo hack test --package=javy --target=wasm32-wasip1 --each-feature -- --nocapture
+	cargo hack test --package=javy --target=wasm32-wasip1 --each-feature -- --nocapture
 
 test-plugin-api:
-	CARGO_TARGET_WASM32_WASIP1_RUNNER="wasmtime --dir=." cargo hack test --package=javy-plugin-api --target=wasm32-wasip1 --each-feature -- --nocapture
+	cargo hack test --package=javy-plugin-api --target=wasm32-wasip1 --each-feature -- --nocapture
 
 test-plugin:
-	CARGO_TARGET_WASM32_WASIP1_RUNNER="wasmtime" cargo test --package=javy-plugin --target=wasm32-wasip1 -- --nocapture
+	cargo test --package=javy-plugin --target=wasm32-wasip1 -- --nocapture
 
 test-plugin-processing:
 	cargo test --package=javy-plugin-processing -- --nocapture


### PR DESCRIPTION
## Description of the change

Moves the Wasm test runner configuration from environment variables to the workspace Cargo config.

## Why am I making this change?

Deduplicates some of the configuration.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
