### PR TITLE
build: Tighten crate selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,45 @@
 .PHONY: fmt fmt-check lint-wasi-targets lint-wasip1-targets lint-wasip2-targets \
 	test-wasi-targets test-wasip1-targets test-wasip2-targets wasi-targets \
-	lint-native-targets test-native-targets test-native-targets-ci native-targets \
-	test-wpt test-wpt-ci test-all clean cli build-default-plugin build-test-plugins \
-	ci
+	lint-native-targets lint-native-targets-ci test-native-targets \
+	test-native-targets-ci native-targets test-wpt test-wpt-ci test-all \
+	clean cli build-default-plugin build-test-plugins ci
 .DEFAULT_GOAL := cli
+
+# Selection for linting / testing.
+#
+# Definitions are expected in`[package.metadata.javy]` in the
+# corresponding Cargo.toml:
+#
+#   targets = ["native" | "wasip1" | "wasip2"]
+#
+# Note that if no targets are defined, the default is [ "native" ]
+#
+# Whether a crate has tests is read from cargo's own per-target `test`
+# flag (e.g. `[lib] test = false`), so test-only fixtures opt out via
+# the standard cargo manifest rather than custom metadata.  The
+# auxiliary plugin crates (javy-test-plugin-wasi{p1, p2}) are
+# currently the only crates exempt from unit/integration testing.
+#
+# Expected arguments:
+#   1: target tag,
+#   2: "lint" or "test"
+define select_crates_for
+$(shell cargo metadata --format-version=1 --no-deps | jq -r \
+  --arg tgt $(1) --arg mode $(2) '\
+    .packages[] \
+    | (.metadata.javy.targets // ["native"]) as $$tgts \
+    | (.targets | any(.test)) as $$has_tests \
+    | select($$tgts | any(. == $$tgt)) \
+    | select($$mode == "lint" or $$has_tests) \
+    | "-p \(.name)"')
+endef
+
+NATIVE_LINT_CRATES := $(call select_crates_for,native,lint)
+NATIVE_TEST_CRATES := $(call select_crates_for,native,test)
+WASIP1_LINT_CRATES := $(call select_crates_for,wasip1,lint)
+WASIP1_TEST_CRATES := $(call select_crates_for,wasip1,test)
+WASIP2_LINT_CRATES := $(call select_crates_for,wasip2,lint)
+WASIP2_TEST_CRATES := $(call select_crates_for,wasip2,test)
 
 # === Format checks ===
 fmt-check:
@@ -15,55 +51,21 @@ fmt:
 lint-wasi-targets: fmt-check lint-wasip1-targets lint-wasip2-targets
 
 lint-wasip1-targets:
-	cargo clippy --workspace \
-	--exclude=javy-cli \
-	--exclude=javy-codegen \
-	--exclude=javy-plugin-processing \
-	--exclude=javy-runner \
-	--exclude=javy-test-plugin-wasip2 \
-	--exclude=javy-fuzz \
-	--exclude=javy-release \
+	cargo clippy $(WASIP1_LINT_CRATES) \
 	--target=wasm32-wasip1 --all-targets --all-features -- -D warnings
 
 lint-wasip2-targets:
-	cargo clippy --workspace \
-	--exclude=javy-cli \
-	--exclude=javy-codegen \
-	--exclude=javy-plugin \
-	--exclude=javy-plugin-processing \
-	--exclude=javy-runner \
-	--exclude=javy-test-plugin-wasip1 \
-	--exclude=javy-fuzz \
-	--exclude=javy-release \
+	cargo clippy $(WASIP2_LINT_CRATES) \
 	--target=wasm32-wasip2 --all-targets --all-features -- -D warnings
 
 test-wasi-targets: test-wasip1-targets test-wasip2-targets
 
 test-wasip1-targets:
-	cargo hack test --workspace \
-	--exclude=javy-cli \
-	--exclude=javy-codegen \
-	--exclude=javy-plugin-processing \
-	--exclude=javy-runner \
-	--exclude=javy-fuzz \
-	--exclude=javy-release \
-	--exclude=javy-test-plugin-wasip1 \
-	--exclude=javy-test-plugin-wasip2 \
-	--exclude=javy-test-invalid-plugin \
+	cargo hack test $(WASIP1_TEST_CRATES) \
 	--target=wasm32-wasip1 --each-feature -- --nocapture
 
 test-wasip2-targets:
-	cargo hack test --workspace \
-	--exclude=javy-cli \
-	--exclude=javy-codegen \
-	--exclude=javy-plugin \
-	--exclude=javy-plugin-processing \
-	--exclude=javy-runner \
-	--exclude=javy-fuzz \
-	--exclude=javy-release \
-	--exclude=javy-test-plugin-wasip1 \
-	--exclude=javy-test-plugin-wasip2 \
-	--exclude=javy-test-invalid-plugin \
+	cargo hack test $(WASIP2_TEST_CRATES) \
 	--target=wasm32-wasip2 --each-feature -- --nocapture
 
 wasi-targets: lint-wasi-targets test-wasi-targets
