### PR TITLE
Bump crate versions for publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "5.0.0-alpha.1"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "5.0.4"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1794,7 +1794,7 @@ dependencies = [
 
 [[package]]
 name = "javy-codegen"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "4.0.0-alpha.1"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "javy",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-processing"
-version = "5.0.4"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "5.0.4"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "javy-test-macros"
-version = "5.0.4"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.4"
+version = "6.0.0"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -27,7 +27,7 @@ wasmtime = "31"
 wasmtime-wasi = "31"
 wasm-opt = "0.116.1"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "5.0.0-alpha.1" }
+javy = { path = "crates/javy", version = "5.0.0" }
 tempfile = "3.20.0"
 uuid = { version = "1.17", features = ["v4"] }
 serde = { version = "1.0", default-features = false }

--- a/crates/codegen/CHANGELOG.md
+++ b/crates/codegen/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0] - 2025-08-28
+
 ### Added
 
 - `Generator` now has a `producer_version` method so the version in the

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-codegen"
-version = "2.0.0-alpha.1"
+version = "2.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.0.0] - 2025-08-28
+
 ### Removed
 
 - `export_alloc_fns` has been removed. This removes the implementation of

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "5.0.0-alpha.1"
+version = "5.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.0.0] - 2025-08-28
+
 ### Added
 
 - `javy_plugin` macro to generate a plugin that uses the new plugin API.

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "4.0.0-alpha.1"
+version = "4.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Bumps all the crate versions so we can publish them and release a new version of the CLI. I'll update the dates in the CHANGELOG to whatever day it is when I'm about to merge this.

## Why am I making this change?

I want to release these changes.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
