### PR TITLE
Stop ignoring Wasmtime in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    ignore:
-      - dependency-name: "wasmtime*"
 
   - package-ecosystem: npm
     directory: "/npm/javy"


### PR DESCRIPTION
## Description of the change

Stops ignoring Wasmtime in Dependabot.

## Why am I making this change?

I think I added this originally because we couldn't update Wasmtime due to Wizer generally not supporting the latest Wasmtime. But that's no longer the case, new Wasmtime releases include new versions of Wizer. Also I added a dependency group for Wasmtime in an earlier PR so, hypothetically, we should be getting a PR that bundles all the Wasmtime updates together.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
