### PR TITLE
Re-add version suffixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "5.1.0"
+version = "5.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "4.1.0"
+version = "4.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "javy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasmtime = "36"
 wasmtime-wasi = "36"
 wasm-opt = "0.116.1"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "5.1.0" }
+javy = { path = "crates/javy", version = "5.1.1-alpha.1" }
 tempfile = "3.21.0"
 uuid = { version = "1.18", features = ["v4"] }
 serde = { version = "1.0", default-features = false }

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "5.1.0"
+version = "5.1.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "4.1.0"
+version = "4.1.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Re-adds version suffixes.

## Why am I making this change?

To follow [the versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates).

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
