### PR TITLE
Add integration tests for source code

### DIFF
--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -263,7 +263,7 @@ fn test_exported_default_fn(builder: &mut Builder) -> Result<()> {
 }
 
 #[javy_cli_test]
-fn test_source_code_compression_default(builder: &mut Builder) -> Result<()> {
+fn test_source_code_default(builder: &mut Builder) -> Result<()> {
     let runner = builder.build()?;
     let javy_source = runner
         .javy_source_custom_section()
@@ -298,6 +298,26 @@ fn test_source_code_compression_disabled(builder: &mut Builder) -> Result<()> {
     let mut javy_source = vec![];
     let res = decompressor.read_to_end(&mut javy_source);
     assert!(res.is_err());
+    Ok(())
+}
+
+#[javy_cli_test(commands(not(Compile)))]
+fn test_source_code_omitted(builder: &mut Builder) -> Result<()> {
+    let runner = builder.source_code(false).build()?;
+    assert!(
+        runner.javy_source_custom_section().is_none(),
+        "Should not have a source code section"
+    );
+    Ok(())
+}
+
+#[javy_cli_test(commands(not(Compile)))]
+fn test_source_code_not_omitted(builder: &mut Builder) -> Result<()> {
+    let runner = builder.source_code(true).build()?;
+    assert!(
+        runner.javy_source_custom_section().is_some(),
+        "Should have a source code section"
+    );
     Ok(())
 }
 

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -111,11 +111,11 @@ pub enum LinkingKind {
 #[derive(Debug, Clone, Default)]
 pub enum SourceEmbedding {
     #[default]
-    /// Embed the source code without compression
+    /// Embed the source code without compression.
     Uncompressed,
-    /// Embed the source code with compression
+    /// Embed the source code with compression.
     Compressed,
-    /// Don't embed the source code
+    /// Don't embed the source code.
     Omitted,
 }
 


### PR DESCRIPTION
## Description of the change

Adds integration tests around source code.

## Why am I making this change?

I want to make sure nothing gets broken around this in the future.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
