### PR TITLE
v5.1.0 of javy, v4.1.0 of javy-plugin-api, v7.0.1 of the Javy CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "5.1.0-alpha.1"
+version = "5.1.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "4.1.0-alpha.1"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "javy",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-processing"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -1876,7 +1876,7 @@ version = "0.1.0"
 
 [[package]]
 name = "javy-test-macros"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "7.0.0"
+version = "7.0.1"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -28,7 +28,7 @@ wasmtime = "36"
 wasmtime-wasi = "36"
 wasm-opt = "0.116.1"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "5.1.0-alpha.1" }
+javy = { path = "crates/javy", version = "5.1.0" }
 tempfile = "3.21.0"
 uuid = { version = "1.18", features = ["v4"] }
 serde = { version = "1.0", default-features = false }

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.1.0] - 2025-10-06
+
 ### Added
 
 - Support for `string_normalize` intrinsic (controlling `normalize` method on

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "5.1.0-alpha.1"
+version = "5.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.1.0] - 2025-10-06
+
+### Changed
+
+- `javy` dependency updated. Now exposes intrinsic for `String.normalize` that defaults to enabled.
+
 ## [4.0.0] - 2025-08-28
 
 ### Added

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "4.1.0-alpha.1"
+version = "4.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Bumps all the versions.

## Why am I making this change?

I want to release new versions of crates and the CLI that enable `string.normalize`.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
