### PR TITLE
Delete no longer necessary import tests

### DIFF
--- a/crates/cli/tests/dynamic_linking_test.rs
+++ b/crates/cli/tests/dynamic_linking_test.rs
@@ -56,28 +56,6 @@ fn test_errors_in_exported_functions_are_correctly_reported(builder: &mut Builde
     Ok(())
 }
 
-#[javy_cli_test(
-    dyn = true,
-    root = "tests/dynamic-linking-scripts",
-    commands(not(Compile))
-)]
-// If you need to change this test, then you've likely made a breaking change.
-pub fn check_for_new_imports(builder: &mut Builder) -> Result<()> {
-    let runner = builder.input("console.js").build()?;
-    runner.ensure_expected_imports(false)
-}
-
-#[javy_cli_test(
-    dyn = true,
-    root = "tests/dynamic-linking-scripts",
-    commands(not(Build))
-)]
-// If you need to change this test, then you've likely made a breaking change.
-pub fn check_for_new_imports_for_compile(builder: &mut Builder) -> Result<()> {
-    let runner = builder.input("console.js").build()?;
-    runner.ensure_expected_imports(true)
-}
-
 #[javy_cli_test(dyn = true, root = "tests/dynamic-linking-scripts")]
 pub fn test_dynamic_linking_with_arrow_fn(builder: &mut Builder) -> Result<()> {
     let mut runner = builder

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 use std::fs;
@@ -93,7 +93,6 @@ pub struct Builder {
     /// Whether to use the `compile` or `build` command.
     command: JavyCommand,
     /// The javy plugin.
-    /// Used for import validation purposes only.
     plugin: Plugin,
     /// Whether to compress the source code.
     compress_source_code: Option<bool>,
@@ -226,19 +225,10 @@ impl Builder {
                         wit,
                         world,
                         preload,
-                        plugin,
                         compress_source_code,
                     )
                 } else {
-                    Runner::compile_static(
-                        bin_path,
-                        root,
-                        input,
-                        wit,
-                        world,
-                        plugin,
-                        compress_source_code,
-                    )
+                    Runner::compile_static(bin_path, root, input, wit, world, compress_source_code)
                 }
             }
             JavyCommand::Build => Runner::build(
@@ -264,7 +254,6 @@ pub struct Runner {
     linker: Linker<StoreContext>,
     initial_fuel: u64,
     preload: Option<(String, Vec<u8>)>,
-    plugin: Plugin,
 }
 
 #[derive(Debug)]
@@ -366,7 +355,6 @@ impl Runner {
             linker,
             initial_fuel: u64::MAX,
             preload,
-            plugin: Plugin::Default,
         })
     }
 
@@ -376,7 +364,6 @@ impl Runner {
         source: impl AsRef<Path>,
         wit: Option<PathBuf>,
         world: Option<String>,
-        plugin: Plugin,
         compress_source_code: Option<bool>,
     ) -> Result<Self> {
         // This directory is unique and will automatically get deleted
@@ -406,7 +393,6 @@ impl Runner {
             linker,
             initial_fuel: u64::MAX,
             preload: None,
-            plugin,
         })
     }
 
@@ -418,7 +404,6 @@ impl Runner {
         wit: Option<PathBuf>,
         world: Option<String>,
         preload: (String, PathBuf),
-        plugin: Plugin,
         compress_source_code: Option<bool>,
     ) -> Result<Self> {
         let tempdir = tempfile::tempdir()?;
@@ -448,7 +433,6 @@ impl Runner {
             linker,
             initial_fuel: u64::MAX,
             preload: Some((preload.0, preload_module)),
-            plugin,
         })
     }
 
@@ -459,70 +443,7 @@ impl Runner {
             linker: Self::setup_linker(&engine)?,
             initial_fuel: u64::MAX,
             preload: None,
-            plugin: Plugin::Default,
         })
-    }
-
-    pub fn ensure_expected_imports(&self, expect_eval_bytecode: bool) -> Result<()> {
-        let module = Module::from_binary(self.linker.engine(), &self.wasm)?;
-        let instance_name = self.plugin.namespace();
-
-        let imports = module
-            .imports()
-            .filter(|i| i.module() == instance_name)
-            .collect::<Vec<_>>();
-        let expected_import_count = if expect_eval_bytecode { 4 } else { 3 };
-        if imports.len() != expected_import_count {
-            bail!("Dynamically linked modules should have exactly {expected_import_count} imports for {instance_name}");
-        }
-
-        let realloc = imports
-            .iter()
-            .find(|i| i.name() == "canonical_abi_realloc")
-            .ok_or_else(|| anyhow!("Should have canonical_abi_realloc import"))?;
-        let ty = realloc.ty();
-        let f = ty.unwrap_func();
-        if !f.params().all(|p| p.is_i32()) || f.params().len() != 4 {
-            bail!("canonical_abi_realloc should accept 4 i32s as parameters");
-        }
-        if !f.results().all(|p| p.is_i32()) || f.results().len() != 1 {
-            bail!("canonical_abi_realloc should return 1 i32 as a result");
-        }
-
-        imports
-            .iter()
-            .find(|i| i.name() == "memory" && i.ty().memory().is_some())
-            .ok_or_else(|| anyhow!("Should have memory import named memory"))?;
-
-        if expect_eval_bytecode {
-            let eval_bytecode = imports
-                .iter()
-                .find(|i| i.name() == "eval_bytecode")
-                .ok_or_else(|| anyhow!("Should have eval_bytecode import"))?;
-            let ty = eval_bytecode.ty();
-            let f = ty.unwrap_func();
-            if !f.params().all(|p| p.is_i32()) || f.params().len() != 2 {
-                bail!("eval_bytecode should accept 2 i32s as parameters");
-            }
-            if f.results().len() != 0 {
-                bail!("eval_bytecode should return no results");
-            }
-        }
-
-        let invoke = imports
-            .iter()
-            .find(|i| i.name() == "invoke")
-            .ok_or_else(|| anyhow!("Should have invoke import"))?;
-        let ty = invoke.ty();
-        let f = ty.unwrap_func();
-        if !f.params().all(|p| p.is_i32()) || f.params().len() != 4 {
-            bail!("invoke should accept 4 i32s as parameters");
-        }
-        if f.results().len() != 0 {
-            bail!("invoke should return no results");
-        }
-
-        Ok(())
     }
 
     pub fn assert_producers(&self) -> Result<()> {


### PR DESCRIPTION
## Description of the change

Deletes the `ensure_imports` tests.

## Why am I making this change?

The snapshot tests added in #989 effectively do the same checks. 

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
