### PR TITLE
Restore stable Rust

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,8 +1,5 @@
 [toolchain]
-# Rust 1.93.0 has a bug where WASI p2 doesn't correctly close file descriptors causing tests to fail.
-# cargo 1.95.0-nightly (fe2f314ae 2026-01-30) runs correctly so presumably we can switch back to stable for 1.94 or
-# 1.95.
-channel = "1.92.0"
+channel = "stable"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-unknown-unknown", "wasm32-wasip1", "wasm32-wasip2"]
 profile = "default"


### PR DESCRIPTION
## Description of the change

Switch back to using latest stable Rust. In this case 1.93.1 which includes a fix for the leaky file descriptor bug we were seeing.

## Why am I making this change?

As I mentioned in a previous comment, I prefer if we continuously integrate using the latest stable version to discover bugs sooner so we have more time to address the bug versus discovering bugs with adopting a newer version of Rust later and having to do a less optimal fix due to time constraints and I'm okay with requiring more PRs as a result of that strategy.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
