### PR TITLE
Update release docs

### DIFF
--- a/docs/docs-contributing-releasing.md
+++ b/docs/docs-contributing-releasing.md
@@ -1,18 +1,16 @@
+# Crate releases
+
+1. Merge a PR removing the `-alpha` suffix on the crate versions.
+2. Change directories into the crate version you want to publish and run
+   `./publish.sh`. If you're publishing `javy` and `javy-plugin-api`, publish
+   the `javy` crate first.
+
 # CLI releases
 
-1. Update the root `Cargo.toml` with the new version, following semver.
-2. Create a tag for the new version like `v0.2.0`.
-
-```
-git tag v0.2.0
-git push origin --tags
-```
-
-3. Create a new release from the new tag in github
-   [here](https://github.com/bytecodealliance/javy/releases/new).
-4. A GitHub Action will trigger for `publish.yml` when a release is published
-   ([i.e. it doesn't run on
-   drafts](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#:~:text=created%2C%20edited%2C%20or%20deleted%20activity%20types%20for%20draft%20releases)),
-   creating the artifacts for downloading.
-
-
+1. Merge a PR updating the root `Cargo.toml` with the new version, following
+   semver.
+2. Create a new release in GitHub
+   [here](https://github.com/bytecodealliance/javy/releases/new). On the page
+   creating the release, create a new tag and title that are set to `v`
+   followed by the new version in the root `Cargo.toml`, for example `v8.0.0`.
+   The `build-assets` workflow should attach artifacts to the new release.


### PR DESCRIPTION
## Description of the change

Updates docs for the release process for crates and the CLI.

## Why am I making this change?

The existing docs were out of date and didn't include instructions for how to release new crate versions.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
