### PR TITLE
Reduce target size by compiling plugin-processing to release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Lint plugin processing
         run: |
           cargo fmt --package=javy-plugin-processing -- --check
-          cargo clippy --package=javy-plugin-processing --all-targets --all-features -- -D warnings
+          cargo clippy --package=javy-plugin-processing --release --all-targets --all-features -- -D warnings
 
       - name: Test
         run: |
@@ -116,7 +116,7 @@ jobs:
 
       - name: Test plugin processing
         run: |
-          cargo test --package=javy-plugin-processing -- --nocapture
+          cargo test --package=javy-plugin-processing --release -- --nocapture
 
       - name: WPT
         run: |

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ cli: plugin
 
 plugin:
 	cargo build --package=javy-plugin --release --target=wasm32-wasip2
-	cargo run --package=javy-plugin-processing target/wasm32-wasip2/release/plugin.wasm target/wasm32-wasip2/release/plugin_wizened.wasm
+	cargo run --package=javy-plugin-processing --release target/wasm32-wasip2/release/plugin.wasm target/wasm32-wasip2/release/plugin_wizened.wasm
 
 build-test-plugin: cli
 	cargo build --package=javy-test-plugin --target=wasm32-wasip2 --release
-	cargo run --package=javy-plugin-processing -- target/wasm32-wasip2/release/test_plugin.wasm crates/runner/test_plugin.wasm
+	cargo run --package=javy-plugin-processing --release -- target/wasm32-wasip2/release/test_plugin.wasm crates/runner/test_plugin.wasm
 
 docs:
 	cargo doc --package=javy-cli --open
@@ -36,7 +36,7 @@ test-plugin:
 	cargo test --package=javy-plugin --target=wasm32-wasip2 -- --nocapture
 
 test-plugin-processing:
-	cargo test --package=javy-plugin-processing -- --nocapture
+	cargo test --package=javy-plugin-processing --release -- --nocapture
 
 test-codegen: cli
 	target/release/javy emit-plugin -o crates/codegen/default_plugin.wasm
@@ -73,7 +73,7 @@ fmt-plugin:
 
 fmt-plugin-processing:
 	cargo fmt --package=javy-plugin-processing -- --check
-	cargo clippy --package=javy-plugin-processing --all-targets --all-features -- -D warnings
+	cargo clippy --package=javy-plugin-processing --release --all-targets --all-features -- -D warnings
 
 # Use `--release` on CLI clippy to align with `test-cli`.
 # This reduces the size of the target directory which improves CI stability.


### PR DESCRIPTION
## Description of the change

Save some space in the `target` directory by compiling the `javy-plugin-processing` crate to release in all cases.

## Why am I making this change?

`wasm-opt` is a huge dependency and having it compiled to two different profiles causes it to use way more space than necessary causing CI to sometimes run out of disk space.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
