### PR TITLE
Simplify makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,7 @@ jobs:
         run: make lint-native-targets
 
       - name: Test
-        run: make test-native-targets-ci
+        run: make test-native-targets
 
       - name: WPT
-        run: |
-          npm install --prefix wpt
-          npm test --prefix wpt
+        run: make test-wpt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt fmt-check lint-wasi-targets test-wasi-targets wasi-targets lint-native-targets test-native-targets native-targets test-wpt test clean cli plugin build-test-plugins
+.PHONY: fmt fmt-check lint-wasi-targets test-wasi-targets wasi-targets lint-native-targets test-native-targets native-targets test-wpt test clean cli plugin build-test-plugins build-default-plugin
 .DEFAULT_GOAL := cli
 
 # === Format checks ===
@@ -31,7 +31,7 @@ test-wasi-targets:
 wasi-targets: lint-wasi-targets test-wasi-targets
 
 # === Lint & Test Native Targets ===
-lint-native-targets:
+lint-native-targets: build-default-plugin
 	CARGO_PROFILE_RELEASE_LTO=off cargo clippy --workspace \
 	--exclude=javy \
 	--exclude=javy-plugin-api \
@@ -39,12 +39,7 @@ lint-native-targets:
 	--exclude=javy-test-plugin-wasip2 \
 	--release --all-targets --all-features -- -D warnings
 
-test-native-targets: build-default-plugin build-test-plugins test-native-targets-ci
-
-# This command assumes a CI environment in which the test plugin
-# assets have been previously created in the expected directories.
-# This ensures that we can recycle CI time.
-test-native-targets-ci:
+test-native-targets: build-default-plugin build-test-plugins
 	CARGO_PROFILE_RELEASE_LTO=off cargo hack test --workspace \
 	--exclude=javy \
 	--exclude=javy-plugin-api \
@@ -52,39 +47,44 @@ test-native-targets-ci:
 	--exclude=javy-test-plugin-wasip2 \
 	--release --each-feature -- --nocapture
 
-
 native-targets: lint-native-targets test-native-targets
 
 # === Web Platform Tests
 
-# For usage in CI, in which we assume pre-existing assets.
-test-wpt-ci:
+test-wpt: cli
 	npm install --prefix wpt
 	npm test --prefix wpt
-
-test-wpt: cli test-wpt-ci
 
 # === All tests ===
 test-all: wasi-targets native-targets test-wpt
 
+# === Binaries ===
 
+# First, build the default plugin, which is a dependency to the CLI.
+# No need to run `javy_plugin_processing`, the CLI build.rs will take
+# care of doing that.
+target/release/javy: build-default-plugin
+	CARGO_PROFILE_RELEASE_LTO=off cargo build -p=javy-cli --release
+
+target/wasm32-wasip2/release/plugin.wasm:
+	cargo build -p=javy-plugin --target=wasm32-wasip2 --release
+
+target/wasm32-wasip2/release/test_plugin.wasm:
+	cargo build -p=javy-test-plugin-wasip2 --target=wasm32-wasip2 --release
+	cargo run --package=javy-plugin-processing --release -- target/wasm32-wasip2/release/test_plugin.wasm target/wasm32-wasip2/release/test_plugin.wasm
+
+target/wasm32-unknown-unknown/release/test_invalid_plugin.wasm:
+	cargo build -p=javy-test-invalid-plugin --target=wasm32-unknown-unknown --release
+
+cli: target/release/javy
+
+# Build the default plugin
+build-default-plugin: target/wasm32-wasip2/release/plugin.wasm
+
+# Build auxiliary plugins, for testing
+build-test-plugins: target/wasm32-wasip2/release/plugin.wasm target/wasm32-wasip2/release/test_plugin.wasm target/wasm32-unknown-unknown/release/test_invalid_plugin.wasm
 
 # === Misc ===
 clean:
 	cargo clean
 
-# First, build the default plugin, which is a dependency to the CLI.
-# No need to run `javy_plugin_processing`, the CLI build.rs will take
-# care of doing that.
-cli: build-default-plugin
-	CARGO_PROFILE_RELEASE_LTO=off cargo build -p=javy-cli --release
-
-# Build the default plugin
-build-default-plugin:
-	cargo build -p=javy-plugin --target=wasm32-wasip2 --release
-
-# Build auxiliary plugins, for testing
-build-test-plugins:
-	cargo build --package=javy-test-plugin-wasip2 --target=wasm32-wasip2 --release
-	cargo build --package=javy-test-invalid-plugin --target=wasm32-unknown-unknown --release
-	cargo run --package=javy-plugin-processing --release -- target/wasm32-wasip2/release/test_plugin.wasm target/wasm32-wasip2/release/test_plugin.wasm


### PR DESCRIPTION
## Description of the change

Use explicit filepaths for dependencies for targets in the Makefile.

## Why am I making this change?

With Makefiles, for a target, if all files it depends on exist and have older timestamps, then `make` won't run the commands to rebuild those files. This should allow us to simplify the Makefile.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
