### PR TITLE
v7.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-processing"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -1876,7 +1876,7 @@ version = "0.1.0"
 
 [[package]]
 name = "javy-test-macros"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "6.0.0"
+version = "7.0.0"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
## Description of the change

Increment major version. We removed the `compile` command so this is a breaking CLI change.

## Why am I making this change?

I want to create a release with the new Windows on AArch64 artifact.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
