### PR TITLE
Coherently handle the `publish` and the `version` entries in each package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin"
-version = "0.2.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "javy-plugin-api",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-processing"
-version = "8.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "javy-runner"
-version = "8.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "tempfile",
@@ -1751,11 +1751,11 @@ dependencies = [
 
 [[package]]
 name = "javy-test-invalid-plugin"
-version = "0.1.0"
+version = "0.0.0"
 
 [[package]]
 name = "javy-test-macros"
-version = "8.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "javy-test-plugin-wasip1"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "javy-plugin-api",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "javy-test-plugin-wasip2"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "javy-plugin-api",

--- a/crates/plugin-processing/Cargo.toml
+++ b/crates/plugin-processing/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "javy-plugin-processing"
-version.workspace = true
+version = "0.0.0"
+publish = false
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin/Cargo.toml
+++ b/crates/plugin/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "javy-plugin"
-version = "0.2.0"
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [lib]
 name = "plugin"

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-runner"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/test-invalid-plugin/Cargo.toml
+++ b/crates/test-invalid-plugin/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "javy-test-invalid-plugin"
-version = "0.1.0"
+version = "0.0.0"
+publish = false
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/test-macros/Cargo.toml
+++ b/crates/test-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-test-macros"
-version.workspace = true
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/test-plugin-wasip1/Cargo.toml
+++ b/crates/test-plugin-wasip1/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "javy-test-plugin-wasip1"
-version = "0.1.0"
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [lib]
 name = "test_plugin"

--- a/crates/test-plugin-wasip2/Cargo.toml
+++ b/crates/test-plugin-wasip2/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "javy-test-plugin-wasip2"
-version = "0.1.0"
+version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 
 [lib]
 name = "test_plugin"


### PR DESCRIPTION
This is the first of a series of patches to improve how we handle version updates and releases. Note that my intention is not change our current mechanism, but to improve it so that there are less manual steps along the way, ideally making it less error prone.


This commit set the `publish` key in each package to `false` and sets the version to `0.0.0`, to explicitly the mark the package as not publishable, as documented in
https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.

The main motivation for this change is to prevent certain packages from being published by mistake, either manually or in light of a future publishing mechanism.
