### PR TITLE
ci: Fix invocation in `build-assets`

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -24,8 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Make plugin
-        run: make plugin
+      - name: Build default plugin
+        run: make build-default-plugin
 
       - name: Upload plugin to artifacts
         uses: actions/upload-artifact@v5


### PR DESCRIPTION
It was referencing a make target that doesn't exist, this commit fixes that.