### PR TITLE
cli: Remove `wasm-opt` from build dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,7 +1594,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "walrus",
- "wasm-opt",
  "wasmparser 0.240.0",
  "wasmtime",
  "wasmtime-wasi",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,4 +33,3 @@ wit-component = "0.240.0"
 anyhow = { workspace = true }
 javy-plugin-processing = { path = "../plugin-processing" }
 tempfile = { workspace = true }
-wasm-opt = { workspace = true }


### PR DESCRIPTION
It's not used as part of the build, but in the crate itself.