### PR TITLE
Exclude test-invalid-plugin from native tests and linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ lint-native-targets: build-default-plugin
 	--exclude=javy \
 	--exclude=javy-plugin-api \
 	--exclude=javy-plugin \
+	--exclude=javy-test-invalid-plugin \
 	--exclude=javy-test-plugin-wasip2 \
 	--release --all-targets --all-features -- -D warnings
 
@@ -44,6 +45,7 @@ test-native-targets: build-default-plugin build-test-plugins
 	--exclude=javy \
 	--exclude=javy-plugin-api \
 	--exclude=javy-plugin \
+	--exclude=javy-test-invalid-plugin \
 	--exclude=javy-test-plugin-wasip2 \
 	--release --each-feature -- --nocapture
 


### PR DESCRIPTION
## Description of the change

Excludes the `test-invalid-plugin` crate from the native tests and native linting.

## Why am I making this change?

This crate should only be compiled to Wasm anyway.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
