### PR TITLE
Delete no longer used PluginKind::Default

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -49,9 +49,7 @@ fn main() -> Result<()> {
                     .linking(LinkingKind::Dynamic)
                     .linking_v2_plugin(true);
             } else {
-                generator
-                    .linking(LinkingKind::Static)
-                    .linking_default_plugin(true);
+                generator.linking(LinkingKind::Static);
             }
 
             generator
@@ -81,11 +79,6 @@ fn main() -> Result<()> {
             let js_opts = JsConfig::from_group_values(&cli_plugin, opts.js.clone())?;
 
             let mut generator = Generator::new(cli_plugin.into_plugin());
-
-            // Always link to the default plugin if no plugin is provided.
-            if codegen_opts.plugin.is_none() {
-                generator.linking_default_plugin(true);
-            }
 
             // Configure the generator with the provided options.
             generator

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -201,18 +201,6 @@ impl Generator {
     }
 
     #[cfg(feature = "plugin_internal")]
-    /// Set true if linking with a default plugin module.
-    pub fn linking_default_plugin(&mut self, value: bool) -> &mut Self {
-        self.plugin_kind = if value {
-            PluginKind::Default
-        } else {
-            PluginKind::User
-        };
-
-        self
-    }
-
-    #[cfg(feature = "plugin_internal")]
     /// Set true if linking with a V2 plugin module.
     pub fn linking_v2_plugin(&mut self, value: bool) -> &mut Self {
         self.plugin_kind = if value {

--- a/crates/codegen/src/plugin.rs
+++ b/crates/codegen/src/plugin.rs
@@ -10,7 +10,6 @@ use wasmparser::Parser;
 pub(crate) enum PluginKind {
     #[default]
     User,
-    Default,
     V2,
 }
 
@@ -19,7 +18,7 @@ impl PluginKind {
     pub(crate) fn import_namespace(self, plugin: &Plugin) -> Result<String> {
         match self {
             PluginKind::V2 => Ok("javy_quickjs_provider_v2".to_string()),
-            PluginKind::User | PluginKind::Default => {
+            PluginKind::User => {
                 // The import namespace to use for this plugin.
                 let module = walrus::Module::from_buffer(plugin.as_bytes())?;
                 let import_namespace: std::borrow::Cow<'_, [u8]> = module


### PR DESCRIPTION
## Description of the change

Deletes references to `PluginKind::Default` in the `codegen` crate.

## Why am I making this change?

It's no longer used for anything in the codegen crate. It used to be used to determine whether to call `eval_bytecode` instead of `invoke` for top-scope evaluation since we used to generate dynamically linked plugins using the same import namespace as a version of the plugin where `invoke` didn't support null function names.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
