### PR TITLE
Add support for Windows on AArch64

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -102,6 +102,12 @@ jobs:
             asset_name: javy-x86_64-windows-${{ github.event.release.tag_name }}
             shasum_cmd: sha256sum
             target: x86_64-pc-windows-msvc
+          - name: windows-arm64
+            os: windows-latest
+            path: target\aarch64-pc-windows-msvc\release\javy.exe
+            asset_name: javy-arm-windows-${{ github.event.release.tag_name }}
+            shasum_cmd: sha256sum
+            target: aarch64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Description of the change

Adds a release artifact for Windows on AArch64.

## Why am I making this change?

Windows on AArch64 is now [a tier 1 target](https://doc.rust-lang.org/beta/rustc/platform-support.html#tier-1-with-host-tools) in Rust. Fixes #767.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
