### PR TITLE
Add Rust toolchain and `wasi-sdk` to `flake.nix`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,7 +37,28 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762655942,
+        "narHash": "sha256-hOM12KcQNQALrhB9w6KJmV5hPpm3GA763HRe9o7JUiI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "6ac961b02d4235572692241e333d0470637f5492",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,18 +2,45 @@
     inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     inputs.flake-utils.url = "github:numtide/flake-utils";
 
-    outputs = { nixpkgs, flake-utils, ... }:
+    inputs.rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+
+    outputs = { nixpkgs, flake-utils, rust-overlay, ... }:
       flake-utils.lib.eachDefaultSystem (system:
         let
-          pkgs = nixpkgs.legacyPackages.${system};
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+          rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          wasiSdk = pkgs.runCommand "wasi-sdk-24" {
+                buildInputs = with pkgs; [ gnutar llvmPackages_latest.clang-unwrapped binutils coreutils ];
+              } ''
+                wasi_tar=${pkgs.fetchurl {
+                  url = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-24/wasi-sdk-24.0-x86_64-linux.tar.gz";
+                  sha256 = "sha256-xsOKq1bl3oit9sHrycOujacviOwrZW+wJO2o1BZ6C8U=";
+                }}
+                ${pkgs.gnutar}/bin/tar xvfz $wasi_tar
+                ${pkgs.coreutils}/bin/ln -fs ${pkgs.llvmPackages_latest.clang-unwrapped}/bin/clang wasi-sdk-24.0-x86_64-linux/bin/clang
+                ${pkgs.coreutils}/bin/ln -fs ${pkgs.binutils}/bin/ar wasi-sdk-24.0-x86_64-linux/bin/ar
+                mv wasi-sdk-24.0-x86_64-linux $out
+              '';
         in
         {
           devShells.default = pkgs.mkShell {
             packages = with pkgs; [
+              wasiSdk
+              rustToolchain
               wasmtime
               llvmPackages_latest.libclang
             ];
-
+            shellHook = ''
+              export WASI_SDK=${wasiSdk}
+            '';
             BINDGEN_EXTRA_CLANG_ARGS = builtins.concatStringsSep " " [
               "-isystem ${pkgs.llvmPackages_latest.libclang.lib}/lib/clang/${pkgs.llvmPackages_latest.libclang.version}/include"
               "-isystem ${pkgs.glibc.dev}/include"


### PR DESCRIPTION
## Description of the change

Fixes #1063

## Checklist

- [ ] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [ ] I've updated documentation including crate documentation if necessary.
