### PR TITLE
make: Correctly format `lint-wasi-targets` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,19 @@ fmt:
 	cargo fmt --all
 
 # === Lint & Test WASI Targets ===
-lint-wasi-targets: fmt-check
+lint-wasi-targets: fmt-check lint-wasip1-targets lint-wasip2-targets
+
+lint-wasip1-targets:
 	cargo clippy --workspace \
 	--exclude=javy-cli \
 	--exclude=javy-codegen \
 	--exclude=javy-plugin-processing \
 	--exclude=javy-runner \
-	--exclude=javy-test-plugin-wasip2
+	--exclude=javy-test-plugin-wasip2 \
 	--exclude=javy-fuzz \
 	--target=wasm32-wasip1 --all-targets --all-features -- -D warnings
+
+lint-wasip2-targets:
 	cargo clippy --workspace \
 	--exclude=javy-cli \
 	--exclude=javy-codegen \
@@ -27,7 +31,9 @@ lint-wasi-targets: fmt-check
 	--exclude=javy-fuzz \
 	--target=wasm32-wasip2 --all-targets --all-features -- -D warnings
 
-test-wasi-targets:
+test-wasi-targets: test-wasip1-targets test-wasip2-targets
+
+test-wasip1-targets:
 	cargo hack test --workspace \
 	--exclude=javy-cli \
 	--exclude=javy-codegen \
@@ -38,6 +44,8 @@ test-wasi-targets:
 	--exclude=javy-test-plugin-wasip2 \
 	--exclude=javy-test-invalid-plugin \
 	--target=wasm32-wasip1 --each-feature -- --nocapture
+
+test-wasip2-targets:
 	cargo hack test --workspace \
 	--exclude=javy-cli \
 	--exclude=javy-codegen \


### PR DESCRIPTION
The formatting error in the Makefile prevented the lint step from completing and from reporting the lint errors declared in the `wasi_p1` plugin api.

In CI, this looked like:

  ```
 --target=wasm32-wasip1 --all-targets --all-features -- -D warnings
   /bin/sh: 1: --target=wasm32-wasip1: not found
   make: [Makefile:13: lint-wasi-targets] Error 127 (ignored)

```
Ref: https://github.com/bytecodealliance/javy/actions/runs/19335192688/job/55308089241#step:4:21

Everything worked, given that the non-zero exit is ignored. I'm currently not sure what's the best way to ensure that this doesn't happen in the future.

Additionally, to make targets easier to read, this commit also divides the p1/p2 targets, which will hopefully make this process less error-prone.