@@ -72,13 +74,7 @@ wasi-targets: lint-wasi-targets test-wasi-targets
 lint-native-targets: build-default-plugin lint-native-targets-ci
 
 lint-native-targets-ci: fmt-check
-	CARGO_PROFILE_RELEASE_LTO=off cargo clippy --workspace \
-	--exclude=javy \
-	--exclude=javy-plugin-api \
-	--exclude=javy-plugin \
-	--exclude=javy-test-invalid-plugin \
-	--exclude=javy-test-plugin-wasip1 \
-	--exclude=javy-test-plugin-wasip2 \
+	CARGO_PROFILE_RELEASE_LTO=off cargo clippy $(NATIVE_LINT_CRATES) \
 	--release --all-targets --all-features -- -D warnings
 
 test-native-targets: build-default-plugin build-test-plugins test-native-targets-ci
@@ -87,13 +83,7 @@ test-native-targets: build-default-plugin build-test-plugins test-native-targets
 # assets have been previously created in the expected directories.
 # This ensures that we can recycle CI time.
 test-native-targets-ci:
-	CARGO_PROFILE_RELEASE_LTO=off cargo hack test --workspace \
-	--exclude=javy \
-	--exclude=javy-plugin-api \
-	--exclude=javy-plugin \
-	--exclude=javy-test-invalid-plugin \
-	--exclude=javy-test-plugin-wasip1 \
-	--exclude=javy-test-plugin-wasip2 \
+	CARGO_PROFILE_RELEASE_LTO=off cargo hack test $(NATIVE_TEST_CRATES) \
 	--release --each-feature -- --nocapture
 
 

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -9,6 +9,9 @@ homepage = "https://github.com/bytecodealliance/javy/tree/main/crates/javy"
 repository = "https://github.com/bytecodealliance/javy/tree/main/crates/javy"
 categories = ["wasm"]
 
+[package.metadata.javy]
+targets = ["wasip1", "wasip2"]
+
 [dependencies]
 anyhow = { workspace = true }
 rquickjs = { version = "0.11.0", features = [

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -9,6 +9,9 @@ homepage = "https://github.com/bytecodealliance/javy/tree/main/crates/plugin-api
 repository = "https://github.com/bytecodealliance/javy/tree/main/crates/plugin-api"
 categories = ["wasm"]
 
+[package.metadata.javy]
+targets = ["wasip1", "wasip2"]
+
 [dependencies]
 anyhow = { workspace = true }
 javy = { workspace = true }

--- a/crates/plugin/Cargo.toml
+++ b/crates/plugin/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 license.workspace = true
 publish = false
 
+[package.metadata.javy]
+targets = ["wasip1"]
+
 [lib]
 name = "plugin"
 crate-type = ["cdylib"]

--- a/crates/test-invalid-plugin/Cargo.toml
+++ b/crates/test-invalid-plugin/Cargo.toml
@@ -6,8 +6,12 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[package.metadata.javy]
+targets = ["wasip1", "wasip2"]
+
 [lib]
 name = "test_invalid_plugin"
 crate-type = ["cdylib"]
+test = false
 
 [dependencies]

--- a/crates/test-plugin-wasip1/Cargo.toml
+++ b/crates/test-plugin-wasip1/Cargo.toml
@@ -6,9 +6,13 @@ edition.workspace = true
 license.workspace = true
 publish = false
 
+[package.metadata.javy]
+targets = ["wasip1"]
+
 [lib]
 name = "test_plugin"
 crate-type = ["cdylib"]
+test = false
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/test-plugin-wasip2/Cargo.toml
+++ b/crates/test-plugin-wasip2/Cargo.toml
@@ -6,9 +6,13 @@ edition.workspace = true
 license.workspace = true
 publish = false
 
+[package.metadata.javy]
+targets = ["wasip2"]
+
 [lib]
 name = "test_plugin"
 crate-type = ["cdylib"]
+test = false
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
The exclude list in the Makefile is arguably unwieldy and makes the process of adding new crates harder than it has to be. This change aims to ease the per-target crate selection for testing and linting though a small function and script that reads each crate's metadata and decides which target it should be built for.

The resulting invocation is very similar to what we had before, e.g. the invocation to lint native targets, with this change looks like the following:

    CARGO_PROFILE_RELEASE_LTO=off cargo clippy -p javy-cli -p javy-codegen -p javy-plugin-processing -p javy-runner -p javy-test-macros -p javy-fuzz -p javy-release \
    --release --all-targets --all-features -- -D warnings

By default all crates are treated as _build on native_ unless stated otherwise. With this approach, the only pre-requisite to add new crates shifts from:

* Adding a new crate
* Decide how and where it should be added to the exclude lists in the Makefile

To:

* Add a new crate with the relevant metadata.

One thing to note is that this change adds overhead to each `make` invocation, since now parsing of the metadata is needed. Basic measurements show that all these invocations take around 240ms, which I believe is fine, given that compilation takes way longer. As a future optimization we can try to cache the invoation initially, and apply filtering on top of the cached result.

This change is motivated by the introduction of a profiler for Javy, which will require introducing several new crates.

