### PR TITLE
Re-add suffixes to crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "5.0.0"
+version = "5.0.1-alpha.1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1794,7 +1794,7 @@ dependencies = [
 
 [[package]]
 name = "javy-codegen"
-version = "2.0.0"
+version = "2.0.1-alpha.1"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 dependencies = [
  "anyhow",
  "javy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasmtime = "31"
 wasmtime-wasi = "31"
 wasm-opt = "0.116.1"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "5.0.0" }
+javy = { path = "crates/javy", version = "5.0.1-alpha.1" }
 tempfile = "3.20.0"
 uuid = { version = "1.17", features = ["v4"] }
 serde = { version = "1.0", default-features = false }

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-codegen"
-version = "2.0.0"
+version = "2.0.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "5.0.0"
+version = "5.0.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "4.0.0"
+version = "4.0.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Re-adds `-alpha.1` suffixes to crate versions.

## Why am I making this change?

To follow our [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates).

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
