### PR TITLE
Allow static mut ref in fuzzing to get lint passing

### DIFF
--- a/fuzz/fuzz_targets/json_differential.rs
+++ b/fuzz/fuzz_targets/json_differential.rs
@@ -36,6 +36,9 @@ fuzz_target!(|data: ArbitraryValue| {
     let _ = exec(&data);
 });
 
+// Allowing the refs since the runtimes are setup once and never changed so
+// this is safe.
+#[allow(static_mut_refs)]
 fn exec(data: &ArbitraryValue) -> Result<()> {
     let rt = unsafe { RT.as_ref().unwrap() };
     let ref_rt = unsafe { REF_RT.as_ref().unwrap() };


### PR DESCRIPTION
## Description of the change

Stop warning on the lint failure in the fuzzing.

## Why am I making this change?

If we ever start linting this file, not doing this results in Clippy failing.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
