### PR TITLE
Turn on all features when using Clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           --exclude=javy-plugin-processing \
           --exclude=javy-runner \
           --exclude=javy-fuzz \
-          --target=wasm32-wasip1 --all-targets -- -D warnings
+          --target=wasm32-wasip1 --all-targets --all-features -- -D warnings
 
       # We need to specify a different job for linting `javy-runner` given that
       # it depends on Wasmtime and Cranelift cannot be compiled to `wasm32-wasip1`
@@ -106,17 +106,17 @@ jobs:
       - name: Lint CLI
         run: |
           cargo fmt -- --check
-          CARGO_PROFILE_RELEASE_LTO=off cargo clippy --package=javy-cli --release --all-targets -- -D warnings
+          CARGO_PROFILE_RELEASE_LTO=off cargo clippy --package=javy-cli --release --all-targets --all-features -- -D warnings
 
       - name: Lint CodeGen
         run: |
           cargo fmt -- --check
-          CARGO_PROFILE_RELEASE_LTO=off cargo hack clippy --package=javy-codegen --release --all-targets --each-feature -- -D warnings
+          CARGO_PROFILE_RELEASE_LTO=off cargo clippy --package=javy-codegen --release --all-targets --all-features -- -D warnings
 
       - name: Lint plugin processing
         run: |
           cargo fmt --package=javy-plugin-processing -- --check
-          cargo clippy --package=javy-plugin-processing --all-targets -- -D warnings
+          cargo clippy --package=javy-plugin-processing --all-targets --all-features -- -D warnings
 
       - name: WPT
         run: |

--- a/Makefile
+++ b/Makefile
@@ -61,19 +61,19 @@ fmt: fmt-javy fmt-plugin-api fmt-plugin fmt-plugin-processing fmt-cli fmt-codege
 
 fmt-javy:
 	cargo fmt --package=javy -- --check
-	cargo clippy --package=javy --target=wasm32-wasip1 --all-targets -- -D warnings
+	cargo clippy --package=javy --target=wasm32-wasip1 --all-targets --all-features -- -D warnings
 
 fmt-plugin-api:
 	cargo fmt --package=javy-plugin-api -- --check
-	cargo clippy --package=javy-plugin-api --target=wasm32-wasip1 --all-targets -- -D warnings
+	cargo clippy --package=javy-plugin-api --target=wasm32-wasip1 --all-targets --all-features -- -D warnings
 
 fmt-plugin:
 	cargo fmt --package=javy-plugin -- --check
-	cargo clippy --package=javy-plugin --target=wasm32-wasip1 --all-targets -- -D warnings
+	cargo clippy --package=javy-plugin --target=wasm32-wasip1 --all-targets --all-features -- -D warnings
 
 fmt-plugin-processing:
 	cargo fmt --package=javy-plugin-processing -- --check
-	cargo clippy --package=javy-plugin-processing --all-targets -- -D warnings
+	cargo clippy --package=javy-plugin-processing --all-targets --all-features -- -D warnings
 
 # Use `--release` on CLI clippy to align with `test-cli`.
 # This reduces the size of the target directory which improves CI stability.
@@ -83,4 +83,4 @@ fmt-cli:
 
 fmt-codegen:
 	cargo fmt --package=javy-codegen -- --check
-	cargo clippy --package=javy-codegen --release --all-targets -- -D warnings
+	cargo clippy --package=javy-codegen --release --all-targets --all-features -- -D warnings


### PR DESCRIPTION
## Description of the change

When using Clippy, enable all crate features.

## Why am I making this change?

I was seeing a clippy failure in CI that I didn't see locally due to Clippy not enabling all features locally.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
