### PR TITLE
Add wasmtime pattern to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 100
     groups:
+      wasmtime:
+        patterns:
+          - "wasmtime*"
       nonbreaking:
         exclude-patterns:
           - "rquickjs*"


### PR DESCRIPTION
## Description of the change

Have Dependabot group wasmtime updates together.

## Why am I making this change?

Wasmtime updates won't succeed unless they're all updated together.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
