### PR TITLE
Lock Rust version to 1.92 to workaround WASI p2 bug

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,8 @@
 [toolchain]
-channel = "stable"
+# Rust 1.93.0 has a bug where WASI p2 doesn't correctly close file descriptors causing tests to fail.
+# cargo 1.95.0-nightly (fe2f314ae 2026-01-30) runs correctly so presumably we can switch back to stable for 1.94 or
+# 1.95.
+channel = "1.92.0"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-unknown-unknown", "wasm32-wasip1", "wasm32-wasip2"]
 profile = "default"


### PR DESCRIPTION
## Description of the change

Locks the Rust version to 1.92.0 instead of using stable which is currently 1.93.0.

## Why am I making this change?

Fixes #1115 

The 262 tests are broken for Rust 1.93.0 with WASI preview 2 due to a bug in Rust's standard library for WASI preview 2. The bug is fixed when run with a nightly for Rust 1.95.0 so presumably we can switch back to using stable when 1.94 or 1.95 is released on the stable channel.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
