### PR TITLE
Fix example in docs for versioning

### DIFF
--- a/docs/docs-contributing.md
+++ b/docs/docs-contributing.md
@@ -39,7 +39,7 @@ breaking changes, increment the number in the suffix, for example `-alpha.2`.
 When releasing, remove the suffix and then publish.
 
 For example, let's say the last published version of `javy` is `2.0.0`, so the
-current version in the Cargo.toml file is `2.0.0-alpha.1`. If you add a new
+current version in the Cargo.toml file is `2.0.1-alpha.1`. If you add a new
 public function, you would change the version to `2.1.0-alpha.1`. This is
 because adding a new public function is considered an additive change. After
 merging those changes, if you add a new public function, you would change the


### PR DESCRIPTION
## Description of the change

Fixes an example in the versioning docs.

Take a look at pages 83 and 84 in Rust for Rustaceans for the canonical source.

## Why am I making this change?

The example was wrong and misleading.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
