### PR TITLE
Update some local dev documentation

### DIFF
--- a/docs/docs-contributing-developing.md
+++ b/docs/docs-contributing-developing.md
@@ -2,3 +2,4 @@
 
 - `wasmtime-cli`, can be installed via `cargo install wasmtime-cli`
 - `cargo-hack`, can be installed via `cargo +stable install cargo-hack --locked`
+- `cargo-vet`, can be installed via `cargo install --version 0.9.0 cargo-vet --locked`

--- a/docs/docs-contributing-testing-locally.md
+++ b/docs/docs-contributing-testing-locally.md
@@ -13,7 +13,19 @@ git submodules update
 cargo +stable install cargo-hack --locked
 ```
 
-3. Run tests, eg:
+3. Run tests and linting, eg:
 ```
-make tests
+make fmt tests
+```
+
+4. If adding new dependencies, vet the dependencies
+
+```
+cargo vet
+```
+
+If this fails, follow on-screen instructions to trust any dependencies it suggests trusting. If `cargo vet` still fails after trusting those dependencies, then run:
+
+```
+cargo vet regenerate exemptions
 ```


### PR DESCRIPTION
## Description of the change

Updates some of our local dev documentation to include running lint checks and cargo vet.

## Why am I making this change?

I noticed we didn't mention anything about linting or cargo vet in our documentation.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
