### PR TITLE
Add a fmt check to CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ fmt:
 	cargo fmt --all
 
 # === Lint & Test WASI Targets ===
-lint-wasi-targets:
+lint-wasi-targets: fmt-check
 	cargo clippy --workspace \
 	--exclude=javy-cli \
 	--exclude=javy-codegen \
@@ -31,7 +31,7 @@ test-wasi-targets:
 wasi-targets: lint-wasi-targets test-wasi-targets
 
 # === Lint & Test Native Targets ===
-lint-native-targets: build-default-plugin
+lint-native-targets: fmt-check build-default-plugin
 	CARGO_PROFILE_RELEASE_LTO=off cargo clippy --workspace \
 	--exclude=javy \
 	--exclude=javy-plugin-api \


### PR DESCRIPTION
## Description of the change

Adds a formatting check to CI.

## Why am I making this change?

We previously identified this check was removed unintentionally and it's useful.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
