### PR TITLE
Update check for clippy in cli build file

### DIFF
--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 
 fn main() -> Result<()> {
-    if let Ok("cargo-clippy") = env::var("CARGO_CFG_FEATURE").as_ref().map(String::as_str) {
+    if env::var("CLIPPY_ARGS").is_ok() {
         stub_plugin_for_clippy()
     } else {
         copy_plugin()


### PR DESCRIPTION
## Description of the change

Updates how we check for Clippy in the CLI's `build.rs` file.

## Why am I making this change?

The existing way doesn't appear to be working. You can verify this by running `cargo clean` and then `make fmt-cli` and see it fail with a file not found error instead of using a stubbed plugin.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
