### PR TITLE
Make producers version in snapshots a constant

### DIFF
--- a/crates/codegen/tests/integration_test.rs
+++ b/crates/codegen/tests/integration_test.rs
@@ -45,6 +45,7 @@ fn test_snapshot_for_dynamically_linked_module() -> Result<()> {
         Some(sample_scripts.join("exported-functions.wit")),
         Some("exported-logs".into()),
     ))?)
+    .producer_version("snapshot".into())
     .generate(&js)?;
     let wat = wasmprinter::print_bytes(wasm)?;
     insta::assert_snapshot!("default_dynamic", wat);
@@ -67,6 +68,7 @@ fn test_snapshot_for_dynamically_linked_v2_module() -> Result<()> {
             Some(sample_scripts.join("exported-functions.wit")),
             Some("exported-logs".into()),
         ))?)
+        .producer_version("snapshot".into())
         .generate(&js)?;
     let wat = wasmprinter::print_bytes(wasm)?;
     insta::assert_snapshot!("v2_dynamic", wat);

--- a/crates/codegen/tests/snapshots/integration_test__default_dynamic.snap
+++ b/crates/codegen/tests/snapshots/integration_test__default_dynamic.snap
@@ -93,7 +93,7 @@ expression: wat
   (data (;2;) "log2")
   (@producers
     (language "JavaScript" "ES2020")
-    (processed-by "Javy" "2.0.0-alpha.1")
+    (processed-by "Javy" "snapshot")
   )
   (@custom "javy_source" (after data) "export function log() {\0a    console.log(\22Hello from function!\22);\0a}\0a\0aexport function log2() {\0a    console.log(\22Hello from function2!\22);\0a}\0a\0aconsole.log(\22Hello from top-level scope\22);\0a")
 )

--- a/crates/codegen/tests/snapshots/integration_test__v2_dynamic.snap
+++ b/crates/codegen/tests/snapshots/integration_test__v2_dynamic.snap
@@ -90,7 +90,7 @@ expression: wat
   (data (;2;) "log2")
   (@producers
     (language "JavaScript" "ES2020")
-    (processed-by "Javy" "2.0.0-alpha.1")
+    (processed-by "Javy" "snapshot")
   )
   (@custom "javy_source" (after data) "export function log() {\0a    console.log(\22Hello from function!\22);\0a}\0a\0aexport function log2() {\0a    console.log(\22Hello from function2!\22);\0a}\0a\0aconsole.log(\22Hello from top-level scope\22);\0a")
 )


### PR DESCRIPTION
## Description of the change

Makes the producers version in the snapshot tests a constant.

## Why am I making this change?

I realized while performing a version bump, that the snapshot tests would always fail whenever the codegen crate version changes and that seems like it's creating unnecessary toil.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
