### PR TITLE
Update Wasmtime version for npm tests

### DIFF
--- a/.github/workflows/ci-npm-javy.yml
+++ b/.github/workflows/ci-npm-javy.yml
@@ -13,11 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install wasmtime-cli
-        env:
-          WASMTIME_VERSION: 6.0.1
+      - name: Read wasmtime version
+        id: wasmtime_version
+        shell: bash
         run: |
-          wget -nv 'https://github.com/bytecodealliance/wasmtime/releases/download/v${{ env.WASMTIME_VERSION }}/wasmtime-v${{ env.WASMTIME_VERSION }}-x86_64-linux.tar.xz' -O /tmp/wasmtime.tar.xz
+          VERSION=$(cargo metadata --format-version=1 --locked | jq '.packages[] | select(.name == "wasmtime") | .version' -r)
+          echo "wasmtime_version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install wasmtime-cli
+        shell: bash
+        run: |
+          wget -nv 'https://github.com/bytecodealliance/wasmtime/releases/download/v${{ steps.wasmtime_version.outputs.wasmtime_version }}/wasmtime-v${{ steps.wasmtime_version.outputs.wasmtime_version }}-x86_64-linux.tar.xz' -O /tmp/wasmtime.tar.xz
           mkdir /tmp/wasmtime
           tar xvf /tmp/wasmtime.tar.xz --strip-components=1 -C /tmp/wasmtime
           echo "/tmp/wasmtime" >> $GITHUB_PATH


### PR DESCRIPTION
## Description of the change

Switches NPM tests to use Wasmtime version in Cargo.toml file.

## Why am I making this change?

I noticed we were using a very old version of Wasmtime when looking at this file for a different reason and figured why not update it.

## Checklist

- [xj] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
