### PR TITLE
bump versions in preparation for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "8.0.0-alpha.1"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "8.1.1"
+version = "9.0.0"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "7.0.0-alpha.1"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "javy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "8.1.1"
+version = "9.0.0"
 authors = ["The Javy Project Developers"]
 edition = "2024"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -33,7 +33,7 @@ wasmtime-wasi = "45"
 wasmtime-wizer = "45"
 wasm-opt = "0.116.1"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "8.0.0-alpha.1" }
+javy = { path = "crates/javy", version = "8.0.0" }
 tempfile = "3.27.0"
 tokio = "1"
 uuid = { version = "1.23", features = ["v4"] }

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [8.0.0] - 2026-06-10
+
 ### Changed
 
 - Bumped rquickjs to 0.12.0.

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "8.0.0-alpha.1"
+version = "8.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [7.0.0] - 2026-06-10
+
 ### Changed
 
 - Bumped rquickjs to 0.12. If you are using a plugin for dynamic linking, you

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "7.0.0-alpha.1"
+version = "7.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Bumping the versions for a release.

Note: I did not bump the codegen crate because there were no changes.

## Checklist

- [ ] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [ ] I've updated documentation including crate documentation if necessary.
