### PR TITLE
Simplify codegen tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,6 @@ jobs:
 
       - name: Test CodeGen
         run: |
-          target/release/javy emit-plugin -o crates/codegen/default_plugin.wasm
           CARGO_PROFILE_RELEASE_LTO=off cargo hack test --package=javy-codegen --release --each-feature -- --nocapture
 
       - name: Test plugin processing

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ test-plugin-processing:
 	cargo test --package=javy-plugin-processing --release -- --nocapture
 
 test-codegen: cli
-	target/release/javy emit-plugin -o crates/codegen/default_plugin.wasm
 	CARGO_PROFILE_RELEASE_LTO=off cargo hack test --package=javy-codegen --release --each-feature -- --nocapture
 
 # Test in release mode to skip some debug assertions

--- a/crates/codegen/.gitignore
+++ b/crates/codegen/.gitignore
@@ -1,1 +1,0 @@
-default_plugin.wasm


### PR DESCRIPTION
## Description of the change

Reference the default plugin instead of copying it in the codegen tests.

## Why am I making this change?

I'm experimenting with updating our CI strategy this seems easier than having to add a step to copy the file.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
