### PR TITLE
Add the initial implementation of javy-profiler

### DIFF
--- a/.github/actions/ci-common/action.yml
+++ b/.github/actions/ci-common/action.yml
@@ -29,7 +29,8 @@ runs:
       id: wasmtime_version
       shell: bash
       run: |
-        VERSION=$(cargo metadata --format-version=1 --locked | jq '.packages[] | select(.name == "wasmtime") | .version' -r)
+        VERSION=$(cargo metadata --format-version=1 --locked \
+          | jq -r '.workspace_members as $ws | (.packages|map({(.id):.version})|add) as $ver | [ .resolve.nodes[] | select(.id as $id | $ws|index($id)) | .deps[] | select(.name=="wasmtime") | .pkg ] | map($ver[.]) | unique | first')
         echo "wasmtime_version=$VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Install wasmtime-cli

--- a/.github/workflows/ci-npm-javy.yml
+++ b/.github/workflows/ci-npm-javy.yml
@@ -17,7 +17,8 @@ jobs:
         id: wasmtime_version
         shell: bash
         run: |
-          VERSION=$(cargo metadata --format-version=1 --locked | jq '.packages[] | select(.name == "wasmtime") | .version' -r)
+          VERSION=$(cargo metadata --format-version=1 --locked \
+            | jq -r '.workspace_members as $ws | (.packages|map({(.id):.version})|add) as $ver | [ .resolve.nodes[] | select(.id as $id | $ws|index($id)) | .deps[] | select(.name=="wasmtime") | .pkg ] | map($ver[.]) | unique | first')
           echo "wasmtime_version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install wasmtime-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build test plugins
         run: make build-test-plugins
 
+      - name: Build feature assets
+        run: make build-all-feature-assets
+
       - name: Upload plugins
         uses: actions/upload-artifact@v7
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,15 @@ version = 4
 
 [[package]]
 name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli 0.32.3",
+]
+
+[[package]]
+name = "addr2line"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9698bf0769c641b18618039fe2ebd41eb3541f98433000f64e663fab7cea2c87"
@@ -321,7 +330,7 @@ checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "rustix",
+ "rustix 1.1.4",
  "smallvec",
 ]
 
@@ -337,10 +346,20 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix",
+ "rustix 1.1.4",
  "rustix-linux-procfs",
  "windows-sys 0.59.0",
  "winx",
