### PR TITLE
Ensure value is freed in is_array_or_proxy_of_array

### DIFF
--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed memory leak in Serde deserializer implementation for RQuickJS values.
+
 ## [6.0.0] - 2025-11-12
 
 ### Removed

--- a/crates/javy/src/serde/de.rs
+++ b/crates/javy/src/serde/de.rs
@@ -533,15 +533,18 @@ fn is_array_or_proxy_of_array(val: &Value) -> bool {
     if val.is_array() {
         return true;
     }
-    let ctx = val.ctx().as_raw().as_ptr();
-    let mut val = val.as_raw();
+    let ctx = val.ctx();
+    let mut val = val.clone();
     loop {
-        let is_proxy = unsafe { JS_IsProxy(val) };
+        let is_proxy = unsafe { JS_IsProxy(val.as_raw()) };
         if !is_proxy {
             return false;
         }
-        val = unsafe { JS_GetProxyTarget(ctx, val) };
-        if unsafe { JS_IsArray(val) } {
+        val = unsafe {
+            let target = JS_GetProxyTarget(ctx.as_raw().as_ptr(), val.as_raw());
+            Value::from_raw(ctx.clone(), target)
+        };
+        if unsafe { JS_IsArray(val.as_raw()) } {
             return true;
         }
     }

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed memory leak in Serde deserializer implementation for RQuickJS values.
+
 ## [5.0.0] - 2025-11-12
 
 ### Removed


### PR DESCRIPTION
## Description of the change

Wraps the value we receive back from `JS_GetProxyTarget` in a `Value` so the reference count is decremented allowing the value to be freed.

## Why am I making this change?

Fixes #1093 

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
