### PR TITLE
Simplify non-release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,33 +87,33 @@ jobs:
       - name: Build test-plugin
         run: |
           cargo build --package=javy-test-plugin --release --target=wasm32-wasip1
-          CARGO_PROFILE_RELEASE_LTO=off cargo build --package=javy-cli --release
-          target/release/javy init-plugin target/wasm32-wasip1/release/test_plugin.wasm -o crates/runner/test_plugin.wasm
+          cargo build --package=javy-cli
+          target/debug/javy init-plugin target/wasm32-wasip1/release/test_plugin.wasm -o crates/runner/test_plugin.wasm
 
       - name: Test CLI
-        run: CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-cli --release -- --nocapture
+        run: cargo test --package=javy-cli -- --nocapture
 
       - name: Test CodeGen
         run: |
-          target/release/javy emit-plugin -o crates/codegen/default_plugin.wasm
-          CARGO_PROFILE_RELEASE_LTO=off cargo hack test --package=javy-codegen --release --each-feature -- --nocapture
+          target/debug/javy emit-plugin -o crates/codegen/default_plugin.wasm
+          cargo hack test --package=javy-codegen --each-feature -- --nocapture
 
       - name: Test plugin processing
         run: |
           cargo test --package=javy-plugin-processing -- --nocapture
 
       - name: Check benchmarks
-        run: CARGO_PROFILE_RELEASE_LTO=off cargo check --package=javy-cli --release --benches
+        run: cargo check --package=javy-cli --benches
 
       - name: Lint CLI
         run: |
           cargo fmt -- --check
-          CARGO_PROFILE_RELEASE_LTO=off cargo clippy --package=javy-cli --release --all-targets -- -D warnings
+          cargo clippy --package=javy-cli --all-targets -- -D warnings
 
       - name: Lint CodeGen
         run: |
           cargo fmt -- --check
-          CARGO_PROFILE_RELEASE_LTO=off cargo hack clippy --package=javy-codegen --release --all-targets --each-feature -- -D warnings
+          cargo hack clippy --package=javy-codegen --all-targets --each-feature -- -D warnings
 
       - name: Lint plugin processing
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,12 @@ serde_json = "1.0"
 walrus = "0.23.3"
 wasmparser = "0.236.0"
 
+[profile.dev]
+# `opt-level` 1 seems necessary for tests to run in a reasonable amount of time.
+opt-level = 1
+# Explicitly disabling LTO seems to substantially speed up the build.
+lto = "off"
+
 [profile.release]
 lto = true
 opt-level = 3

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,10 @@ bench: cli
 	cargo bench --package=javy-cli
 
 check-bench:
-	CARGO_PROFILE_RELEASE_LTO=off cargo check --package=javy-cli --release --benches
+	cargo check --package=javy-cli --benches
 
-# Disabling LTO substantially improves compile time
 cli: plugin
-	CARGO_PROFILE_RELEASE_LTO=off cargo build --package=javy-cli --release
+	cargo build --package=javy-cli
 
 plugin:
 	cargo build --package=javy-plugin --release --target=wasm32-wasip1 --features=$(PLUGIN_FEATURES)
@@ -20,7 +19,7 @@ plugin:
 
 build-test-plugin: cli
 	cargo build --package=javy-test-plugin --release --target=wasm32-wasip1
-	target/release/javy init-plugin target/wasm32-wasip1/release/test_plugin.wasm -o crates/runner/test_plugin.wasm
+	target/debug/javy init-plugin target/wasm32-wasip1/release/test_plugin.wasm -o crates/runner/test_plugin.wasm
 
 docs:
 	cargo doc --package=javy-cli --open
@@ -39,14 +38,11 @@ test-plugin-processing:
 	cargo test --package=javy-plugin-processing -- --nocapture
 
 test-codegen: cli
-	target/release/javy emit-plugin -o crates/codegen/default_plugin.wasm
-	CARGO_PROFILE_RELEASE_LTO=off cargo hack test --package=javy-codegen --release --each-feature -- --nocapture
+	target/debug/javy emit-plugin -o crates/codegen/default_plugin.wasm
+	cargo hack test --package=javy-codegen --each-feature -- --nocapture
 
-# Test in release mode to skip some debug assertions
-# Note: to make this faster, the engine should be optimized beforehand (wasm-strip + wasm-opt).
-# Disabling LTO substantially improves compile time
 test-cli: plugin build-test-plugin
-	CARGO_PROFILE_RELEASE_LTO=off cargo test --package=javy-cli --release --features=$(CLI_FEATURES) -- --nocapture
+	cargo test --package=javy-cli --features=$(CLI_FEATURES) -- --nocapture
 
 test-runner:
 	cargo test --package=javy-runner -- --nocapture
@@ -75,12 +71,10 @@ fmt-plugin-processing:
 	cargo fmt --package=javy-plugin-processing -- --check
 	cargo clippy --package=javy-plugin-processing --all-targets -- -D warnings
 
-# Use `--release` on CLI clippy to align with `test-cli`.
-# This reduces the size of the target directory which improves CI stability.
 fmt-cli:
 	cargo fmt --package=javy-cli -- --check
-	CARGO_PROFILE_RELEASE_LTO=off cargo clippy --package=javy-cli --release --all-targets -- -D warnings
+	cargo clippy --package=javy-cli --all-targets -- -D warnings
 
 fmt-codegen:
 	cargo fmt --package=javy-codegen -- --check
-	cargo clippy --package=javy-codegen --release --all-targets -- -D warnings
+	cargo clippy --package=javy-codegen --all-targets -- -D warnings

--- a/crates/cli/benches/benchmark.rs
+++ b/crates/cli/benches/benchmark.rs
@@ -202,7 +202,7 @@ fn execute_javy(index_js: &Path, wasm: &Path, linking: &Linking) -> Result<()> {
         args.push("-C");
         args.push("plugin=../../target/wasm32-wasip1/release/plugin_wizened.wasm");
     }
-    let status_code = Command::new(Path::new("../../target/release/javy").to_str().unwrap())
+    let status_code = Command::new(Path::new("../../target/debug/javy").to_str().unwrap())
         .args(args)
         .status()?;
     if !status_code.success() {

--- a/docs/docs-contributing-building.md
+++ b/docs/docs-contributing-building.md
@@ -13,7 +13,7 @@ In the repository root, run:
 
 ```
 $ cargo build -p javy-plugin --target=wasm32-wasip1 -r
-$ cargo build -p javy-cli -r
+$ cargo build -p javy-cli
 ```
 
 Alternatively if you want to install the `javy` binary globally, at the
@@ -22,7 +22,3 @@ repository root, run:
 $ cargo build -p javy-plugin --target=wasm32-wasip1 -r
 $ cargo install --path crates/cli
 ```
-
-If you are going to recompile frequently, you may want to prepend
-`CARGO_PROFILE_RELEASE_LTO=off` to cargo build for the CLI to speed up the
-build.


### PR DESCRIPTION
## Description of the change

Replaces the use of setting `CARGO_PROFILE_RELEASE_LTO=off` in a few places with the use of the dev profile configured so the tests pass. Specifically setting `opt-level` to `1` instead of the default `0` was necessary.

## Why am I making this change?

While I was writing #985, I wondered if there was a way to also remove the `CARGO_PROFILE_RELEASE_LTO` we have all over the place.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
