### PR TITLE
Pin deterministic-wasi-ctx dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 [workspace.dependencies]
 brotli = "8.0.2"
 clap = { version = "4.5.60", features = ["derive"] }
-deterministic-wasi-ctx = "4.0.1"
+deterministic-wasi-ctx = "=4.0.1"
 wasmtime = "43"
 wasmtime-wasi = "43"
 wasmtime-wizer = "43"


### PR DESCRIPTION
## Description of the change

Pins the `deterministic-wasi-ctx` dependency to a particular version.

## Why am I making this change?

Fixes #1182. `deterministic-wasi-ctx` requires a particular major version of `wasmtime` and that status quo setup will have the `javy-codegen` crate try to download the latest `4.x.x` version of `deterministic-wasi-ctx` that may or may not depend on the same major version of `wasmtime`. Pinning the version of `deterministic-wasi-ctx` will ensure `javy-codegen` and `deterministic-wasi-ctx` depend on the same major version of `wasmtime`.

An alternative approach would be to switch `deterministic-wasi-ctx` back to depending on a range of `wasmtime` versions instead of a specific major version.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
