### PR TITLE
Add version suffixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,7 +1562,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "6.0.0"
+version = "6.0.1-alpha.1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "javy-codegen"
-version = "3.0.0"
+version = "3.0.1-alpha.1"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "5.0.0"
+version = "5.0.1-alpha.1"
 dependencies = [
  "anyhow",
  "javy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasmtime = "36"
 wasmtime-wasi = "36"
 wasm-opt = "0.116.1"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "6.0.0" }
+javy = { path = "crates/javy", version = "6.0.1-alpha.1" }
 tempfile = "3.23.0"
 uuid = { version = "1.18", features = ["v4"] }
 serde = { version = "1.0", default-features = false }

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-codegen"
-version = "3.0.0"
+version = "3.0.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "6.0.0"
+version = "6.0.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "5.0.0"
+version = "5.0.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Re-adds the `-alpha.1` suffixes on our crates.

## Why am I making this change?

To accord with [our versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates).

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
