### PR TITLE
Revert "Simplify makefile (#1068)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,12 @@ jobs:
           path: target/
 
       - name: Lint
-        run: make lint-native-targets
+        run: make lint-native-targets-ci
 
       - name: Test
-        run: make test-native-targets
+        run: make test-native-targets-ci
 
       - name: WPT
-        run: make test-wpt
+        run: |
+          npm install --prefix wpt
+          npm test --prefix wpt


### PR DESCRIPTION
## Description of the change

Tries to revert #1068.

## Why am I making this change?

I noticed we don't seem to be triggering rebuilds of Wasm plugins when we should be both locally and in CI. So let's go back to an approach we have more confidence in.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
