### PR TITLE
Remove CLI_FEATURES from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test-codegen: cli
 # Note: to make this faster, the engine should be optimized beforehand (wasm-strip + wasm-opt).
 # Disabling LTO substantially improves compile time
 test-cli: plugin build-test-plugin
-	CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-cli --release --features=$(CLI_FEATURES) -- --nocapture
+	CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-cli --release -- --nocapture
 
 test-runner:
 	cargo test --package=javy-runner -- --nocapture

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ cli: plugin
 	CARGO_PROFILE_RELEASE_LTO=off cargo build --package=javy-cli --release
 
 plugin:
-	cargo build --package=javy-plugin --release --target=wasm32-wasip1 --features=$(PLUGIN_FEATURES)
+	cargo build --package=javy-plugin --release --target=wasm32-wasip1
 	cargo run --package=javy-plugin-processing target/wasm32-wasip1/release/plugin.wasm target/wasm32-wasip1/release/plugin_wizened.wasm
 
 build-test-plugin: cli


### PR DESCRIPTION
## Description of the change

Removes an unused flag for the CLI in the Makefile.

## Why am I making this change?

I noticed this while looking at something else and it seems like an easy change.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
