### PR TITLE
Update versions, in preparation for a release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "7.0.0-alpha.1"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "javy-codegen"
-version = "4.0.0-alpha.2"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "6.0.0-alpha.1"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "javy",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-processing"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -1755,7 +1755,7 @@ version = "0.1.0"
 
 [[package]]
 name = "javy-test-macros"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "8.0.0"
+version = "8.1.0"
 authors = ["The Javy Project Developers"]
 edition = "2024"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/codegen/CHANGELOG.md
+++ b/crates/codegen/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.0.0] - 2026-03-17
 
 ### Changed
 

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-codegen"
-version = "4.0.0-alpha.2"
+version = "4.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [7.0.0] - 2026-03-17
 
 ### Changed
 

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "7.0.0-alpha.1"
+version = "7.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [6.0.0] - 2026-03-17
 
 ### Changed
 

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "6.0.0-alpha.1"
+version = "6.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Why am I making this change?

To release a new version.

## Checklist

- [ ] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [ ] I've updated documentation including crate documentation if necessary.
