### PR TITLE
Add codegen option for including source

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -83,6 +83,7 @@ fn main() -> Result<()> {
             // Configure the generator with the provided options.
             generator
                 .wit_opts(codegen_opts.wit)
+                .source(codegen_opts.source)
                 .source_compression(codegen_opts.source_compression)
                 .js_runtime_config(js_opts.to_json()?);
             set_producer_version(&mut generator);

--- a/crates/codegen/CHANGELOG.md
+++ b/crates/codegen/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `Generator` now has a `producer_version` method so the version in the
   producers custom section can be set.
+- `Generator` now has a `source` method so that the javy source custom
+  section can be omitted.
 
 ### Changed
 

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -159,7 +159,9 @@ pub struct Generator {
     pub(crate) plugin: Plugin,
     /// What kind of linking to use when generating a module.
     pub(crate) linking: LinkingKind,
-    /// Whether to embed the compressed JS source in the generated module.
+    /// Whether to embed the JS source in the generated module.
+    pub(crate) source: bool,
+    /// Whether to compress the JS source in the generated module.
     pub(crate) source_compression: bool,
     /// WIT options for code generation.
     pub(crate) wit_opts: WitOptions,
@@ -185,6 +187,12 @@ impl Generator {
     /// Set the kind of linking (default: [`LinkingKind::Static`])
     pub fn linking(&mut self, linking: LinkingKind) -> &mut Self {
         self.linking = linking;
+        self
+    }
+
+    /// Set if JS source should be included in the generated Wasm (default: true).
+    pub fn source(&mut self, source: bool) -> &mut Self {
+        self.source = source;
         self
     }
 
@@ -512,10 +520,12 @@ impl Generator {
                 .as_deref()
                 .unwrap_or(env!("CARGO_PKG_VERSION")),
         );
-        if !self.source_compression {
-            module.customs.add(SourceCodeSection::uncompressed(js)?);
-        } else {
-            module.customs.add(SourceCodeSection::compressed(js)?);
+        if self.source {
+            if !self.source_compression {
+                module.customs.add(SourceCodeSection::uncompressed(js)?);
+            } else {
+                module.customs.add(SourceCodeSection::compressed(js)?);
+            }
         }
 
         let wasm = self.postprocess(&mut module)?;


### PR DESCRIPTION
## Description of the change

Adds a codegen option that allows for opting out of the `javy_source` custom section. If `-C source=n` is specified to the CLI, `source-compression` has no effect.

Fixes #982 

## Why am I making this change?

Allows for smaller Wasm modules output by Javy in case the source code is not necesary. Through local testing I was able to shrink my Wasm modules by about one third.

## Checklist

- [X] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [X] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [X] I've updated documentation including crate documentation if necessary.
