### PR TITLE
Remove unnecessary build step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           cache-prefix: wasi
 
-      - name: Compile plugin
-        run: cargo build -p javy-plugin --release --target=wasm32-wasip2
-
       - name: Lint
         run: |
           cargo clippy --workspace \


### PR DESCRIPTION
## Description of the change

Deletes a step in CI.

## Why am I making this change?

We build the plugin later in this job. I have no idea why I left this step in in #1009.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
