### PR TITLE
Add flake for Nix-based systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ javy.wasm
 /index.js
 index.wasm
 index.wit
+.envrc
+.direnv/
 
 .DS_Store
 

--- a/docs/docs-contributing-building.md
+++ b/docs/docs-contributing-building.md
@@ -1,6 +1,11 @@
 # Build requirements
 
 - On Ubuntu, `sudo apt-get install curl pkg-config libssl-dev clang`
+- On NixOS (using flakes):
+  - Install [`direnv`](https://direnv.net/)
+  - Run `echo use flake > .envrc`
+  - Run `direnv allow` in the repository root
+  - Finally run `make` or `make cli`
 - [rustup](https://rustup.rs/)
 - Stable Rust, installed via `rustup install stable && rustup default stable`
 - wasm32-wasip2, can be installed via `rustup target add wasm32-wasip2`

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761907660,
+        "narHash": "sha256-kJ8lIZsiPOmbkJypG+B5sReDXSD1KGu2VEPNqhRa/ew=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fb006b87f04c4d3bdf08cfdbc7fab9c13d94a15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    inputs.flake-utils.url = "github:numtide/flake-utils";
+
+    outputs = { nixpkgs, flake-utils, ... }:
+      flake-utils.lib.eachDefaultSystem (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          devShells.default = pkgs.mkShell {
+            packages = with pkgs; [
+              llvmPackages_latest.libclang
+            ];
+
+            LIBCLANG_PATH = "${pkgs.llvmPackages_latest.libclang.lib}/lib";
+          };
+        });
+  }


### PR DESCRIPTION
This change makes it easier to handle per-project dependencies on NixOS when using Nix flakes. 