### PR TITLE
Add a ci target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,4 +91,8 @@ clean:
 vet:
 	cargo vet --locked
 
+# Intended to simulate what the GitHub Actions CI workflow will run.
+# We don't invoke this directly because we often run out of disk space in
+# GitHub Actions if we try to compile native targets in the same workflow as
+# WASI targets so we have to use a multi-step process in GitHub to avoid that.
 ci: lint-wasi-targets lint-native-targets vet test-all


### PR DESCRIPTION
## Description of the change

Adds vet and ci targets to the Makefile.

## Why am I making this change?

I want an easy way to check locally if a change is likely to fail CI.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
