### PR TITLE
profiler: Fill in the profiler state functions

### DIFF
--- a/crates/profiler-lib/src/format.rs
+++ b/crates/profiler-lib/src/format.rs
@@ -1,0 +1,127 @@
+//! Binary encoding of the profile report.
+//!
+//! A report is a magic + version header followed by fixed-width,
+//! little-endian records, in the following format:
+//!
+//! ```text
+//! magic   : b"JPRF"   (4 bytes)
+//! version : u8        (== VERSION)
+//! records : u32       (number of records that follow)
+//! record[] :          (16 bytes each, ordered by (func_addr, target))
+//!   func_addr : u32
+//!   target    : u32
+//!   count     : u64
+//! ```
+
+use anyhow::{Result, ensure};
+
+const MAGIC: &[u8; 4] = b"JPRF";
+const VERSION: u8 = 1;
+const HEADER_LEN: usize = MAGIC.len() + size_of::<u8>() + size_of::<u32>();
+const RECORD_LEN: usize = size_of::<u32>() + size_of::<u32>() + size_of::<u64>();
+
+/// A single `(func_addr, target) -> count` report entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Record {
+    /// QuickJS bytecode buffer start address, identifying the JS function.
+    pub func_addr: u32,
+    /// The `br_table` target, i.e. the QuickJS opcode.
+    pub target: u32,
+    /// Total countable Wasm instructions attributed to that opcode.
+    pub count: u64,
+}
+
+/// Serialize `records` into the binary report format.
+pub fn write<I>(records: I) -> Vec<u8>
+where
+    I: ExactSizeIterator<Item = Record>,
+{
+    let mut out = Vec::with_capacity(HEADER_LEN + records.len() * RECORD_LEN);
+    out.extend_from_slice(MAGIC);
+    out.push(VERSION);
+    out.extend_from_slice(&(records.len() as u32).to_le_bytes());
+    for r in records {
+        out.extend_from_slice(&r.func_addr.to_le_bytes());
+        out.extend_from_slice(&r.target.to_le_bytes());
+        out.extend_from_slice(&r.count.to_le_bytes());
+    }
+    out
+}
+
+/// Parse a binary report, validating the magic and version.
+pub fn read(bytes: &[u8]) -> Result<Vec<Record>> {
+    ensure!(bytes.len() >= HEADER_LEN, "report shorter than header");
+    ensure!(&bytes[..MAGIC.len()] == MAGIC, "bad report magic");
+
+    let version = bytes[MAGIC.len()];
+    ensure!(version == VERSION, "unsupported report version {version}");
+
+    let count_off = MAGIC.len() + size_of::<u8>();
+    let count =
+        u32::from_le_bytes(bytes[count_off..count_off + size_of::<u32>()].try_into()?) as usize;
+
+    let body = &bytes[HEADER_LEN..];
+    ensure!(
+        body.len() == count * RECORD_LEN,
+        "report body is {} bytes, expected {} for {count} records",
+        body.len(),
+        count * RECORD_LEN
+    );
+
+    let records = body
+        .chunks_exact(RECORD_LEN)
+        .map(|c| Record {
+            func_addr: u32::from_le_bytes(c[0..4].try_into().unwrap()),
+            target: u32::from_le_bytes(c[4..8].try_into().unwrap()),
+            count: u64::from_le_bytes(c[8..16].try_into().unwrap()),
+        })
+        .collect();
+
+    Ok(records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrips() {
+        let records = vec![
+            Record {
+                func_addr: 0x1000,
+                target: 5,
+                count: 3,
+            },
+            Record {
+                func_addr: 0x1000,
+                target: 7,
+                count: 5,
+            },
+        ];
+        let bytes = write(records.clone().into_iter());
+        assert_eq!(read(&bytes).unwrap(), records);
+    }
+
+    #[test]
+    fn empty_roundtrips() {
+        let bytes = write(std::iter::empty());
+        assert!(read(&bytes).unwrap().is_empty());
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let mut bytes = write(std::iter::empty());
+        bytes[0] = b'X';
+        assert!(read(&bytes).is_err());
+    }
+
+    #[test]
+    fn rejects_truncated_body() {
+        let bytes = write(std::iter::once(Record {
+            func_addr: 1,
+            target: 2,
+            count: 3,
+        }));
+        assert!(read(&bytes[..bytes.len() - 1]).is_err());
+    }
+}

--- a/crates/profiler-lib/src/interpreter.rs
+++ b/crates/profiler-lib/src/interpreter.rs
@@ -186,6 +186,32 @@ pub fn is_byte_load(load: &Load) -> bool {
     matches!(load.kind, LoadKind::I32_8 { .. } | LoadKind::I64_8 { .. })
 }
 
+/// Collect the byte offsets of "countable" opcodes.
+pub(crate) fn countable_opcodes(func: &LocalFunction) -> BTreeSet<u32> {
+    #[derive(Default)]
+    struct Collect {
+        countable: BTreeSet<u32>,
+    }
+    impl<'instr> Visitor<'instr> for Collect {
+        fn visit_instr(&mut self, instr: &'instr Instr, loc: &'instr InstrLocId) {
+            let excluded = matches!(
+                instr,
+                Instr::Block(_)
+                    | Instr::Loop(_)
+                    | Instr::Drop(_)
+                    | Instr::Return(_)
+                    | Instr::Unreachable(_)
+            );
+            if !excluded {
+                self.countable.insert(loc.data());
+            }
+        }
+    }
+    let mut v = Collect::default();
+    dfs_in_order(&mut v, func, func.entry_block());
+    v.countable
+}
+
 impl<'f, 'instr> Visitor<'instr> for AbstractInterp<'f> {
     fn visit_instr(&mut self, _: &'instr Instr, loc: &'instr InstrLocId) {
         // Save the program counter before visiting each operator.

--- a/crates/profiler-lib/src/lib.rs
+++ b/crates/profiler-lib/src/lib.rs
@@ -1,16 +1,28 @@
+pub mod format;
 mod interpreter;
 mod state;
 
-use state::State;
+use state::{Profiler, State};
+use std::cell::RefCell;
 use std::io::Read;
 use std::sync::OnceLock;
 
 static STATE: OnceLock<State> = OnceLock::new();
 
+thread_local! {
+    /// Runtime profiling state.
+    static PROFILER: RefCell<Profiler> = RefCell::new(Profiler::new());
+}
+
 fn state() -> &'static State {
     STATE
         .get()
         .expect("STATE must be initialized via `wizer.initialize`")
+}
+
+/// Run `f` with mutable access to the runtime [`Profiler`].
+fn with_profiler<R>(f: impl FnOnce(&mut Profiler) -> R) -> R {
+    PROFILER.with_borrow_mut(f)
 }
 
 /// Use Wizer to pre-initialize the user library module that will be
@@ -63,32 +75,55 @@ pub extern "C" fn is_dispatch_load(fid: u32, pc: u32) -> bool {
 /// Start a new JS function frame.
 #[unsafe(no_mangle)]
 pub extern "C" fn start_func() {
-    todo!()
+    with_profiler(|p| p.start_func());
 }
 
-/// Exit the top most JS function frame.
+/// Pop the top most JS function frame. The outermost activation closes
+/// out the final opcode with the instruction count at this point.
 #[unsafe(no_mangle)]
-pub extern "C" fn exit_func() {
-    todo!()
+pub extern "C" fn exit_func(instruction_count: i64) {
+    with_profiler(|p| p.exit_func(instruction_count as u64));
 }
 
-/// Set current dispatch function target. i.e., the `br_table` target.
+/// Switch to the dispatch `br_table` target, closing out the previous
+/// opcode with the instruction count at this point.
 #[unsafe(no_mangle)]
-pub extern "C" fn set_dispatch_target(_target: u32) {
-    todo!()
+pub extern "C" fn set_dispatch_target(target: u32, instruction_count: i64) {
+    with_profiler(|p| p.set_dispatch_target(target, instruction_count as u64));
 }
 
 /// Set the effective address (i.e., the start address) of the current
 /// function which uniquely identifies it.
 #[unsafe(no_mangle)]
-pub extern "C" fn set_func_addr(_addr: u32) {
-    todo!()
+pub extern "C" fn set_func_addr(addr: u32) {
+    with_profiler(|p| p.set_func_addr(addr));
 }
 
-/// Handle the execution of the given opcode.
+/// Whether the opcode at offset `pc` in function `fid` is counted by
+/// the profiler.
 #[unsafe(no_mangle)]
-pub extern "C" fn handle_opcode(_pc: u32) {
-    todo!()
+pub extern "C" fn is_countable_opcode(fid: u32, pc: u32) -> bool {
+    state().is_countable_opcode(fid, pc)
+}
+
+/// Flush the profiler results into a buffer.
+#[unsafe(no_mangle)]
+pub extern "C" fn report() {
+    with_profiler(|p| p.report());
+}
+
+// TODO: Validate that `report` must run exactly once per profile
+// invocation.
+/// Linear-memory offset of the serialized report buffer.
+#[unsafe(no_mangle)]
+pub extern "C" fn report_ptr() -> u32 {
+    with_profiler(|p| p.report_bytes().as_ptr() as u32)
+}
+
+/// Length in bytes of the serialized report buffer.
+#[unsafe(no_mangle)]
+pub extern "C" fn report_len() -> u32 {
+    with_profiler(|p| p.report_bytes().len() as u32)
 }
 
 #[cfg(test)]

--- a/crates/profiler-lib/src/monitor.mm
+++ b/crates/profiler-lib/src/monitor.mm
@@ -1,57 +1,46 @@
 use {{LIBRARY_NAME}};
 
-// Ensure that we only read the first address of the function
-// bytecode, which serves as the function identifier.
+// Global count of executed countable Wasm instructions, across every
+// function.
+var instruction_count: i64;
+
+// Set to true on the dispatch function entry to capture the function's
+// address from its first dispatch load.
 var expect_first_load: bool;
 
-// True only while executing a handler body, that is the window
-// between a dispatch `br_table` and the next dispatch load. Provides
-// more accurate counting of Wasm-instructions-per-JS-opcode.
-var counting: bool;
-
 wasm:func:entry / @static {{LIBRARY_NAME}}.is_dispatch_func(fid as i32) as bool / {
-    // When entering the dispatch function, track a new JS function frame.
+    // Push a new JS function frame.
     {{LIBRARY_NAME}}.start_func();
-    // When entering the dispatch function, we expect the first load later on.
     expect_first_load = true;
 }
 
 wasm:func:exit / @static {{LIBRARY_NAME}}.is_dispatch_func(fid as i32) as bool / {
-    // When exiting the dispatch function, pop the current JS function frame.
-    {{LIBRARY_NAME}}.exit_func();
+    // Pop the topmost JS function frame. The outermost activation closes
+    // out the final opcode with the current instruction count.
+    {{LIBRARY_NAME}}.exit_func(instruction_count);
 }
 
+// Switching the dispatch target closes out the opcode that just ran
+// and begins the new one.
+// Declared before the increment probe so this `br_table` counts toward
+// current JS opcode it dispatches to, not the previous one.
 wasm:opcode:br_table:before / @static {{LIBRARY_NAME}}.is_dispatch_func(fid as i32) as bool / {
-    // We are in the dispatch loop, so we track the current dispatch target.
-    {{LIBRARY_NAME}}.set_dispatch_target(target as i32);
-    // Entering a handler body for `target`, so we begin counting.
-    counting = true;
+    {{LIBRARY_NAME}}.set_dispatch_target(target as i32, instruction_count);
 }
 
-wasm:opcode:*load*:before / @static {{LIBRARY_NAME}}.is_dispatch_load(fid as i32, pc as i32) as bool / {
-    // When hitting the dispatch load, stop counting, the current and
-    // following instructions do not belong to any JS opcode handler.
-    counting = false;
+// Increment the instruction count, iff the opcode is countable.
+wasm:opcode:*:before / @static {{LIBRARY_NAME}}.is_countable_opcode(fid as i32, pc as i32) as bool / {
+    instruction_count = instruction_count + 1;
 }
 
 wasm:opcode:*load*:before / expect_first_load && @static {{LIBRARY_NAME}}.is_dispatch_load(fid as i32, pc as i32) as bool / {
-    // Set the current function identifier, which is the effective address of the dispatch load.
-    // We no longer care about `expect_first_load`, this probe should
-    // only fire once per JS function invocation.
+    // First load of the frame: its effective address identifies the JS
+    // function.
     {{LIBRARY_NAME}}.set_func_addr(effective_addr as i32);
     expect_first_load = false;
 }
 
-wasm:opcode:*:before / @static {{LIBRARY_NAME}}.is_dispatch_func(fid as i32) as bool
-    && counting
-    && opname != "nop"
-    && opname != "drop"
-    && opname != "block"
-    && opname != "loop"
-    && opname != "unreachable"
-    && opname != "return"
-    && opname != "else"
-    && opname != "end" / {
-
-    {{LIBRARY_NAME}}.handle_opcode(pc as i32);
+wasm:func:exit / fname == "_start" / {
+    // At program exit emit the single, whole-execution report.
+    {{LIBRARY_NAME}}.report();
 }

--- a/crates/profiler-lib/src/state.rs
+++ b/crates/profiler-lib/src/state.rs
@@ -1,10 +1,11 @@
 //! Instrumentation state to derive probe insertion.
 
 use anyhow::{Result, bail};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use walrus::ir::{BrTable, Visitor, dfs_in_order};
 use walrus::{FunctionId, FunctionKind, LocalFunction, ModuleConfig};
 
+use crate::format;
 use crate::interpreter;
 
 /// Threshold above which a `br_table` qualifies as the interpreter
@@ -19,6 +20,11 @@ pub struct State {
     /// Byte offsets of the `i32.load8_u` instructions in the dispatch
     /// function whose values feed the dispatch `br_table`'s index.
     dispatch_loads: BTreeSet<u32>,
+    /// Per function, the byte offsets of the opcodes the
+    /// profiler counts.
+    /// Calcualted eagerly so that at runtime the calculation becomes
+    /// a simple lookup in the `BTreeSet`.
+    countable_opcodes: HashMap<u32, BTreeSet<u32>>,
 }
 
 impl State {
@@ -60,9 +66,23 @@ impl State {
         };
         let dispatch_loads = interpreter::analyze(&module, local, threshold);
 
+        let countable_opcodes = module
+            .funcs
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, func)| match &func.kind {
+                FunctionKind::Local(local) => {
+                    let pcs = interpreter::countable_opcodes(local);
+                    (!pcs.is_empty()).then_some((idx as u32, pcs))
+                }
+                _ => None,
+            })
+            .collect();
+
         Ok(Self {
             dispatch_func_idx,
             dispatch_loads,
+            countable_opcodes,
         })
     }
 
@@ -77,6 +97,126 @@ impl State {
     /// fetching the next QuickJS opcode.
     pub fn is_dispatch_load(&self, id: u32, pc: u32) -> bool {
         id == self.dispatch_func_idx && self.dispatch_loads.contains(&pc)
+    }
+
+    /// Whether the opcode at offset `pc` in function `fid` is one the
+    /// profiler cares about.
+    pub fn is_countable_opcode(&self, fid: u32, pc: u32) -> bool {
+        self.countable_opcodes
+            .get(&fid)
+            .is_some_and(|pcs| pcs.contains(&pc))
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct DispatchTarget(u32);
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct FuncAddr(u32);
+
+/// A JavaScript function frame.
+#[derive(Default)]
+struct Frame {
+    /// The function's bytecode buffer start address, which uniquely
+    /// identifies the JS function being executed.
+    func_addr: Option<FuncAddr>,
+}
+
+/// Profiling state.
+///
+/// It tracks the interpreter's stack frames and accumulates the cost
+/// of each JS opcode, per JS function.
+///
+/// Cost is an approximation: an opcode is charged every instruction
+/// from the dispatch into its handler until the next dispatch. That spans
+/// the handler, any helper functions it calls, and the decode of the
+/// following opcode. This could result in an overapproximation in
+/// some cases, e.g., handling the last opcode in the bytecode buffer
+/// for a given JS function.
+#[derive(Default)]
+pub struct Profiler {
+    /// JS function frames.
+    stack: Vec<Frame>,
+    /// The current dispatch target scope.
+    current: Option<(FuncAddr, DispatchTarget)>,
+    /// Instruction count belonging to the last dispatch target.
+    last_instruction_count: u64,
+    /// Per-function-and-dispatch target count.
+    counts: BTreeMap<(FuncAddr, DispatchTarget), u64>,
+    /// Serialized counts report.
+    report: Vec<u8>,
+}
+
+impl Profiler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Push a new interpreter frame.
+    pub fn start_func(&mut self) {
+        self.stack.push(Frame::default());
+    }
+
+    /// End the current function's frame. When the outermost interpreter
+    /// activation returns, close out the final opcode passing in the
+    /// instruction count up until that point.
+    pub fn exit_func(&mut self, instruction_count: u64) {
+        self.stack.pop().expect("Function frame to exist");
+        if self.stack.is_empty() {
+            if let Some(key) = self.current {
+                *self.counts.entry(key).or_default() +=
+                    instruction_count.saturating_sub(self.last_instruction_count);
+            }
+            self.last_instruction_count = instruction_count;
+            self.current = None;
+        }
+    }
+
+    /// Switch the dispatch target to `target` (the QuickJS opcode whose
+    /// handler is about to run). This also closes out the opcode that was
+    /// running, charging it the instructions executed since the previous
+    /// switch. `instruction_count` is the running count of executed
+    /// countable Wasm instructions.
+    pub fn set_dispatch_target(&mut self, target: u32, instruction_count: u64) {
+        // Close out the opcode that just finished.
+        if let Some(key) = self.current {
+            *self.counts.entry(key).or_default() +=
+                instruction_count.saturating_sub(self.last_instruction_count);
+        }
+        self.last_instruction_count = instruction_count;
+
+        // Begin attributing to the opcode being dispatched.
+        if let Some(addr) = self.stack.last().and_then(|frame| frame.func_addr) {
+            self.current = Some((addr, DispatchTarget(target)));
+        }
+    }
+
+    /// Record the start address of the topmost function frame.
+    pub fn set_func_addr(&mut self, addr: u32) {
+        if let Some(frame) = self.stack.last_mut() {
+            frame.func_addr = Some(FuncAddr(addr));
+        }
+    }
+
+    /// Serialize the accumulated counts into the internal report buffer
+    /// using the [`crate::format`] encoding. Call once at program exit;
+    /// afterwards [`Profiler::report_bytes`] exposes the buffer for the
+    /// host to read out of linear memory.
+    pub fn report(&mut self) {
+        self.report =
+            format::write(
+                self.counts
+                    .iter()
+                    .map(|(&(addr, target), &count)| format::Record {
+                        func_addr: addr.0,
+                        target: target.0,
+                        count,
+                    }),
+            );
+    }
+
+    /// The serialized report buffer.
+    pub fn report_bytes(&self) -> &[u8] {
+        &self.report
     }
 }
 
@@ -385,5 +525,95 @@ mod tests {
         assert!(state.is_dispatch_load(state.dispatch_func_idx, pc));
         assert!(!state.is_dispatch_load(state.dispatch_func_idx + 1, pc));
         Ok(())
+    }
+
+    #[test]
+    fn set_dispatch_target_attributes_deltas_per_opcode() {
+        let mut p = Profiler::new();
+        p.start_func();
+        p.set_func_addr(0x1000);
+
+        p.set_dispatch_target(5, 0);
+        p.set_dispatch_target(7, 3);
+        p.set_dispatch_target(5, 8);
+        p.exit_func(12);
+
+        let f = FuncAddr(0x1000);
+        assert_eq!(p.counts.get(&(f, DispatchTarget(5))), Some(&7)); // 3 + 4
+        assert_eq!(p.counts.get(&(f, DispatchTarget(7))), Some(&5));
+        assert_eq!(p.counts.len(), 2);
+    }
+
+    #[test]
+    fn first_dispatch_target_charges_nothing() {
+        let mut p = Profiler::new();
+        p.start_func();
+        p.set_func_addr(0x10);
+        p.set_dispatch_target(0, 5);
+        assert!(p.counts.is_empty());
+
+        p.set_dispatch_target(1, 8);
+        assert_eq!(p.counts.get(&(FuncAddr(0x10), DispatchTarget(0))), Some(&3));
+    }
+
+    #[test]
+    fn exit_func_restores_caller_function() {
+        let mut p = Profiler::new();
+        p.start_func();
+        p.set_func_addr(0xA00);
+        p.set_dispatch_target(1, 0);
+
+	// Nested call.
+        p.start_func();
+        p.set_func_addr(0xB00);
+        p.set_dispatch_target(2, 10);
+        p.exit_func(13);
+
+	// Back to the parent function call.
+        p.set_dispatch_target(3, 15);
+        p.exit_func(20);
+
+        assert_eq!(
+            p.counts.get(&(FuncAddr(0xA00), DispatchTarget(1))),
+            Some(&10)
+        );
+        assert_eq!(p.counts.get(&(FuncAddr(0xB00), DispatchTarget(2))), Some(&5));
+        assert_eq!(p.counts.get(&(FuncAddr(0xA00), DispatchTarget(3))), Some(&5));
+    }
+
+    #[test]
+    fn report_encodes_records_in_order() {
+        let mut p = Profiler::new();
+        p.start_func();
+        p.set_func_addr(0x1000);
+        p.set_dispatch_target(7, 0);
+        p.set_dispatch_target(5, 5);
+        p.exit_func(8);
+
+        p.report();
+        let records = format::read(p.report_bytes()).unwrap();
+
+        assert_eq!(
+            records,
+            vec![
+                format::Record {
+                    func_addr: 0x1000,
+                    target: 5,
+                    count: 3
+                },
+                format::Record {
+                    func_addr: 0x1000,
+                    target: 7,
+                    count: 5
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn report_with_no_counts_reads_back_empty() {
+        let mut p = Profiler::new();
+        p.report();
+        assert!(format::read(p.report_bytes()).unwrap().is_empty());
     }
 }

--- a/crates/profiler-lib/src/state.rs
+++ b/crates/profiler-lib/src/state.rs
@@ -22,7 +22,7 @@ pub struct State {
     dispatch_loads: BTreeSet<u32>,
     /// Per function, the byte offsets of the opcodes the
     /// profiler counts.
-    /// Calcualted eagerly so that at runtime the calculation becomes
+    /// Calculated eagerly so that at runtime the calculation becomes
     /// a simple lookup in the `BTreeSet`.
     countable_opcodes: HashMap<u32, BTreeSet<u32>>,
 }
@@ -563,13 +563,13 @@ mod tests {
         p.set_func_addr(0xA00);
         p.set_dispatch_target(1, 0);
 
-	// Nested call.
+        // Nested call.
         p.start_func();
         p.set_func_addr(0xB00);
         p.set_dispatch_target(2, 10);
         p.exit_func(13);
 
-	// Back to the parent function call.
+        // Back to the parent function call.
         p.set_dispatch_target(3, 15);
         p.exit_func(20);
 
@@ -577,8 +577,14 @@ mod tests {
             p.counts.get(&(FuncAddr(0xA00), DispatchTarget(1))),
             Some(&10)
         );
-        assert_eq!(p.counts.get(&(FuncAddr(0xB00), DispatchTarget(2))), Some(&5));
-        assert_eq!(p.counts.get(&(FuncAddr(0xA00), DispatchTarget(3))), Some(&5));
+        assert_eq!(
+            p.counts.get(&(FuncAddr(0xB00), DispatchTarget(2))),
+            Some(&5)
+        );
+        assert_eq!(
+            p.counts.get(&(FuncAddr(0xA00), DispatchTarget(3))),
+            Some(&5)
+        );
     }
 
     #[test]


### PR DESCRIPTION
This patch is a follow-up to https://github.com/bytecodealliance/javy/pull/1213

It fills in the profiler state implementation, so that it can be usable from the whamm monitor.

The most notable change that is not described in the original issue, is the profile result encoding format, described in the `format.rs` module.