+]
+
+[[package]]
+name = "cap-rand"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
+dependencies = [
+ "ambient-authority",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -352,7 +371,7 @@ dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -365,7 +384,7 @@ dependencies = [
  "cap-primitives",
  "iana-time-zone",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "winx",
 ]
 
@@ -495,6 +514,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1dd95b5ebb5c1c54581dd6346f3ed6a79a3eef95dd372fc2ac13d535535300e"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,11 +604,29 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c088d3406f0c0252efa7445adfd2d05736bfb5218838f64eaf79d567077aed14"
+dependencies = [
+ "cranelift-assembler-x64-meta 0.125.4",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
 version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c80cf55a351448317210f26c434be761bcb25e7b36116ec92f89540b73e2833"
 dependencies = [
- "cranelift-assembler-x64-meta",
+ "cranelift-assembler-x64-meta 0.132.0",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c03f887a763abb9c1dc08f722aa82b69067fda623b6f0273050f45f8b1a6776"
+dependencies = [
+ "cranelift-srcgen 0.125.4",
 ]
 
 [[package]]
@@ -588,7 +635,16 @@ version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07937ca8617b340162fe3a4716be885b5847e9b56d6c7a89abbe4d42340fdc91"
 dependencies = [
- "cranelift-srcgen",
+ "cranelift-srcgen 0.132.0",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206887a11a43f507fee320a218dc365980bfc42ec2696792079a9f8c9369e90"
+dependencies = [
+ "cranelift-entity 0.125.4",
 ]
 
 [[package]]
@@ -597,8 +653,18 @@ version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88217b08180882436d54c0133274885c590698ae854e352bede1cda041230800"
 dependencies = [
- "cranelift-entity",
+ "cranelift-entity 0.132.0",
  "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac0790c83cfdab95709c5d0105fd888221e3af9049a7d7ec376ec901ab4e4dba"
+dependencies = [
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -614,25 +680,52 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a98aed2d262eda69310e84bae8e053ee4f17dbdd3347b8d9156aa618ba2de0a"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64 0.125.4",
+ "cranelift-bforest 0.125.4",
+ "cranelift-bitset 0.125.4",
+ "cranelift-codegen-meta 0.125.4",
+ "cranelift-codegen-shared 0.125.4",
+ "cranelift-control 0.125.4",
+ "cranelift-entity 0.125.4",
+ "cranelift-isle 0.125.4",
+ "gimli 0.32.3",
+ "hashbrown 0.15.5",
+ "log",
+ "pulley-interpreter 38.0.4",
+ "regalloc2 0.13.5",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "cranelift-codegen"
 version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe1aac2efd4cba2047845fce38a68519935a30e20c8a6294ba7e2f448fe722d"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-isle",
+ "cranelift-assembler-x64 0.132.0",
+ "cranelift-bforest 0.132.0",
+ "cranelift-bitset 0.132.0",
+ "cranelift-codegen-meta 0.132.0",
+ "cranelift-codegen-shared 0.132.0",
+ "cranelift-control 0.132.0",
+ "cranelift-entity 0.132.0",
+ "cranelift-isle 0.132.0",
  "gimli 0.33.0",
  "hashbrown 0.17.0",
  "libm",
  "log",
- "pulley-interpreter",
- "regalloc2",
+ "pulley-interpreter 45.0.0",
+ "regalloc2 0.15.1",
  "rustc-hash",
  "serde",
  "smallvec",
@@ -642,22 +735,50 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6906852826988563e9b0a9232ad951f53a47aa41ffd02f8ac852d3f41aae836a"
+dependencies = [
+ "cranelift-assembler-x64-meta 0.125.4",
+ "cranelift-codegen-shared 0.125.4",
+ "cranelift-srcgen 0.125.4",
+ "heck 0.5.0",
+ "pulley-interpreter 38.0.4",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
 version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0909eaf9d6f18f5bf802d50608cb4368ac340fbd03cc44f2888d1cfcc3faa64e"
 dependencies = [
- "cranelift-assembler-x64-meta",
- "cranelift-codegen-shared",
- "cranelift-srcgen",
+ "cranelift-assembler-x64-meta 0.132.0",
+ "cranelift-codegen-shared 0.132.0",
+ "cranelift-srcgen 0.132.0",
  "heck 0.5.0",
- "pulley-interpreter",
+ "pulley-interpreter 45.0.0",
 ]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a50105aab667b5cc845f2be37c78475d7cc127cd8ec0a31f7b2b71d526099a7"
 
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c95a8da8be283f49cda7d0ef228c94f10d791e517b27b0c7e282dadd2e79ce45"
+
+[[package]]
+name = "cranelift-control"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6adcc7aa7c0bc1727176a6f2d99c28a9e79a541ccd5ca911a0cb352da8befa36"
+dependencies = [
+ "arbitrary",
+]
 
 [[package]]
 name = "cranelift-control"
@@ -670,14 +791,37 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "981b56af777f9a34ea6dcce93255125776d391410c2a68b75bed5941b714fa15"
+dependencies = [
+ "cranelift-bitset 0.125.4",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-entity"
 version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a55309b47e6633ab05821304206cb1e92952e845b1224985562bb7ac1e92323"
 dependencies = [
- "cranelift-bitset",
+ "cranelift-bitset 0.132.0",
  "serde",
  "serde_derive",
  "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea982589684dfb71afecb9fc09555c3a266300a1162a60d7fa39d41a5705b1c"
+dependencies = [
+ "cranelift-codegen 0.125.4",
+ "log",
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -686,11 +830,17 @@ version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064d2d3533d9608f1cf44c8899cf2f7f33feb70300b0fb83e687b0d9e7b91147"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.132.0",
  "log",
  "smallvec",
  "target-lexicon",
 ]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0422686b22ed6a1f33cc40e3c43eb84b67155788568d1a5cac8439d3dca1783"
 
 [[package]]
 name = "cranelift-isle"
@@ -700,14 +850,31 @@ checksum = "1ac4e0bc095b2dab2212d1e99d7a74b62afc1485db023f1c0cb34a68758f7bd1"
 
 [[package]]
 name = "cranelift-native"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f697bbbe135c655ea1deb7af0bae4a5c4fae2c88fdfc0fa57b34ae58c91040"
+dependencies = [
+ "cranelift-codegen 0.125.4",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-native"
 version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a40053f5cb925451dd1d57393d14ad3145c8e0786701c27b5415ebb9a3ba4f"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.132.0",
  "libc",
  "target-lexicon",
 ]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.125.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718efe674f3df645462677e22a3128e890d88ba55821bb091083d257707be76c"
 
 [[package]]
 name = "cranelift-srcgen"
@@ -915,7 +1082,7 @@ dependencies = [
  "rand_core 0.10.1",
  "rand_pcg",
  "wasi",
- "wasmtime",
+ "wasmtime 45.0.0",
  "wasmtime-wasi",
 ]
 
@@ -1012,6 +1179,19 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
@@ -1047,6 +1227,17 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1113,7 +1304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1305,6 +1496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
+ "serde",
 ]
 
 [[package]]
@@ -1362,6 +1554,12 @@ dependencies = [
  "serde",
  "triomphe",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "iana-time-zone"
@@ -1566,6 +1764,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +1851,7 @@ dependencies = [
  "clap",
  "javy-codegen",
  "javy-plugin-processing",
+ "javy-profiler",
  "javy-runner",
  "javy-test-macros",
  "serde",
@@ -1649,7 +1859,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "walrus",
- "wasmtime",
+ "wasmtime 45.0.0",
  "wasmtime-wasi",
  "wit-component 0.248.0",
 ]
@@ -1670,7 +1880,7 @@ dependencies = [
  "wasm-opt",
  "wasmparser 0.248.0",
  "wasmprinter 0.246.2",
- "wasmtime",
+ "wasmtime 45.0.0",
  "wasmtime-wasi",
  "wasmtime-wizer",
  "wit-parser 0.248.0",
@@ -1717,9 +1927,21 @@ dependencies = [
  "walrus",
  "wasm-opt",
  "wasmparser 0.248.0",
- "wasmtime",
+ "wasmtime 45.0.0",
  "wasmtime-wasi",
  "wasmtime-wizer",
+]
+
+[[package]]
+name = "javy-profiler"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "javy-profiler-lib",
+ "wasmtime 45.0.0",
+ "wasmtime-wasi",
+ "wasmtime-wizer",
+ "whamm",
 ]
 
 [[package]]
@@ -1739,7 +1961,7 @@ dependencies = [
  "chrono",
  "regex",
  "tempfile",
- "toml_edit",
+ "toml_edit 0.23.7",
 ]
 
 [[package]]
@@ -1750,7 +1972,7 @@ dependencies = [
  "tempfile",
  "uuid",
  "wasmparser 0.248.0",
- "wasmtime",
+ "wasmtime 45.0.0",
  "wasmtime-wasi",
 ]
 
@@ -1804,6 +2026,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
@@ -1860,6 +2088,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1867,6 +2105,12 @@ checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1924,7 +2168,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -2001,6 +2245,18 @@ dependencies = [
 
 [[package]]
 name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "object"
 version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
@@ -2049,6 +2305,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -2142,6 +2441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,7 +2465,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.7",
 ]
 
 [[package]]
@@ -2171,14 +2479,37 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beafc309a2d35e16cc390644d88d14dfa45e45e15075ec6a9e37f6dfb43e926f"
+dependencies = [
+ "cranelift-bitset 0.125.4",
+ "log",
+ "pulley-macros 38.0.4",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-interpreter"
 version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9204ad9435f2a6fe3bd13bba52389fb8488fa20ba497e35c5d2db638166019d"
 dependencies = [
- "cranelift-bitset",
+ "cranelift-bitset 0.132.0",
  "log",
- "pulley-macros",
+ "pulley-macros 45.0.0",
  "wasmtime-internal-core",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885fbb6c07454cfc8725a18a1da3cfc328ee8c53fb8d0671ea313edc8567947"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2198,7 +2529,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
 dependencies = [
- "env_logger",
+ "env_logger 0.11.9",
  "log",
  "rand 0.10.1",
 ]
@@ -2230,6 +2561,8 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
@@ -2245,10 +2578,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "rand_core"
@@ -2314,6 +2660,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -2390,6 +2750,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
+
+[[package]]
 name = "rquickjs"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,6 +2827,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2468,7 +2847,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2479,7 +2858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -2576,11 +2955,35 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
 ]
 
 [[package]]
@@ -2965,6 +3368,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-interface"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
+dependencies = [
+ "bitflags",
+ "cap-fs-ext",
+ "cap-std",
+ "fd-lock",
+ "io-lifetimes",
+ "rustix 0.38.44",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2985,7 +3404,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3076,17 +3495,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.0.3",
+ "toml_datetime 0.7.3",
  "toml_parser",
  "toml_writer",
  "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3100,12 +3540,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.3",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -3121,6 +3575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "toml_writer"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3132,6 +3592,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3172,6 +3633,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-id-start"
@@ -3322,6 +3789,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi-common"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7178030744403adba447b07cd5c1d683e4b01c5521dd96e14d082f3ed2c1f29c"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "cap-fs-ext",
+ "cap-rand",
+ "cap-std",
+ "cap-time-ext",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "log",
+ "rustix 1.1.4",
+ "system-interface",
+ "thiserror 2.0.17",
+ "tracing",
+ "wasmtime 38.0.4",
+ "wiggle 38.0.4",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3399,6 +3891,16 @@ dependencies = [
  "wasm-encoder 0.248.0",
  "wasmparser 0.248.0",
  "wat",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.239.0",
 ]
 
 [[package]]
@@ -3529,6 +4031,19 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
@@ -3573,6 +4088,7 @@ dependencies = [
  "hashbrown 0.17.0",
  "indexmap",
  "semver",
+ "serde",
 ]
 
 [[package]]
@@ -3601,6 +4117,17 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3981f3d51f39f24f5fc90f93049a90f08dbbca8deba602cd46bb8ca67a94718"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.239.0",
+]
+
+[[package]]
+name = "wasmprinter"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e41f7493ba994b8a779430a4c25ff550fd5a40d291693af43a6ef48688f00e3"
@@ -3623,11 +4150,65 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81eafc07c867be94c47e0dc66355d9785e09107a18901f76a20701ba0663ad7"
+dependencies = [
+ "addr2line 0.25.1",
+ "anyhow",
+ "async-trait",
+ "bitflags",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "fxprof-processed-profile",
+ "gimli 0.32.3",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "ittapi",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object 0.37.3",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter 38.0.4",
+ "rayon",
+ "rustix 1.1.4",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.239.0",
+ "wasmparser 0.239.0",
+ "wasmtime-environ 38.0.4",
+ "wasmtime-internal-cache 38.0.4",
+ "wasmtime-internal-component-macro 38.0.4",
+ "wasmtime-internal-component-util 38.0.4",
+ "wasmtime-internal-cranelift 38.0.4",
+ "wasmtime-internal-fiber 38.0.4",
+ "wasmtime-internal-jit-debug 38.0.4",
+ "wasmtime-internal-jit-icache-coherence 38.0.4",
+ "wasmtime-internal-math",
+ "wasmtime-internal-slab",
+ "wasmtime-internal-unwinder 38.0.4",
+ "wasmtime-internal-versioned-export-macros 38.0.4",
+ "wasmtime-internal-winch 38.0.4",
+ "wat",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime"
 version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d35aec1e932d00a7c941f816ad589e65ad8db948b9e971bf8ec655a1669f1f67"
 dependencies = [
- "addr2line",
+ "addr2line 0.26.0",
  "async-trait",
  "bitflags",
  "bumpalo",
@@ -3642,12 +4223,12 @@ dependencies = [
  "log",
  "mach2",
  "memfd",
- "object",
+ "object 0.39.1",
  "once_cell",
  "postcard",
- "pulley-interpreter",
+ "pulley-interpreter 45.0.0",
  "rayon",
- "rustix",
+ "rustix 1.1.4",
  "semver",
  "serde",
  "serde_derive",
@@ -3658,20 +4239,47 @@ dependencies = [
  "wasm-compose",
  "wasm-encoder 0.248.0",
  "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-cache",
- "wasmtime-internal-component-macro",
- "wasmtime-internal-component-util",
+ "wasmtime-environ 45.0.0",
+ "wasmtime-internal-cache 45.0.0",
+ "wasmtime-internal-component-macro 45.0.0",
+ "wasmtime-internal-component-util 45.0.0",
  "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-fiber",
- "wasmtime-internal-jit-debug",
- "wasmtime-internal-jit-icache-coherence",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
+ "wasmtime-internal-cranelift 45.0.0",
+ "wasmtime-internal-fiber 45.0.0",
+ "wasmtime-internal-jit-debug 45.0.0",
+ "wasmtime-internal-jit-icache-coherence 45.0.0",
+ "wasmtime-internal-unwinder 45.0.0",
+ "wasmtime-internal-versioned-export-macros 45.0.0",
+ "wasmtime-internal-winch 45.0.0",
  "wat",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78587abe085a44a13c90fa16fea6db014e9883e627a7044d7f0cb397ad08d1da"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bitset 0.125.4",
+ "cranelift-entity 0.125.4",
+ "gimli 0.32.3",
+ "indexmap",
+ "log",
+ "object 0.37.3",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.239.0",
+ "wasmparser 0.239.0",
+ "wasmprinter 0.239.0",
+ "wasmtime-internal-component-util 38.0.4",
 ]
 
 [[package]]
@@ -3682,14 +4290,14 @@ checksum = "d7da3dcce82a7e784121c19c8c9c5f69a743088264ff5212033e4a1f1b9dfaaf"
 dependencies = [
  "anyhow",
  "cpp_demangle",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-entity",
+ "cranelift-bforest 0.132.0",
+ "cranelift-bitset 0.132.0",
+ "cranelift-entity 0.132.0",
  "gimli 0.33.0",
  "hashbrown 0.17.0",
  "indexmap",
  "log",
- "object",
+ "object 0.39.1",
  "postcard",
  "rustc-demangle",
  "semver",
@@ -3701,8 +4309,28 @@ dependencies = [
  "wasm-encoder 0.248.0",
  "wasmparser 0.248.0",
  "wasmprinter 0.248.0",
- "wasmtime-internal-component-util",
+ "wasmtime-internal-component-util 45.0.0",
  "wasmtime-internal-core",
+]
+
+[[package]]
+name = "wasmtime-internal-cache"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78fb9299e318b0af3efb75d88321515a20a5ccb040bcde1f0f7d46d656fa8fef"
+dependencies = [
+ "anyhow",
+ "base64",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix 1.1.4",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "toml 0.8.23",
+ "windows-sys 0.60.2",
+ "zstd",
 ]
 
 [[package]]
@@ -3715,14 +4343,29 @@ dependencies = [
  "directories-next",
  "log",
  "postcard",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_derive",
  "sha2",
- "toml",
- "wasmtime-environ",
+ "toml 0.9.8",
+ "wasmtime-environ 45.0.0",
  "windows-sys 0.61.2",
  "zstd",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d843bb444f2d1509ea9304ad749242d1fa5de95cde67665bfcdcafa0f360925c"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasmtime-internal-component-util 38.0.4",
+ "wasmtime-internal-wit-bindgen 38.0.4",
+ "wit-parser 0.239.0",
 ]
 
 [[package]]
@@ -3735,10 +4378,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wasmtime-internal-component-util",
- "wasmtime-internal-wit-bindgen",
+ "wasmtime-internal-component-util 45.0.0",
+ "wasmtime-internal-wit-bindgen 45.0.0",
  "wit-parser 0.248.0",
 ]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801ee1a80ab66f065a88c6a62f2d495d5540d027b366757c6a53e9c42f153aef"
 
 [[package]]
 name = "wasmtime-internal-component-util"
@@ -3760,29 +4409,72 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb50f1c50365c32e557266ca85acdf77696c44a3f98797ba6af58cebc6d6d1e"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen 0.125.4",
+ "cranelift-control 0.125.4",
+ "cranelift-entity 0.125.4",
+ "cranelift-frontend 0.125.4",
+ "cranelift-native 0.125.4",
+ "gimli 0.32.3",
+ "itertools 0.14.0",
+ "log",
+ "object 0.37.3",
+ "pulley-interpreter 38.0.4",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.17",
+ "wasmparser 0.239.0",
+ "wasmtime-environ 38.0.4",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder 38.0.4",
+ "wasmtime-internal-versioned-export-macros 38.0.4",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
 version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5773b36b87566239b020f1d01aa753a35626df85030485e40e36fc42a97acf4f"
 dependencies = [
  "cfg-if",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
+ "cranelift-codegen 0.132.0",
+ "cranelift-control 0.132.0",
+ "cranelift-entity 0.132.0",
+ "cranelift-frontend 0.132.0",
+ "cranelift-native 0.132.0",
  "gimli 0.33.0",
  "itertools 0.14.0",
  "log",
- "object",
- "pulley-interpreter",
+ "object 0.39.1",
+ "pulley-interpreter 45.0.0",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.17",
  "wasmparser 0.248.0",
- "wasmtime-environ",
+ "wasmtime-environ 45.0.0",
  "wasmtime-internal-core",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-unwinder 45.0.0",
+ "wasmtime-internal-versioned-export-macros 45.0.0",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9308cdb17f8d51e3164185616d809e28c29a6515c03b9dd95c89436b71f6d154"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.1.4",
+ "wasmtime-internal-versioned-export-macros 38.0.4",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3794,10 +4486,22 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "rustix",
- "wasmtime-environ",
- "wasmtime-internal-versioned-export-macros",
+ "rustix 1.1.4",
+ "wasmtime-environ 45.0.0",
+ "wasmtime-internal-versioned-export-macros 45.0.0",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9b63a22bf2a8b6a149a41c6768bc17a8b2e3288a249cb8216987fbd7128e81"
+dependencies = [
+ "cc",
+ "object 0.37.3",
+ "rustix 1.1.4",
+ "wasmtime-internal-versioned-export-macros 38.0.4",
 ]
 
 [[package]]
@@ -3807,9 +4511,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b426a5d0ec9c11a1a4525ed4e973b7caf40223b6d392588bb9f6468e4ae9d29"
 dependencies = [
  "cc",
- "object",
- "rustix",
- "wasmtime-internal-versioned-export-macros",
+ "object 0.39.1",
+ "rustix 1.1.4",
+ "wasmtime-internal-versioned-export-macros 45.0.0",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb8e042b6e3de2f3d708279f89f50b4b9aa1b9bab177300cdffb0ffcd2816df5"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3825,16 +4541,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-internal-math"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1f0674f38cd7d014eb1a49ea1d1766cca1a64459e8856ee118a10005302e16"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-slab"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb24b7535306713e7a250f8b71e35f05b6a5031bf9c3ed7330c308e899cbe7d3"
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d5a80e2623a49cb8e8c419542337b8fe0260b162c40dcc201080a84cbe9b7c"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen 0.125.4",
+ "log",
+ "object 0.37.3",
+]
+
+[[package]]
 name = "wasmtime-internal-unwinder"
 version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a62ad422ee3cbf1e87c2242dc0717a01c7a5878fbc3a68abc4b4d2fff3e85e1"
 dependencies = [
  "cfg-if",
- "cranelift-codegen",
+ "cranelift-codegen 0.132.0",
  "log",
- "object",
- "wasmtime-environ",
+ "object 0.39.1",
+ "wasmtime-environ 45.0.0",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e277f734b9256359b21517c3b0c26a2a9de6c53a51b670ae55cdcde548bf4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3850,19 +4605,50 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4dc9333737142f6ece4369c8bcdda03a11edbd43d8fbd3e15004c194b9b743"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen 0.125.4",
+ "gimli 0.32.3",
+ "log",
+ "object 0.37.3",
+ "target-lexicon",
+ "wasmparser 0.239.0",
+ "wasmtime-environ 38.0.4",
+ "wasmtime-internal-cranelift 38.0.4",
+ "winch-codegen 38.0.4",
+]
+
+[[package]]
+name = "wasmtime-internal-winch"
 version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2aceb92b48b6e3a5cc2a05ab7a2dcb565eaf86fb870d04664b7f12cf9bba39a"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.132.0",
  "gimli 0.33.0",
  "log",
- "object",
+ "object 0.39.1",
  "target-lexicon",
  "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
+ "wasmtime-environ 45.0.0",
+ "wasmtime-internal-cranelift 45.0.0",
+ "winch-codegen 45.0.0",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f758625553fe33fdce0713f63bb7784c4f5fecb7f7cd4813414519ec24b6a4c"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "heck 0.5.0",
+ "indexmap",
+ "wit-parser 0.239.0",
 ]
 
 [[package]]
@@ -3897,14 +4683,14 @@ dependencies = [
  "io-extras",
  "io-lifetimes",
  "rand 0.10.1",
- "rustix",
+ "rustix 1.1.4",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
  "url",
- "wasmtime",
+ "wasmtime 45.0.0",
  "wasmtime-wasi-io",
- "wiggle",
+ "wiggle 45.0.0",
  "windows-sys 0.61.2",
 ]
 
@@ -3918,7 +4704,7 @@ dependencies = [
  "bytes",
  "futures",
  "tracing",
- "wasmtime",
+ "wasmtime 45.0.0",
 ]
 
 [[package]]
@@ -3931,7 +4717,7 @@ dependencies = [
  "rayon",
  "wasm-encoder 0.248.0",
  "wasmparser 0.248.0",
- "wasmtime",
+ "wasmtime 45.0.0",
 ]
 
 [[package]]
@@ -3966,6 +4752,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "whamm"
+version = "1.0.0-rc1"
+source = "git+https://github.com/saulecabrera/whamm?branch=binary-entrypoints#666984d3465ae8b981db2f46a1e38f8b843d02b4"
+dependencies = [
+ "anyhow",
+ "clap",
+ "clap_mangen",
+ "env_logger 0.10.2",
+ "glob",
+ "indexmap",
+ "itertools 0.14.0",
+ "lazy_static",
+ "log",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_yml",
+ "termcolor",
+ "wasi-common",
+ "wasmtime 38.0.4",
+ "wat",
+ "wirm",
+]
+
+[[package]]
+name = "wiggle"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9ee0c6dd73bdf0aff4404059bdc24ca61ad92056d20f4e59b8b0780789cafb4"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags",
+ "thiserror 2.0.17",
+ "tracing",
+ "wasmtime 38.0.4",
+ "wiggle-macro 38.0.4",
+]
+
+[[package]]
 name = "wiggle"
 version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3974,9 +4800,23 @@ dependencies = [
  "bitflags",
  "thiserror 2.0.17",
  "tracing",
- "wasmtime",
- "wasmtime-environ",
- "wiggle-macro",
+ "wasmtime 45.0.0",
+ "wasmtime-environ 45.0.0",
+ "wiggle-macro 45.0.0",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e415549583fd492ccab881076fa5c41590362d3b5e99df793f619d67333c97b"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "witx",
 ]
 
 [[package]]
@@ -3989,8 +4829,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wasmtime-environ",
+ "wasmtime-environ 45.0.0",
  "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a533b4fdc593bf9c4bf52ae0b3a126f15babfb25fce03bfe0bcc84e1172222"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wiggle-generate 38.0.4",
 ]
 
 [[package]]
@@ -4002,7 +4854,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wiggle-generate",
+ "wiggle-generate 45.0.0",
 ]
 
 [[package]]
@@ -4038,21 +4890,41 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
+version = "38.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c0bb17ae9bf89ebc74512150e6ee0a27b1eac5ff3b54d8cec264f4b4255022d"
+dependencies = [
+ "anyhow",
+ "cranelift-assembler-x64 0.125.4",
+ "cranelift-codegen 0.125.4",
+ "gimli 0.32.3",
+ "regalloc2 0.13.5",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.17",
+ "wasmparser 0.239.0",
+ "wasmtime-environ 38.0.4",
+ "wasmtime-internal-cranelift 38.0.4",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "winch-codegen"
 version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3128bd53313b132e8737d7d318edbc438bab1abe525ac037bbf9857839e717e2"
 dependencies = [
- "cranelift-assembler-x64",
- "cranelift-codegen",
+ "cranelift-assembler-x64 0.132.0",
+ "cranelift-codegen 0.132.0",
  "gimli 0.33.0",
- "regalloc2",
+ "regalloc2 0.15.1",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.17",
  "wasmparser 0.248.0",
- "wasmtime-environ",
+ "wasmtime-environ 45.0.0",
  "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
+ "wasmtime-internal-cranelift 45.0.0",
 ]
 
 [[package]]
@@ -4290,6 +5162,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wirm"
+version = "4.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3398cfb47e9ac60f209294450b58f9577ba3019e299da09e9b1efeeba726930a"
+dependencies = [
+ "log",
+ "paste",
+ "wasm-encoder 0.247.0",
+ "wasmparser 0.247.0",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4454,6 +5338,24 @@ dependencies = [
  "wasm-metadata 0.248.0",
  "wasmparser 0.248.0",
  "wit-parser 0.248.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c92c939d667b7bf0c6bf2d1f67196529758f99a2a45a3355cc56964fd5315d"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.239.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "fuzz",
   "release",
   "crates/profiler-lib",
+  "crates/profiler",
 ]
 resolver = "2"
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 	test-wasi-targets test-wasip1-targets test-wasip2-targets wasi-targets \
 	lint-native-targets lint-native-targets-ci test-native-targets \
 	test-native-targets-ci native-targets test-wpt test-wpt-ci test-all \
-	clean cli build-default-plugin build-test-plugins ci
+	clean cli build-default-plugin build-requested-feature-assets \
+	build-all-feature-assets build-test-plugins ci
 .DEFAULT_GOAL := cli
 
 # Selection for linting / testing.
@@ -41,6 +42,33 @@ WASIP1_TEST_CRATES := $(call select_crates_for,wasip1,test)
 WASIP2_LINT_CRATES := $(call select_crates_for,wasip2,lint)
 WASIP2_TEST_CRATES := $(call select_crates_for,wasip2,test)
 
+# Building optional feature assets
+#
+# In stable Rust, it is impossible to specify binary dependencies (see
+# https://rust-lang.github.io/rfcs/3028-cargo-binary-dependencies.html).
+# This function queries through the CLI metadata, the command(s)
+# needed to build asset dependencies belonging to any of the specified
+# features, e.g.,
+#
+#     make cli features=profiler
+#
+# it will retrive `cargo build -p javy-profiler-lib
+# --target=wasm32-wasip1 --release` as defined the CLI's Cargo.toml
+define feature_asset_cmds
+$(shell cargo metadata --format-version=1 --no-deps | jq -r \
+  --arg feats "$(1)" '\
+    .packages[] \
+    | select(.name == "javy-cli") \
+    | (.metadata.javy."feature-assets" // {}) as $$m \
+    | ($$feats | gsub(","; " ") | split(" ") | map(select(length > 0))) as $$req \
+    | [ $$m | to_entries[] \
+        | select($$feats == "all" or (.key as $$k | $$req | index($$k))) \
+        | .value | if type == "array" then .[] else . end ] \
+    | join(" && ")')
+endef
+
+cargo_features = $(if $(strip $(features)),--features "$(features)")
+
 # === Format checks ===
 fmt-check:
 	cargo fmt --all --check
@@ -71,13 +99,13 @@ test-wasip2-targets:
 wasi-targets: lint-wasi-targets test-wasi-targets
 
 # === Lint & Test Native Targets ===
-lint-native-targets: build-default-plugin lint-native-targets-ci
+lint-native-targets: build-default-plugin build-all-feature-assets lint-native-targets-ci
 
 lint-native-targets-ci: fmt-check
 	CARGO_PROFILE_RELEASE_LTO=off cargo clippy $(NATIVE_LINT_CRATES) \
 	--release --all-targets --all-features -- -D warnings
 
-test-native-targets: build-default-plugin build-test-plugins test-native-targets-ci
+test-native-targets: build-default-plugin build-all-feature-assets build-test-plugins test-native-targets-ci
 
 # This command assumes a CI environment in which the test plugin
 # assets have been previously created in the expected directories.
@@ -115,12 +143,24 @@ ci: lint-wasi-targets lint-native-targets test-all
 # First, build the default plugin, which is a dependency to the CLI.
 # No need to run `javy_plugin_processing`, the CLI build.rs will take
 # care of doing that.
-cli: build-default-plugin
-	CARGO_PROFILE_RELEASE_LTO=off cargo build -p=javy-cli --release
+#
+# Any optional features are excluded from the default build;
+# use `make cli features=<list>` to enable them.
+cli: build-default-plugin build-requested-feature-assets
+	CARGO_PROFILE_RELEASE_LTO=off cargo build -p=javy-cli --release $(cargo_features)
 
 # Build the default plugin
 build-default-plugin:
 	cargo build -p=javy-plugin --target=wasm32-wasip1 --release
+
+# Build the assets for the requested features via `features=<list>`.
+build-requested-feature-assets:
+	$(call feature_asset_cmds,$(features))
+
+# Build all feature assets, this is useful for testing/liting since
+# all features will be enabled.
+build-all-feature-assets:
+	$(call feature_asset_cmds,all)
 
 # Build auxiliary plugins, for testing
 build-test-plugins:

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,6 +21,12 @@ serde = { workspace = true, default-features = false }
 serde_json = { workspace = true }
 javy-codegen = { path = "../codegen/", features = ["plugin_internal"] }
 javy-plugin-processing = { path = "../plugin-processing" }
+javy-profiler = { path = "../profiler", optional = true }
+
+[features]
+default = []
+# Experimental support to profile JS execution on WebAssembly.
+profiler = ["dep:javy-profiler"]
 
 [dev-dependencies]
 brotli = { workspace = true }
@@ -34,3 +40,6 @@ anyhow = { workspace = true }
 javy-plugin-processing = { path = "../plugin-processing" }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
+
+[package.metadata.javy.feature-assets]
+profiler = "cargo build -p=javy-profiler-lib --target=wasm32-wasip1 --release"

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -43,6 +43,10 @@ pub enum Command {
     /// Initializes a plugin binary.
     #[command(arg_required_else_help = true)]
     InitPlugin(InitPluginCommandOpts),
+    /// Profiling commands for Javy-generated WebAssembly modules.
+    #[cfg(feature = "profiler")]
+    #[command(arg_required_else_help = true, subcommand)]
+    Profile(crate::profiler::ProfileCommand),
 }
 
 const RUNTIME_CONFIG_ARG_SHORT: char = 'J';

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,6 +2,8 @@ mod commands;
 mod js_config;
 mod option;
 mod plugin;
+#[cfg(feature = "profiler")]
+mod profiler;
 
 use crate::commands::{Cli, Command, EmitPluginCommandOpts};
 use anyhow::Result;
@@ -61,6 +63,8 @@ async fn main() -> Result<()> {
             fs::write(&opts.output, wasm)?;
             Ok(())
         }
+        #[cfg(feature = "profiler")]
+        Command::Profile(cmd) => profiler::run(cmd).await,
         Command::InitPlugin(opts) => {
             let plugin_bytes = fs::read(&opts.plugin)?;
             let uninitialized_plugin = UninitializedPlugin::new(&plugin_bytes)?;

--- a/crates/cli/src/profiler.rs
+++ b/crates/cli/src/profiler.rs
@@ -1,0 +1,46 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Subcommand)]
+pub enum ProfileCommand {
+    /// Instruments a Javy-generated module for profiling JS execution.
+    #[command(arg_required_else_help = true)]
+    Inject(ProfileInjectOpts),
+}
+
+#[derive(Debug, Parser)]
+pub struct ProfileInjectOpts {
+    #[arg(value_name = "INPUT", required = true)]
+    /// Path of the WebAssembly module to instrument.
+    pub input: PathBuf,
+
+    #[arg(short, default_value = "profiled.wasm")]
+    /// Output path of the instrumented WebAssembly output file.
+    /// If no output is given, a `profiled.wasm` will be created
+    /// in the same directory as the input program.
+    pub output: PathBuf,
+}
+
+/// Run the profiling subcommand.
+pub async fn run(cmd: &ProfileCommand) -> Result<()> {
+    match cmd {
+        ProfileCommand::Inject(opts) => inject(opts).await,
+    }
+}
+
+async fn inject(opts: &ProfileInjectOpts) -> Result<()> {
+    let wasm = fs::read(&opts.input)?;
+    let output = javy_profiler::inject(wasm).await?;
+
+    fs::write(&opts.output, &output.instrumented)?;
+
+    let state_lib_path = opts
+        .output
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!("{}.wasm", javy_profiler::LIBRARY_NAME));
+    fs::write(&state_lib_path, &output.state_lib)?;
+    Ok(())
+}

--- a/crates/profiler-lib/Cargo.toml
+++ b/crates/profiler-lib/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [lib]
 name = "javy_profiler_lib"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/profiler-lib/src/lib.rs
+++ b/crates/profiler-lib/src/lib.rs
@@ -2,24 +2,54 @@ mod interpreter;
 mod state;
 
 use state::State;
-use std::sync::LazyLock;
+use std::io::Read;
+use std::sync::OnceLock;
 
-// TODO: Passing empty bytes is temporary. Whamm currently does not
-//       offer a mechanism to pass in the target application bytes.
-//       Prior to hooking the bytes we need to either find the best
-//       way to accomplish that in Whamm's instrumentation pass or
-//       create a custom pass in Javy, e.g., through Wizer. Ideally we
-//       want the former: arguably, having access to the bytes is
-//       something that other libraries might need.
-static STATE: std::sync::LazyLock<State> =
-    LazyLock::new(|| State::from_bytes(&[]).expect("State initialization to work"));
+static STATE: OnceLock<State> = OnceLock::new();
+
+fn state() -> &'static State {
+    STATE
+        .get()
+        .expect("STATE must be initialized via `wizer.initialize`")
+}
+
+/// Use Wizer to pre-initialize the user library module that will be
+/// passed to Whamm. Note that this is temporary workaround until
+/// Whamm grows such capability (see
+/// https://github.com/ejrgilbert/whamm/issues/325).
+#[unsafe(export_name = "wizer.initialize")]
+pub extern "C" fn wizer_initialize() {
+    let mut bytes = Vec::new();
+    std::io::stdin()
+        .read_to_end(&mut bytes)
+        .expect("read target application bytes from stdin");
+    let state = State::from_bytes(&bytes).expect("State initialization to work");
+    STATE
+        .set(state)
+        .unwrap_or_else(|_| panic!("STATE must only be initialized once"));
+}
+
+/// Import namespace for the user library to be imported by the
+/// monitor script.
+pub static LIBRARY_NAME: &str = "profiler";
+
+const MONITOR_TEMPLATE: &str = include_str!("monitor.mm");
+const LIBRARY_NAME_PLACEHOLDER: &str = "{{LIBRARY_NAME}}";
+
+/// Materialize the bundled whamm monitor script with [`LIBRARY_NAME`]
+/// substituted.
+pub fn monitor() -> Vec<u8> {
+    MONITOR_TEMPLATE
+        .replace(LIBRARY_NAME_PLACEHOLDER, LIBRARY_NAME)
+        .into_bytes()
+}
 
 /// Returns true if the given index corresponds to the dispatch
 /// function according to the heuristics defined in the [`state`]
 /// module.
 #[unsafe(no_mangle)]
-pub extern "C" fn is_dipatch_func(index: u32) -> bool {
-    STATE.is_dispatch_func(index)
+pub extern "C" fn is_dispatch_func(index: u32) -> bool {
+    state().is_dispatch_func(index)
 }
 
 /// Returns true if the given program counter offset is classified as
@@ -27,5 +57,63 @@ pub extern "C" fn is_dipatch_func(index: u32) -> bool {
 /// dispatch.
 #[unsafe(no_mangle)]
 pub extern "C" fn is_dispatch_load(fid: u32, pc: u32) -> bool {
-    STATE.is_dispatch_load(fid, pc)
+    state().is_dispatch_load(fid, pc)
+}
+
+/// Start a new JS function frame.
+#[unsafe(no_mangle)]
+pub extern "C" fn start_func() {
+    todo!()
+}
+
+/// Exit the top most JS function frame.
+#[unsafe(no_mangle)]
+pub extern "C" fn exit_func() {
+    todo!()
+}
+
+/// Set current dispatch function target. i.e., the `br_table` target.
+#[unsafe(no_mangle)]
+pub extern "C" fn set_dispatch_target(_target: u32) {
+    todo!()
+}
+
+/// Set the effective address (i.e., the start address) of the current
+/// function which uniquely identifies it.
+#[unsafe(no_mangle)]
+pub extern "C" fn set_func_addr(_addr: u32) {
+    todo!()
+}
+
+/// Handle the execution of the given opcode.
+#[unsafe(no_mangle)]
+pub extern "C" fn handle_opcode(_pc: u32) {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LIBRARY_NAME, LIBRARY_NAME_PLACEHOLDER, monitor};
+    use anyhow::Result;
+
+    #[test]
+    fn test_user_library_name() -> Result<()> {
+        assert_eq!(LIBRARY_NAME, "profiler");
+        Ok(())
+    }
+
+    #[test]
+    fn monitor_substitutes_all_placeholders() -> Result<()> {
+        let m = monitor();
+        let s = std::str::from_utf8(&m)?;
+        assert!(
+            !s.contains(LIBRARY_NAME_PLACEHOLDER),
+            "monitor() must replace every placeholder"
+        );
+        assert!(
+            s.contains(LIBRARY_NAME),
+            "monitor() must reference LIBRARY_NAME"
+        );
+        Ok(())
+    }
 }

--- a/crates/profiler-lib/src/monitor.mm
+++ b/crates/profiler-lib/src/monitor.mm
@@ -1,0 +1,57 @@
+use {{LIBRARY_NAME}};
+
+// Ensure that we only read the first address of the function
+// bytecode, which serves as the function identifier.
+var expect_first_load: bool;
+
+// True only while executing a handler body, that is the window
+// between a dispatch `br_table` and the next dispatch load. Provides
+// more accurate counting of Wasm-instructions-per-JS-opcode.
+var counting: bool;
+
+wasm:func:entry / @static {{LIBRARY_NAME}}.is_dispatch_func(fid as i32) as bool / {
+    // When entering the dispatch function, track a new JS function frame.
+    {{LIBRARY_NAME}}.start_func();
+    // When entering the dispatch function, we expect the first load later on.
+    expect_first_load = true;
+}
+
+wasm:func:exit / @static {{LIBRARY_NAME}}.is_dispatch_func(fid as i32) as bool / {
+    // When exiting the dispatch function, pop the current JS function frame.
+    {{LIBRARY_NAME}}.exit_func();
+}
+
+wasm:opcode:br_table:before / @static {{LIBRARY_NAME}}.is_dispatch_func(fid as i32) as bool / {
+    // We are in the dispatch loop, so we track the current dispatch target.
+    {{LIBRARY_NAME}}.set_dispatch_target(target as i32);
+    // Entering a handler body for `target`, so we begin counting.
+    counting = true;
+}
+
+wasm:opcode:*load*:before / @static {{LIBRARY_NAME}}.is_dispatch_load(fid as i32, pc as i32) as bool / {
+    // When hitting the dispatch load, stop counting, the current and
+    // following instructions do not belong to any JS opcode handler.
+    counting = false;
+}
+
+wasm:opcode:*load*:before / expect_first_load && @static {{LIBRARY_NAME}}.is_dispatch_load(fid as i32, pc as i32) as bool / {
+    // Set the current function identifier, which is the effective address of the dispatch load.
+    // We no longer care about `expect_first_load`, this probe should
+    // only fire once per JS function invocation.
+    {{LIBRARY_NAME}}.set_func_addr(effective_addr as i32);
+    expect_first_load = false;
+}
+
+wasm:opcode:*:before / @static {{LIBRARY_NAME}}.is_dispatch_func(fid as i32) as bool
+    && counting
+    && opname != "nop"
+    && opname != "drop"
+    && opname != "block"
+    && opname != "loop"
+    && opname != "unreachable"
+    && opname != "return"
+    && opname != "else"
+    && opname != "end" / {
+
+    {{LIBRARY_NAME}}.handle_opcode(pc as i32);
+}

--- a/crates/profiler/Cargo.toml
+++ b/crates/profiler/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "javy-profiler"
+# We do not want to publish this crate. It is only meant to be used by
+# the CLI.
+publish = false
+version = "0.0.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+whamm = { git = "https://github.com/saulecabrera/whamm", branch = "binary-entrypoints" }
+javy-profiler-lib = { path = "../profiler-lib" }
+anyhow = { workspace = true }
+wasmtime = { workspace = true }
+wasmtime-wasi = { workspace = true }
+wasmtime-wizer = { workspace = true, features = ["wasmtime"] }

--- a/crates/profiler/build.rs
+++ b/crates/profiler/build.rs
@@ -1,0 +1,43 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let workspace_root = PathBuf::from(&manifest_dir);
+    let workspace_root = workspace_root
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root");
+    let lib_path = workspace_root.join("target/wasm32-wasip1/release/javy_profiler_lib.wasm");
+
+    println!("cargo:rerun-if-changed={}", lib_path.display());
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR");
+    let dst = Path::new(&out_dir).join("profiler_lib.wasm");
+
+    if lib_path.exists() {
+        fs::copy(&lib_path, &dst).expect("copy profiler_lib.wasm into OUT_DIR");
+        return;
+    }
+
+    // Stub the profiler lib for clippy.
+    if is_clippy() {
+        fs::write(&dst, []).expect("write profiler_lib.wasm stub");
+        println!("cargo:warning=using stubbed profiler_lib.wasm for static analysis purposes...");
+        return;
+    }
+
+    // When building the profiler crate explicitly fail if the
+    // profiler library is not present.
+    panic!(
+        "javy_profiler_lib.wasm not found at {}.\n \
+         Build with make cli features=profiler.",
+        lib_path.display()
+    );
+}
+
+fn is_clippy() -> bool {
+    env::var("CARGO_CFG_FEATURE").as_deref() == Ok("cargo-clippy")
+}

--- a/crates/profiler/src/lib.rs
+++ b/crates/profiler/src/lib.rs
@@ -1,0 +1,69 @@
+//! Javy's profiler entrypoint.
+
+use anyhow::{Result, anyhow};
+use javy_profiler_lib::monitor;
+use wasmtime::{Engine, Linker, Store};
+use wasmtime_wasi::{WasiCtxBuilder, p2::pipe::MemoryInputPipe};
+use wasmtime_wizer::Wizer;
+use whamm::api::instrument::{UserLibs, instrument_with_rewriting};
+
+/// The profiler state library.
+const PROFILER_LIB_MODULE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/profiler_lib.wasm"));
+
+/// Re-export of the profiler library's import namespace.
+pub use javy_profiler_lib::LIBRARY_NAME;
+
+/// The pair of artifacts produced by [`inject`].
+pub struct ProfileOutput {
+    /// The original module rewritten with whamm probes.
+    pub instrumented: Vec<u8>,
+    /// The wizened state library that backs the runtime imports
+    /// injected by whamm.
+    pub state_lib: Vec<u8>,
+}
+
+/// Pre-initialize the profiler state library through wizer.
+async fn preinitialize_state_lib(state_lib: &[u8], app_wasm: &[u8]) -> Result<Vec<u8>> {
+    let engine = Engine::default();
+    let mut builder = WasiCtxBuilder::new();
+    builder
+        .stdin(MemoryInputPipe::new(app_wasm.to_vec()))
+        .inherit_stderr();
+    let wasi = builder.build_p1();
+    let mut store = Store::new(&engine, wasi);
+
+    Ok(Wizer::new()
+        .init_func("wizer.initialize")
+        .run(&mut store, state_lib, async |store, module| {
+            let engine = store.engine();
+            let mut linker = Linker::new(engine);
+            wasmtime_wasi::p1::add_to_linker_async(&mut linker, |cx| cx)?;
+            linker.define_unknown_imports_as_traps(module)?;
+            let instance = linker.instantiate_async(store, module).await?;
+            Ok(instance)
+        })
+        .await?)
+}
+
+/// Rewrite the given WebAssembly module, injecting probes as
+/// WebAssembly instructions as directed by the given monitor script.
+pub async fn inject(wasm: Vec<u8>) -> Result<ProfileOutput> {
+    let initialized_state_lib = preinitialize_state_lib(PROFILER_LIB_MODULE, &wasm).await?;
+
+    let mut user_libs = UserLibs::new();
+    user_libs.insert(
+        LIBRARY_NAME.to_string(),
+        (None, initialized_state_lib.clone()),
+    );
+
+    let instrumented = instrument_with_rewriting(wasm, monitor(), user_libs, None, None)
+        .map_err(|mut e| {
+            e.report();
+            anyhow!("Instrumentation failed. This is considered a bug. Please report this behavior upstream.")
+        })?;
+
+    Ok(ProfileOutput {
+        instrumented,
+        state_lib: initialized_state_lib,
+    })
+}


### PR DESCRIPTION
This patch is a follow-up to
https://github.com/bytecodealliance/javy/pull/1208.

It marks the initial work to introduce the profiling functionality as described in https://github.com/bytecodealliance/javy/issues/1206.

Concretely, this patch focuses on the Whamm integration:

* Making the necessary changes to the build system to enable building the profiler library that will be consumed by Whamm.
* Adding a new `profile` command and `profile inject` subcommad to the CLI
* Gating this functionality under a feature flag.

Structure wise I tried to make this change as self-contained as possible (see the changes the makefile, and the introduction of the `profiler` feature flag), allowing for an straightforward removal from tree if we ever decide that this feture should not stabilized.


- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
