### PR TITLE
Update to rquickjs 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,6 +570,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1527,8 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -1826,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "7.0.1-alpha.1"
+version = "8.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1870,7 +1881,7 @@ version = "4.0.1-alpha.1"
 dependencies = [
  "anyhow",
  "brotli",
- "convert_case",
+ "convert_case 0.10.0",
  "deterministic-wasi-ctx",
  "insta",
  "swc_core",
@@ -1909,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "6.0.1-alpha.1"
+version = "7.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "javy",
@@ -2757,9 +2768,9 @@ checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
 name = "rquickjs"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a"
+checksum = "c0688f8b0192998cca685adefdfad3483da295fa40a0ec406b4c14ecd729e858"
 dependencies = [
  "rquickjs-core",
  "rquickjs-macro",
@@ -2767,22 +2778,22 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1"
+checksum = "2fee8c5383f0cfda3b980a80ca4520e726e09b593c59562f579daa51b6c20411"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "relative-path",
  "rquickjs-sys",
 ]
 
 [[package]]
 name = "rquickjs-macro"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7106215ff41a5677b104906a13e1a440b880f4b6362b5dc4f3978c267fad2b80"
+checksum = "04e6cf4b6e695b526cb430a6f445d3ccb9908696b99f1c1f8a1480af38bed5e6"
 dependencies = [
- "convert_case",
+ "convert_case 0.11.0",
  "fnv",
  "ident_case",
  "indexmap",
@@ -2795,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-serde"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9382258c8bd1cc5c555887e5e379ab1491ff0287ca68ceb07be39ea561beb23"
+checksum = "04cf0aa631f8d0c5051db35f9f59899c34074d7b6be280c03fd4ce6165d0ed35"
 dependencies = [
  "rquickjs",
  "serde",
@@ -2805,9 +2816,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-sys"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83"
+checksum = "698077537c286a169de8693b216672bcef148bf2e2e112ebf50758c68e9afa09"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wasmtime-wasi = "45"
 wasmtime-wizer = "45"
 wasm-opt = "0.116.1"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "7.0.1-alpha.1" }
+javy = { path = "crates/javy", version = "8.0.0-alpha.1" }
 tempfile = "3.27.0"
 tokio = "1"
 uuid = { version = "1.23", features = ["v4"] }

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -11,7 +11,7 @@ fn test_empty(builder: &mut Builder) -> Result<()> {
     let mut runner = builder.input("empty.js").build()?;
 
     let (_, _, fuel_consumed) = run(&mut runner, vec![]);
-    assert_fuel_consumed_within_threshold(22_448, fuel_consumed);
+    assert_fuel_consumed_within_threshold(18_182, fuel_consumed);
     Ok(())
 }
 
@@ -21,7 +21,7 @@ fn test_identity(builder: &mut Builder) -> Result<()> {
 
     let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 42);
     assert_eq!(42, output);
-    assert_fuel_consumed_within_threshold(46_797, fuel_consumed);
+    assert_fuel_consumed_within_threshold(43_248, fuel_consumed);
     Ok(())
 }
 
@@ -31,7 +31,7 @@ fn test_fib(builder: &mut Builder) -> Result<()> {
 
     let (output, _, fuel_consumed) = run_with_u8s(&mut runner, 5);
     assert_eq!(8, output);
-    assert_fuel_consumed_within_threshold(64_681, fuel_consumed);
+    assert_fuel_consumed_within_threshold(62_358, fuel_consumed);
     Ok(())
 }
 
@@ -81,7 +81,7 @@ fn test_console_log(builder: &mut Builder) -> Result<()> {
     let (output, logs, fuel_consumed) = run(&mut runner, vec![]);
     assert_eq!(b"hello world from console.log\n".to_vec(), output);
     assert_eq!("hello world from console.error\n", logs.as_str());
-    assert_fuel_consumed_within_threshold(34_983, fuel_consumed);
+    assert_fuel_consumed_within_threshold(29_616, fuel_consumed);
     Ok(())
 }
 
@@ -238,7 +238,7 @@ fn test_exported_functions(builder: &mut Builder) -> Result<()> {
         .build()?;
     let (_, logs, fuel_consumed) = run_fn(&mut runner, "foo", vec![]);
     assert_eq!("Hello from top-level\nHello from foo\n", logs);
-    assert_fuel_consumed_within_threshold(59_981, fuel_consumed);
+    assert_fuel_consumed_within_threshold(56_778, fuel_consumed);
     let (_, logs, _) = run_fn(&mut runner, "foo-bar", vec![]);
     assert_eq!("Hello from top-level\nHello from fooBar\n", logs);
     Ok(())
@@ -337,7 +337,7 @@ fn test_exported_default_arrow_fn(builder: &mut Builder) -> Result<()> {
 
     let (_, logs, fuel_consumed) = run_fn(&mut runner, "default", vec![]);
     assert_eq!(logs, "42\n");
-    assert_fuel_consumed_within_threshold(37_298, fuel_consumed);
+    assert_fuel_consumed_within_threshold(32_716, fuel_consumed);
     Ok(())
 }
 
@@ -350,7 +350,7 @@ fn test_exported_default_fn(builder: &mut Builder) -> Result<()> {
         .build()?;
     let (_, logs, fuel_consumed) = run_fn(&mut runner, "default", vec![]);
     assert_eq!(logs, "42\n");
-    assert_fuel_consumed_within_threshold(39_147, fuel_consumed);
+    assert_fuel_consumed_within_threshold(33_868, fuel_consumed);
     Ok(())
 }
 
@@ -359,7 +359,7 @@ fn test_string_normalize(builder: &mut Builder) -> Result<()> {
     let mut runner = builder.input("normalize.js").build()?;
     let (_, logs, fuel_consumed) = run(&mut runner, vec![]);
     assert_eq!(logs, "true\n");
-    assert_fuel_consumed_within_threshold(55_418, fuel_consumed);
+    assert_fuel_consumed_within_threshold(50_886, fuel_consumed);
     Ok(())
 }
 

--- a/crates/codegen/tests/snapshots/integration_test__default_dynamic.snap
+++ b/crates/codegen/tests/snapshots/integration_test__default_dynamic.snap
@@ -6,9 +6,9 @@ expression: wat
   (type (;0;) (func))
   (type (;1;) (func (param i32 i32 i32 i32) (result i32)))
   (type (;2;) (func (param i32 i32 i32 i32 i32)))
-  (import "javy-default-plugin-v3" "cabi_realloc" (func (;0;) (type 1)))
-  (import "javy-default-plugin-v3" "invoke" (func (;1;) (type 2)))
-  (import "javy-default-plugin-v3" "memory" (memory (;0;) 0))
+  (import "javy-default-plugin-v4" "cabi_realloc" (func (;0;) (type 1)))
+  (import "javy-default-plugin-v4" "invoke" (func (;1;) (type 2)))
+  (import "javy-default-plugin-v4" "memory" (memory (;0;) 0))
   (export "_start" (func 4))
   (export "log" (func 2))
   (export "log2" (func 3))
@@ -17,11 +17,11 @@ expression: wat
     i32.const 0
     i32.const 0
     i32.const 1
-    i32.const 396
+    i32.const 403
     call 0
     local.tee 0
     i32.const 0
-    i32.const 396
+    i32.const 403
     memory.init 0
     data.drop 0
     i32.const 0
@@ -35,7 +35,7 @@ expression: wat
     memory.init 1
     data.drop 1
     local.get 0
-    i32.const 396
+    i32.const 403
     i32.const 1
     local.get 1
     i32.const 3
@@ -46,11 +46,11 @@ expression: wat
     i32.const 0
     i32.const 0
     i32.const 1
-    i32.const 396
+    i32.const 403
     call 0
     local.tee 0
     i32.const 0
-    i32.const 396
+    i32.const 403
     memory.init 0
     data.drop 0
     i32.const 0
@@ -64,7 +64,7 @@ expression: wat
     memory.init 2
     data.drop 2
     local.get 0
-    i32.const 396
+    i32.const 403
     i32.const 1
     local.get 1
     i32.const 4
@@ -75,20 +75,20 @@ expression: wat
     i32.const 0
     i32.const 0
     i32.const 1
-    i32.const 396
+    i32.const 403
     call 0
     local.tee 0
     i32.const 0
-    i32.const 396
+    i32.const 403
     memory.init 0
     local.get 0
-    i32.const 396
+    i32.const 403
     i32.const 0
     i32.const 0
     i32.const 0
     call 1
   )
-  (data (;0;) "\15\07\01\18function.mjs\01\06log\01\08log2\01\0econsole\01(Hello from function!\01*Hello from function2!\014Hello from top-level scope\0d\c6\03\00\02\00\00\c8\03\00\01\ca\03\00\00\00\0c \0a\01\a2\01\00\00\00\03\02\02\1f\00\c8\03\00\01\ca\03\01\01\0cC\0a\01\c8\03\00\00\00\03\00\00\13\009\e6\00\00\00C\e4\00\00\00\04\e7\00\00\00$\01\00)\c6\03\01\07\04\03\034\10;function log() {\0a    console.log(\22Hello from function!\22);\0a}\0cC\0a\01\ca\03\00\00\00\03\00\00\13\009\e6\00\00\00C\e4\00\00\00\04\e8\00\00\00$\01\00)\c6\03\05\08\04\03\054\10=function log2() {\0a    console.log(\22Hello from function2!\22);\0a}\08\ec\08\c1\00\e3\c1\01\e4)9\e6\00\00\00C\e4\00\00\00\04\e9\00\00\00$\01\00\0e\06/\c6\03\01\01\06\00\0a\10\004\10\00")
+  (data (;0;) "\1a\1c\e9\e7\b6\07\01\18function.mjs\01\06log\01\08log2\01\0econsole\01(Hello from function!\01*Hello from function2!\014Hello from top-level scope\0d\e4\03\00\02\00\00\e6\03\00\01\e8\03\00\00\00\0c \0a\01\a8\01\00\00\00\03\00\02\02\1f\00\e6\03\00\06\e8\03\01\06\0cC\0a\01\e6\03\00\00\00\03\00\00\00\13\008\f5\00\00\00A\f3\00\00\00\04\f6\00\00\00$\01\00)\e4\03\01\07\04\03\034\10;function log() {\0a    console.log(\22Hello from function!\22);\0a}\0cC\0a\01\e8\03\00\00\00\03\00\00\00\13\008\f5\00\00\00A\f3\00\00\00\04\f7\00\00\00$\01\00)\e4\03\05\08\04\03\054\10=function log2() {\0a    console.log(\22Hello from function2!\22);\0a}\08\f0\08\c5\00\e7\c5\01\e8)8\f5\00\00\00A\f3\00\00\00\04\f8\00\00\00$\01\00\0e\06/\e4\03\01\01\06\00\0a\10\004\10\00")
   (data (;1;) "log")
   (data (;2;) "log2")
   (@producers

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Bumped rquickjs to 0.12.0.
+
+### Removed
+
+- `big_int` on `Config`. `big_int` is enabled unconditionally.
+
 ## [7.0.0] - 2026-03-17
 
 ### Changed

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "7.0.1-alpha.1"
+version = "8.0.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -14,12 +14,12 @@ targets = ["wasip1", "wasip2"]
 
 [dependencies]
 anyhow = { workspace = true }
-rquickjs = { version = "0.11.0", features = [
+rquickjs = { version = "0.12.0", features = [
     "array-buffer",
     "bindgen",
     "disable-assertions",
 ] }
-rquickjs-serde = { version = "0.5.0", optional = true }
+rquickjs-serde = { version = "0.6.1", optional = true }
 serde = { workspace = true, default-features = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 serde-transcode = { version = "1.1", optional = true }

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -19,7 +19,7 @@ bitflags! {
         const MAP_SET = 1 << 6;
         const TYPED_ARRAY  = 1 << 7;
         const PROMISE  = 1 << 8;
-        const BIG_INT = 1 << 9;
+        // Removed 9 representing BIG_INT.
         // Removed 10 and 11 representing BIG_FLOAT and BIG_DECIMAL.
         const OPERATORS = 1 << 12;
         const BIGNUM_EXTENSION = 1 << 13;
@@ -146,12 +146,6 @@ impl Config {
     /// Configures whether the `Promise` instrinsic will be available.
     pub fn promise(&mut self, enable: bool) -> &mut Self {
         self.intrinsics.set(JSIntrinsics::PROMISE, enable);
-        self
-    }
-
-    /// Configures whether supoort for `BigInt` will be available.
-    pub fn big_int(&mut self, enable: bool) -> &mut Self {
-        self.intrinsics.set(JSIntrinsics::BIG_INT, enable);
         self
     }
 

--- a/crates/javy/src/json.rs
+++ b/crates/javy/src/json.rs
@@ -6,9 +6,8 @@ use rquickjs_serde::{de::Deserializer, ser::Serializer};
 pub fn parse<'js>(context: Ctx<'js>, bytes: &mut [u8]) -> Result<Value<'js>> {
     let mut deserializer = simd_json::Deserializer::from_slice(bytes)?;
     let mut serializer = Serializer::from_context(context.clone())?;
-    serde_transcode::transcode(&mut deserializer, &mut serializer)?;
-
-    Ok(serializer.value)
+    let value = serde_transcode::transcode(&mut deserializer, &mut serializer)?;
+    Ok(value)
 }
 
 /// Transcodes a [Value] into a slice of JSON bytes.

--- a/crates/javy/src/messagepack.rs
+++ b/crates/javy/src/messagepack.rs
@@ -11,8 +11,8 @@ use rquickjs_serde::{de::Deserializer, ser::Serializer};
 pub fn transcode_input<'js>(context: Ctx<'js>, bytes: &[u8]) -> Result<Value<'js>> {
     let mut deserializer = rmp_serde::Deserializer::from_read_ref(bytes);
     let mut serializer = Serializer::from_context(context.clone())?;
-    serde_transcode::transcode(&mut deserializer, &mut serializer)?;
-    Ok(serializer.value)
+    let value = serde_transcode::transcode(&mut deserializer, &mut serializer)?;
+    Ok(value)
 }
 
 /// Transcodes a [`JSValueRef`] into a MessagePack encoded byte vector.

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -110,10 +110,6 @@ impl Runtime {
                 unsafe { intrinsic::Promise::add_intrinsic(ctx.as_raw()) }
             }
 
-            if intrinsics.contains(JSIntrinsics::BIG_INT) {
-                unsafe { intrinsic::BigInt::add_intrinsic(ctx.as_raw()) }
-            }
-
             if intrinsics.contains(JSIntrinsics::TEXT_ENCODING) {
                 text_encoding::register(ctx.clone())
                     .expect("registering TextEncoding APIs to succeed");

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Bumped rquickjs to 0.12. If you are using a plugin for dynamic linking, you
+  are strongly encouraged to change the import namespace.
+
+### Removed
+
+- `big_int` on `Config`. `big_int` is enabled unconditionally.
+
 ## [6.0.0] - 2026-03-17
 
 ### Changed

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "6.0.1-alpha.1"
+version = "7.0.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -7,7 +7,7 @@ use crate::shared_config::SharedConfig;
 
 mod shared_config;
 
-import_namespace!("javy-default-plugin-v3");
+import_namespace!("javy-default-plugin-v4");
 
 fn config() -> Config {
     // Read shared config JSON in from stdin.

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -34,7 +34,7 @@ impl Plugin {
             Self::InvalidUser => "invalid-plugin",
             // Could try and derive this but not going to for now since tests
             // will break if it changes.
-            Self::Default | Self::DefaultAsUser => "javy-default-plugin-v3",
+            Self::Default | Self::DefaultAsUser => "javy-default-plugin-v4",
             Self::UserWasiP1 { .. } => "test-plugin-wasip1",
             Self::UserWasiP2 { .. } => "test-plugin-wasip2",
         }

--- a/docs/docs-using-dynamic-linking.md
+++ b/docs/docs-using-dynamic-linking.md
@@ -41,6 +41,6 @@ Run:
 $ echo 'console.log("hello world!");' > my_code.js
 $ javy emit-plugin -o plugin.wasm
 $ javy build -C dynamic -C plugin=plugin.wasm -o my_code.wasm my_code.js
-$ wasmtime run --preload javy-default-plugin-v3=plugin.wasm my_code.wasm
+$ wasmtime run --preload javy-default-plugin-v4=plugin.wasm my_code.wasm
 hello world!
 ```

--- a/docs/docs-using-nodejs.md
+++ b/docs/docs-using-nodejs.md
@@ -158,7 +158,7 @@ async function runJavy(pluginModule, embeddedModule, input) {
       wasi.getImportObject(),
     );
     const instance = await WebAssembly.instantiate(embeddedModule, {
-      "javy-default-plugin-v3": pluginInstance.exports,
+      "javy-default-plugin-v4": pluginInstance.exports,
     });
 
     // Javy plugin is a WASI reactor see https://github.com/WebAssembly/WASI/blob/main/legacy/application-abi.md?plain=1


### PR DESCRIPTION
## Description of the change

Updates rquickjs to 0.12.0. Also bumps the crate and public versions because of QuickJS bytecode changes and removal of one API. Specifically this version of rquickjs always includes `BigInt` support. The `rquickjs-serde` API also changed so I've updated the serializers. The fuel usage has also dropped across a number of test cases.

## Why am I making this change?

It can't be done automatically.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
