### PR TITLE
Fix bug in CI to download plugin after restoring target cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,16 +71,16 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup cache and tools
+        uses: ./.github/actions/ci-common
+        with:
+          cache-prefix: native
+
       - name: Download plugins
         uses: actions/download-artifact@v5
         with:
           name: plugins
           path: target/
-
-      - name: Setup cache and tools
-        uses: ./.github/actions/ci-common
-        with:
-          cache-prefix: native
 
       - name: Check benchmarks
         run: cargo check --package=javy-cli --release --benches


### PR DESCRIPTION
## Description of the change

In the CI GitHub Actions workflow, change to download the plugin after restoring the cache rather than before.

## Why am I making this change?

I noticed in a different PR of mine, a cached version of the plugin was being used in tests.

## Checklist

- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
