### PR TITLE
Use 1.90.0 to fix build error for now

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "stable"
+channel = "1.90.0"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-unknown-unknown", "wasm32-wasip2"]
 profile = "default"


### PR DESCRIPTION
## Description of the change

Uses 1.90.0 to build for now.

## Why am I making this change?

Try to mitigate #1052 while we figure out how we want to fix it.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
