### PR TITLE
cli - v8.0.0, codegen - v3.0.0, plugin-api - v5.0.0, javy - v6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "6.0.0-alpha.1"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "7.0.1"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "javy-codegen"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "5.0.0-alpha.1"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "javy",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-processing"
-version = "7.0.1"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "7.0.1"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -1678,7 +1678,7 @@ version = "0.1.0"
 
 [[package]]
 name = "javy-test-macros"
-version = "7.0.1"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "7.0.1"
+version = "8.0.0"
 authors = ["The Javy Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -29,7 +29,7 @@ wasmtime = "36"
 wasmtime-wasi = "36"
 wasm-opt = "0.116.1"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "6.0.0-alpha.1" }
+javy = { path = "crates/javy", version = "6.0.0" }
 tempfile = "3.23.0"
 uuid = { version = "1.18", features = ["v4"] }
 serde = { version = "1.0", default-features = false }

--- a/crates/codegen/CHANGELOG.md
+++ b/crates/codegen/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.0] - 2025-11-12
+
 ### Changed
 
 - `cabi_realloc` will not be removed while generating a statically-linked Wasm module from a JS file.

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-codegen"
-version = "3.0.0-alpha.1"
+version = "3.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [6.0.0] - 2025-11-12
+
 ### Removed
 
 - `big_float`, `big_decimal`, and `string_normalize` on `Config`. For BigFloat

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "6.0.0-alpha.1"
+version = "6.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.0.0] - 2025-11-12
+
 ### Removed
 
 - `big_float`, `big_decimal`, and `string_normalize` on `Config`. For BigFloat

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "5.0.0-alpha.1"
+version = "5.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Bumps versions of CLI, codegen, plugin-api, and javy.

## Why am I making this change?

I want to release the crates so folks can use Rust 1.91.0 and may as well ship the CLI changes at the same time.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
