### PR TITLE
Remove setting env vars for WIT parsing

### DIFF
--- a/crates/codegen/src/exports.rs
+++ b/crates/codegen/src/exports.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use convert_case::{Case, Casing};
-use std::{env, path::Path};
+use std::path::Path;
 
 use crate::js::JS;
 use crate::wit;
@@ -15,7 +15,7 @@ pub(crate) struct Export {
 
 pub(crate) fn process_exports(js: &JS, wit: &Path, wit_world: &str) -> Result<Vec<Export>> {
     let js_exports = js.exports()?;
-    parse_wit_exports(wit, wit_world)?
+    wit::parse_exports(wit, wit_world)?
         .into_iter()
         .map(|wit_export| {
             let export = wit_export.from_case(Case::Kebab).to_case(Case::Camel);
@@ -29,24 +29,4 @@ pub(crate) fn process_exports(js: &JS, wit: &Path, wit_world: &str) -> Result<Ve
             }
         })
         .collect::<Result<Vec<Export>>>()
-}
-
-fn parse_wit_exports(wit: &Path, wit_world: &str) -> Result<Vec<String>> {
-    // Configure wit-parser to not require semicolons but only if the relevant
-    // environment variable is not already set.
-    const SEMICOLONS_OPTIONAL_ENV_VAR: &str = "WIT_REQUIRE_SEMICOLONS";
-    let semicolons_env_var_already_set = env::var(SEMICOLONS_OPTIONAL_ENV_VAR).is_ok();
-    if !semicolons_env_var_already_set {
-        env::set_var(SEMICOLONS_OPTIONAL_ENV_VAR, "0");
-    }
-
-    let exports = wit::parse_exports(wit, wit_world);
-
-    // If we set the environment variable to not require semicolons, remove
-    // that environment variable now that we no longer need it set.
-    if !semicolons_env_var_already_set {
-        env::remove_var(SEMICOLONS_OPTIONAL_ENV_VAR);
-    }
-
-    exports
 }


### PR DESCRIPTION
## Description of the change

Remove unnecessary setting of environment variables for parsing WIT files. There should not be any change in behaviour.

## Why am I making this change?

Back when we used a version of wit-parser that supported semicolons if an environment variable was set, we set the environment variable. But we've since stopped supporting WIT files that do not contain semicolons so we no longer need this logic.

This gets flagged if you try setting the edition for the crate to 2024.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
