### PR TITLE
Delete map does not support non string key test

### DIFF
--- a/crates/javy/src/serde/de.rs
+++ b/crates/javy/src/serde/de.rs
@@ -639,19 +639,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_map_does_not_support_non_string_keys() {
-        let rt = Runtime::default();
-        // Sanity check to make sure it's not possible to deserialize
-        // to a map where keys are not strings (e.g. numerical value).
-        rt.context().with(|c| {
-            c.eval::<Value<'_>, _>("var a = {1337: 42};").unwrap();
-            let val = c.globals().get("a").unwrap();
-            deserialize_value::<BTreeMap<String, i32>>(val);
-        });
-    }
-
-    #[test]
     fn test_u64_bounds() {
         let rt = Runtime::default();
         rt.context().with(|c| {


### PR DESCRIPTION
## Description of the change

Deletes `test_map_does_not_support_non_string_keys` for the JS value deserializer. 

## Why am I making this change?

This test doesn't make sense to me. When stringifying JS maps that have integer keys, the keys are stringified, so this test should _not_ panic. We test that behaviour in `test_map_always_converts_keys_to_string`. The `test_map_does_not_support_non_string_keys` test fails when run because it doesn't panic.

The only reason this hasn't impacted CI to date is because we ignore it implicitly in our Makefile and in CI because we run these tests targeting WASI which uses the Wasmtime test runner so `should_panic` tests are ignored.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
