### PR TITLE
Add `BytecodeStripping` to `Config` and default it to strip source to reduce bytecode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "8.0.1-alpha.1"
+version = "8.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "7.0.1-alpha.1"
+version = "7.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "javy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wasmtime-wasi = "46.0.0"
 wasmtime-wizer = "46.0.0"
 wasm-opt = "0.116.1"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "8.0.1-alpha.1" }
+javy = { path = "crates/javy", version = "8.1.0-alpha.1" }
 tempfile = "3.27.0"
 tokio = "1"
 uuid = { version = "1.23", features = ["v4"] }

--- a/crates/cli/tests/dynamic_linking_test.rs
+++ b/crates/cli/tests/dynamic_linking_test.rs
@@ -5,6 +5,7 @@ use javy_test_macros::javy_cli_test;
 #[javy_cli_test(dyn = true, root = "tests/dynamic-linking-scripts")]
 pub fn test_dynamic_linking(builder: &mut Builder) -> Result<()> {
     let mut runner = builder.input("console.js").build()?;
+    assert_wasm_size_within_threshold(388, runner.wasm.len());
 
     let (_, logs, _) = runner.exec(vec![])?;
     assert_eq!("42\n", String::from_utf8(logs)?);
@@ -18,6 +19,7 @@ pub fn test_dynamic_linking_with_func(builder: &mut Builder) -> Result<()> {
         .wit("linking-with-func.wit")
         .world("foo-test")
         .build()?;
+    assert_wasm_size_within_threshold(615, runner.wasm.len());
 
     let (_, logs, _) = runner.exec_func("foo-bar", vec![])?;
 
@@ -28,6 +30,7 @@ pub fn test_dynamic_linking_with_func(builder: &mut Builder) -> Result<()> {
 #[javy_cli_test(dyn = true, root = "tests/dynamic-linking-scripts")]
 pub fn test_dynamic_linking_with_func_without_flag(builder: &mut Builder) -> Result<()> {
     let mut runner = builder.input("linking-with-func-without-flag.js").build()?;
+    assert_wasm_size_within_threshold(521, runner.wasm.len());
 
     let res = runner.exec_func("foo", vec![]);
 
@@ -45,6 +48,7 @@ fn test_errors_in_exported_functions_are_correctly_reported(builder: &mut Builde
         .wit("errors-in-exported-functions.wit")
         .world("foo-test")
         .build()?;
+    assert_wasm_size_within_threshold(509, runner.wasm.len());
 
     let res = runner.exec_func("foo", vec![]);
 
@@ -64,6 +68,7 @@ pub fn test_dynamic_linking_with_arrow_fn(builder: &mut Builder) -> Result<()> {
         .wit("linking-arrow-func.wit")
         .world("exported-arrow")
         .build()?;
+    assert_wasm_size_within_threshold(529, runner.wasm.len());
 
     let (_, logs, _) = runner.exec_func("default", vec![])?;
 
@@ -74,6 +79,7 @@ pub fn test_dynamic_linking_with_arrow_fn(builder: &mut Builder) -> Result<()> {
 #[javy_cli_test(dyn = true, root = "tests/dynamic-linking-scripts")]
 fn test_producers_section_present(builder: &mut Builder) -> Result<()> {
     let runner = builder.input("console.js").build()?;
+    assert_wasm_size_within_threshold(388, runner.wasm.len());
     runner.assert_producers()
 }
 
@@ -95,6 +101,7 @@ fn test_using_wasip1_plugin_with_dynamic_works(builder: &mut Builder) -> Result<
         .preload(plugin.namespace().into(), plugin.path())
         .input("plugin.js")
         .build()?;
+    assert_wasm_size_within_threshold(463, runner.wasm.len());
 
     let result = runner.exec(vec![]);
     assert!(result.is_ok(), "Expected ok but got {result:?}");
@@ -112,6 +119,7 @@ fn test_using_wasip1_plugin_with_export_works(builder: &mut Builder) -> Result<(
         .wit("plugin-exports.wit")
         .world("plugin")
         .build()?;
+    assert_wasm_size_within_threshold(597, runner.wasm.len());
 
     let result = runner.exec_func("fn", vec![]);
     assert!(result.is_ok(), "Expected ok but got {result:?}");
@@ -127,6 +135,7 @@ fn test_using_wasip2_plugin_with_dynamic_works(builder: &mut Builder) -> Result<
         .preload(plugin.namespace().into(), plugin.path())
         .input("plugin.js")
         .build()?;
+    assert_wasm_size_within_threshold(463, runner.wasm.len());
 
     let result = runner.exec(vec![]);
     assert!(result.is_ok());
@@ -144,9 +153,22 @@ fn test_using_wasip2_plugin_with_export_works(builder: &mut Builder) -> Result<(
         .wit("plugin-exports.wit")
         .world("plugin")
         .build()?;
+    assert_wasm_size_within_threshold(597, runner.wasm.len());
 
     let result = runner.exec_func("fn", vec![]);
     assert!(result.is_ok(), "Expected ok but got {result:?}");
 
     Ok(())
+}
+
+fn assert_wasm_size_within_threshold(target_size: usize, wasm_size: usize) {
+    let target_size = target_size as f64;
+    let wasm_size = wasm_size as f64;
+    let threshold = 3.0;
+    let percentage_difference = ((wasm_size - target_size) / target_size).abs() * 100.0;
+
+    assert!(
+        percentage_difference <= threshold,
+        "wasm_size ({wasm_size}) was not within {threshold:.2}% of the target_size value ({target_size})",
+    );
 }

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -192,7 +192,7 @@ fn test_readme_script(builder: &mut Builder) -> Result<()> {
 
     let (output, _, fuel_consumed) = run(&mut runner, r#"{ "n": 2, "bar": "baz" }"#.into());
     assert_eq!(r#"{"foo":3,"newBar":"baz!"}"#.as_bytes(), output);
-    assert_fuel_consumed_within_threshold(265_289, fuel_consumed);
+    assert_fuel_consumed_within_threshold(256_087, fuel_consumed);
     Ok(())
 }
 
@@ -238,7 +238,7 @@ fn test_exported_functions(builder: &mut Builder) -> Result<()> {
         .build()?;
     let (_, logs, fuel_consumed) = run_fn(&mut runner, "foo", vec![]);
     assert_eq!("Hello from top-level\nHello from foo\n", logs);
-    assert_fuel_consumed_within_threshold(59_651, fuel_consumed);
+    assert_fuel_consumed_within_threshold(57_013, fuel_consumed);
     let (_, logs, _) = run_fn(&mut runner, "foo-bar", vec![]);
     assert_eq!("Hello from top-level\nHello from fooBar\n", logs);
     Ok(())

--- a/crates/codegen/tests/snapshots/integration_test__default_dynamic.snap
+++ b/crates/codegen/tests/snapshots/integration_test__default_dynamic.snap
@@ -17,11 +17,11 @@ expression: wat
     i32.const 0
     i32.const 0
     i32.const 1
-    i32.const 403
+    i32.const 283
     call 0
     local.tee 0
     i32.const 0
-    i32.const 403
+    i32.const 283
     memory.init 0
     data.drop 0
     i32.const 0
@@ -35,7 +35,7 @@ expression: wat
     memory.init 1
     data.drop 1
     local.get 0
-    i32.const 403
+    i32.const 283
     i32.const 1
     local.get 1
     i32.const 3
@@ -46,11 +46,11 @@ expression: wat
     i32.const 0
     i32.const 0
     i32.const 1
-    i32.const 403
+    i32.const 283
     call 0
     local.tee 0
     i32.const 0
-    i32.const 403
+    i32.const 283
     memory.init 0
     data.drop 0
     i32.const 0
@@ -64,7 +64,7 @@ expression: wat
     memory.init 2
     data.drop 2
     local.get 0
-    i32.const 403
+    i32.const 283
     i32.const 1
     local.get 1
     i32.const 4
@@ -75,20 +75,20 @@ expression: wat
     i32.const 0
     i32.const 0
     i32.const 1
-    i32.const 403
+    i32.const 283
     call 0
     local.tee 0
     i32.const 0
-    i32.const 403
+    i32.const 283
     memory.init 0
     local.get 0
-    i32.const 403
+    i32.const 283
     i32.const 0
     i32.const 0
     i32.const 0
     call 1
   )
-  (data (;0;) "\1a\1c\e9\e7\b6\07\01\18function.mjs\01\06log\01\08log2\01\0econsole\01(Hello from function!\01*Hello from function2!\014Hello from top-level scope\0d\e4\03\00\02\00\00\e6\03\00\01\e8\03\00\00\00\0c \0a\01\a8\01\00\00\00\03\00\02\02\1f\00\e6\03\00\06\e8\03\01\06\0cC\0a\01\e6\03\00\00\00\03\00\00\00\13\008\f5\00\00\00A\f3\00\00\00\04\f6\00\00\00$\01\00)\e4\03\01\07\04\03\034\10;function log() {\0a    console.log(\22Hello from function!\22);\0a}\0cC\0a\01\e8\03\00\00\00\03\00\00\00\13\008\f5\00\00\00A\f3\00\00\00\04\f7\00\00\00$\01\00)\e4\03\05\08\04\03\054\10=function log2() {\0a    console.log(\22Hello from function2!\22);\0a}\08\f0\08\c5\00\e7\c5\01\e8)8\f5\00\00\00A\f3\00\00\00\04\f8\00\00\00$\01\00\0e\06/\e4\03\01\01\06\00\0a\10\004\10\00")
+  (data (;0;) "\1a\c7\14e}\07\01\18function.mjs\01\06log\01\08log2\01\0econsole\01(Hello from function!\01*Hello from function2!\014Hello from top-level scope\0d\e4\03\00\02\00\00\e6\03\00\01\e8\03\00\00\00\0c \0a\01\a8\01\00\00\00\03\00\02\02\1f\00\e6\03\00\06\e8\03\01\06\0cC\0a\01\e6\03\00\00\00\03\00\00\00\13\008\f5\00\00\00A\f3\00\00\00\04\f6\00\00\00$\01\00)\e4\03\01\07\04\03\034\10\00\0cC\0a\01\e8\03\00\00\00\03\00\00\00\13\008\f5\00\00\00A\f3\00\00\00\04\f7\00\00\00$\01\00)\e4\03\05\08\04\03\054\10\00\08\f0\08\c5\00\e7\c5\01\e8)8\f5\00\00\00A\f3\00\00\00\04\f8\00\00\00$\01\00\0e\06/\e4\03\01\01\06\00\0a\10\004\10\00")
   (data (;1;) "log")
   (data (;2;) "log2")
   (@producers

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Added `Config::strip_source` and `Config::strip_debug` to configure stripping
+  source code and debug information when generating QuickJS bytecode.
+  Source stripping is enabled by default; debug-information stripping is
+  disabled. Source stripping affects the output of
+  `Function.prototype.toString()`.
+
 ## [8.0.0] - 2026-06-10
 
 ### Changed

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -10,11 +10,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Added `Config::strip_source` and `Config::strip_debug` to configure stripping
-  source code and debug information when generating QuickJS bytecode.
-  Source stripping is enabled by default; debug-information stripping is
-  disabled. Source stripping affects the output of
-  `Function.prototype.toString()`.
+- Added `Config::bytecode_stripping` to configure which optional information is
+  retained when generating QuickJS bytecode. Source code is stripped by
+  default; debug information is retained. Source stripping affects the output
+  of `Function.prototype.toString()`.
 
 ## [8.0.0] - 2026-06-10
 

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "8.0.1-alpha.1"
+version = "8.1.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -68,7 +68,7 @@ pub enum BytecodeStripping {
     /// Omit debug information, which also omits source code.
     ///
     /// Error stack traces no longer include line/column locations.
-    Debug,
+    SourceAndDebug,
 }
 
 /// A configuration for [`Runtime`](crate::Runtime).
@@ -296,8 +296,8 @@ mod tests {
         let mut config = Config::default();
         assert_eq!(config.bytecode_stripping, BytecodeStripping::Source);
 
-        config.bytecode_stripping(BytecodeStripping::Debug);
-        assert_eq!(config.bytecode_stripping, BytecodeStripping::Debug);
+        config.bytecode_stripping(BytecodeStripping::SourceAndDebug);
+        assert_eq!(config.bytecode_stripping, BytecodeStripping::SourceAndDebug);
     }
 
     #[cfg(feature = "json")]

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -49,6 +49,28 @@ bitflags! {
     }
 }
 
+/// Controls which optional information QuickJS retains in compiled bytecode.
+///
+/// Stripping source code reduces bytecode size, but changes
+/// `Function.prototype.toString()` to no longer return the function's source
+/// code. Stripping debug information further reduces bytecode size, but removes
+/// line/column locations from JavaScript error stack traces.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum BytecodeStripping {
+    /// Retain source code and debug information.
+    None,
+    /// Omit source code while retaining debug information.
+    ///
+    /// For compiled functions, `Function.prototype.toString()` no longer
+    /// returns the function's source code.
+    #[default]
+    Source,
+    /// Omit debug information, which also omits source code.
+    ///
+    /// Error stack traces no longer include line/column locations.
+    Debug,
+}
+
 /// A configuration for [`Runtime`](crate::Runtime).
 ///
 /// These are the global configuration options to create a [`Runtime`](crate::Runtime),
@@ -76,10 +98,8 @@ pub struct Config {
     pub(crate) log_stream: Box<dyn Write>,
     /// The stream to use for calls to `console.error`.
     pub(crate) err_stream: Box<dyn Write>,
-    /// Whether to omit source code from compiled bytecode. Enabled by default.
-    pub(crate) strip_source: bool,
-    /// Whether to omit debug information from compiled bytecode. Disabled by default.
-    pub(crate) strip_debug: bool,
+    /// Which optional information to omit from compiled bytecode.
+    pub(crate) bytecode_stripping: BytecodeStripping,
 }
 
 impl Default for Config {
@@ -98,8 +118,7 @@ impl Default for Config {
             max_stack_size: 256 * 1024, // from rquickjs
             log_stream: Box::new(std::io::stdout()),
             err_stream: Box::new(std::io::stderr()),
-            strip_source: true,
-            strip_debug: false,
+            bytecode_stripping: BytecodeStripping::default(),
         }
     }
 }
@@ -241,15 +260,9 @@ impl Config {
         self
     }
 
-    /// Configures whether source code will be omitted from compiled bytecode.
-    pub fn strip_source(&mut self, enable: bool) -> &mut Self {
-        self.strip_source = enable;
-        self
-    }
-
-    /// Configures whether debug information will be omitted from compiled bytecode.
-    pub fn strip_debug(&mut self, enable: bool) -> &mut Self {
-        self.strip_debug = enable;
+    /// Configures which optional information is omitted from compiled bytecode.
+    pub fn bytecode_stripping(&mut self, stripping: BytecodeStripping) -> &mut Self {
+        self.bytecode_stripping = stripping;
         self
     }
 
@@ -276,17 +289,15 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
-    use super::Config;
+    use super::{BytecodeStripping, Config};
 
     #[test]
     fn bytecode_stripping_defaults_and_configuration() {
         let mut config = Config::default();
-        assert!(config.strip_source);
-        assert!(!config.strip_debug);
+        assert_eq!(config.bytecode_stripping, BytecodeStripping::Source);
 
-        config.strip_source(false).strip_debug(true);
-        assert!(!config.strip_source);
-        assert!(config.strip_debug);
+        config.bytecode_stripping(BytecodeStripping::Debug);
+        assert_eq!(config.bytecode_stripping, BytecodeStripping::Debug);
     }
 
     #[cfg(feature = "json")]

--- a/crates/javy/src/config.rs
+++ b/crates/javy/src/config.rs
@@ -76,6 +76,10 @@ pub struct Config {
     pub(crate) log_stream: Box<dyn Write>,
     /// The stream to use for calls to `console.error`.
     pub(crate) err_stream: Box<dyn Write>,
+    /// Whether to omit source code from compiled bytecode. Enabled by default.
+    pub(crate) strip_source: bool,
+    /// Whether to omit debug information from compiled bytecode. Disabled by default.
+    pub(crate) strip_debug: bool,
 }
 
 impl Default for Config {
@@ -94,6 +98,8 @@ impl Default for Config {
             max_stack_size: 256 * 1024, // from rquickjs
             log_stream: Box::new(std::io::stdout()),
             err_stream: Box::new(std::io::stderr()),
+            strip_source: true,
+            strip_debug: false,
         }
     }
 }
@@ -235,6 +241,18 @@ impl Config {
         self
     }
 
+    /// Configures whether source code will be omitted from compiled bytecode.
+    pub fn strip_source(&mut self, enable: bool) -> &mut Self {
+        self.strip_source = enable;
+        self
+    }
+
+    /// Configures whether debug information will be omitted from compiled bytecode.
+    pub fn strip_debug(&mut self, enable: bool) -> &mut Self {
+        self.strip_debug = enable;
+        self
+    }
+
     /// Whether the `WeakRef` instrinsic will be enabled.
     pub fn weak_ref(&mut self, enable: bool) -> &mut Self {
         self.intrinsics.set(JSIntrinsics::WEAK_REF, enable);
@@ -257,10 +275,21 @@ impl Config {
 }
 
 #[cfg(test)]
-#[cfg(feature = "json")]
 mod tests {
     use super::Config;
 
+    #[test]
+    fn bytecode_stripping_defaults_and_configuration() {
+        let mut config = Config::default();
+        assert!(config.strip_source);
+        assert!(!config.strip_debug);
+
+        config.strip_source(false).strip_debug(true);
+        assert!(!config.strip_source);
+        assert!(config.strip_debug);
+    }
+
+    #[cfg(feature = "json")]
     #[test]
     fn err_config_validation() {
         let mut config = Config::default();
@@ -270,6 +299,7 @@ mod tests {
         assert!(config.validate().is_err());
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn ok_config_validation() {
         let mut config = Config::default();

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -3,7 +3,7 @@ use super::from_js_error;
 #[cfg(feature = "json")]
 use crate::apis::json;
 use crate::{
-    Config,
+    BytecodeStripping, Config,
     apis::{console, random, stream_io, text_encoding},
     config::{JSIntrinsics, JavyIntrinsics},
 };
@@ -36,25 +36,21 @@ pub struct Runtime {
     /// The inner QuickJS runtime representation.
     // Read above on the usage of `ManuallyDrop`.
     inner: ManuallyDrop<QRuntime>,
-    /// Whether source code is omitted from compiled bytecode.
-    strip_source: bool,
-    /// Whether debug information is omitted from compiled bytecode.
-    strip_debug: bool,
+    /// Which optional information is omitted from compiled bytecode.
+    bytecode_stripping: BytecodeStripping,
 }
 
 impl Runtime {
     /// Creates a new [Runtime].
     pub fn new(config: Config) -> Result<Self> {
         let rt = ManuallyDrop::new(QRuntime::new()?);
-        let strip_source = config.strip_source;
-        let strip_debug = config.strip_debug;
+        let bytecode_stripping = config.bytecode_stripping;
 
         let context = Self::build_from_config(&rt, config)?;
         Ok(Self {
             inner: rt,
             context,
-            strip_source,
-            strip_debug,
+            bytecode_stripping,
         })
     }
 
@@ -175,10 +171,19 @@ impl Runtime {
     }
 
     fn bytecode_write_options(&self) -> WriteOptions {
-        WriteOptions {
-            strip_source: self.strip_source,
-            strip_debug: self.strip_debug,
-            ..WriteOptions::default()
+        match self.bytecode_stripping {
+            BytecodeStripping::None => WriteOptions::default(),
+            BytecodeStripping::Source => WriteOptions {
+                strip_source: true,
+                ..WriteOptions::default()
+            },
+            // QuickJS stores source code in its debug-information block, so
+            // stripping debug information necessarily strips source as well.
+            BytecodeStripping::Debug => WriteOptions {
+                strip_source: true,
+                strip_debug: true,
+                ..WriteOptions::default()
+            },
         }
     }
 
@@ -205,16 +210,26 @@ impl Default for Runtime {
 #[cfg(test)]
 mod tests {
     use super::Runtime;
-    use crate::Config;
+    use crate::{BytecodeStripping, Config};
 
     #[test]
     fn bytecode_write_options_follow_config() {
         let mut config = Config::default();
-        config.strip_source(false).strip_debug(true);
-
-        let runtime = Runtime::new(config).unwrap();
-        let options = runtime.bytecode_write_options();
+        config.bytecode_stripping(BytecodeStripping::None);
+        let options = Runtime::new(config).unwrap().bytecode_write_options();
         assert!(!options.strip_source);
+        assert!(!options.strip_debug);
+
+        let mut config = Config::default();
+        config.bytecode_stripping(BytecodeStripping::Source);
+        let options = Runtime::new(config).unwrap().bytecode_write_options();
+        assert!(options.strip_source);
+        assert!(!options.strip_debug);
+
+        let mut config = Config::default();
+        config.bytecode_stripping(BytecodeStripping::Debug);
+        let options = Runtime::new(config).unwrap().bytecode_write_options();
+        assert!(options.strip_source);
         assert!(options.strip_debug);
     }
 }

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -36,15 +36,26 @@ pub struct Runtime {
     /// The inner QuickJS runtime representation.
     // Read above on the usage of `ManuallyDrop`.
     inner: ManuallyDrop<QRuntime>,
+    /// Whether source code is omitted from compiled bytecode.
+    strip_source: bool,
+    /// Whether debug information is omitted from compiled bytecode.
+    strip_debug: bool,
 }
 
 impl Runtime {
     /// Creates a new [Runtime].
     pub fn new(config: Config) -> Result<Self> {
         let rt = ManuallyDrop::new(QRuntime::new()?);
+        let strip_source = config.strip_source;
+        let strip_debug = config.strip_debug;
 
         let context = Self::build_from_config(&rt, config)?;
-        Ok(Self { inner: rt, context })
+        Ok(Self {
+            inner: rt,
+            context,
+            strip_source,
+            strip_debug,
+        })
     }
 
     fn build_from_config(rt: &QRuntime, cfg: Config) -> Result<ManuallyDrop<Context>> {
@@ -163,11 +174,19 @@ impl Runtime {
         self.inner.is_job_pending()
     }
 
+    fn bytecode_write_options(&self) -> WriteOptions {
+        WriteOptions {
+            strip_source: self.strip_source,
+            strip_debug: self.strip_debug,
+            ..WriteOptions::default()
+        }
+    }
+
     /// Compiles the given module to bytecode.
     pub fn compile_to_bytecode(&self, name: &str, contents: &str) -> Result<Vec<u8>> {
         self.context()
             .with(|this| {
-                Module::declare(this.clone(), name, contents)?.write(WriteOptions::default())
+                Module::declare(this.clone(), name, contents)?.write(self.bytecode_write_options())
             })
             .map_err(|e| self.context().with(|cx| from_js_error(cx.clone(), e)))
     }
@@ -180,5 +199,22 @@ impl Default for Runtime {
     /// This function panics if there is an error setting up the runtime.
     fn default() -> Self {
         Self::new(Config::default()).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Runtime;
+    use crate::Config;
+
+    #[test]
+    fn bytecode_write_options_follow_config() {
+        let mut config = Config::default();
+        config.strip_source(false).strip_debug(true);
+
+        let runtime = Runtime::new(config).unwrap();
+        let options = runtime.bytecode_write_options();
+        assert!(!options.strip_source);
+        assert!(options.strip_debug);
     }
 }

--- a/crates/javy/src/runtime.rs
+++ b/crates/javy/src/runtime.rs
@@ -179,7 +179,7 @@ impl Runtime {
             },
             // QuickJS stores source code in its debug-information block, so
             // stripping debug information necessarily strips source as well.
-            BytecodeStripping::Debug => WriteOptions {
+            BytecodeStripping::SourceAndDebug => WriteOptions {
                 strip_source: true,
                 strip_debug: true,
                 ..WriteOptions::default()
@@ -227,7 +227,7 @@ mod tests {
         assert!(!options.strip_debug);
 
         let mut config = Config::default();
-        config.bytecode_stripping(BytecodeStripping::Debug);
+        config.bytecode_stripping(BytecodeStripping::SourceAndDebug);
         let options = Runtime::new(config).unwrap().bytecode_write_options();
         assert!(options.strip_source);
         assert!(options.strip_debug);

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,6 +8,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Added `Config::strip_source` and `Config::strip_debug` to configure stripping
+  source code and debug information when generating QuickJS bytecode.
+  Source stripping is enabled by default; debug-information stripping is
+  disabled. Source stripping affects the output of
+  `Function.prototype.toString()`.
+
 ## [7.0.0] - 2026-06-10
 
 ### Changed

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -10,11 +10,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Added `Config::strip_source` and `Config::strip_debug` to configure stripping
-  source code and debug information when generating QuickJS bytecode.
-  Source stripping is enabled by default; debug-information stripping is
-  disabled. Source stripping affects the output of
-  `Function.prototype.toString()`.
+- Added `Config::bytecode_stripping` to configure which optional information is
+  retained when generating QuickJS bytecode. Source code is stripped by
+  default; debug information is retained. Source stripping affects the output
+  of `Function.prototype.toString()`.
 
 ## [7.0.0] - 2026-06-10
 

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "7.0.1-alpha.1"
+version = "7.1.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Adds configurations for `BytecodeStripping` to `Javy::Config` that control whether source code and debug information is included in QuickJS bytecode. Defaults to stripping source but not debug information. Stripping source affects operations like `function.prototype.toString()`. I don't think this should impact profiling. Stripping debug information results in stacktraces no longer including line numbers. Defaulting to stripping source does change Javy's behaviour in that the last few releases implicitly included source code.

I've also added some automated tests to ensure the Wasm modules don't increase in size too much. I'm happy to tweak the percentage threshold.

I have made adding the configuration and changing the default a minor version bump in `javy` and `javy-plugin-api`. Arguably this could be a major version change since the behaviour of the JavaScript could change. However I'm not sure if anyone would actually be relying on source code being included in practice and they have the option of setting the configuration to not strip source code.

There is an open question of whether this would be more appropriate as a codegen configuration instead of a runtime one given this seems more related to codegen than runtime behaviour. However, I think making this a codegen option would involve needing to update the plugin Wasm API to expose an additional parameter for `compile-src` which would be disruptive. I'm not sure if anyone would actually want to configure Javy to not strip the source code in practice. Another option I considered is simply not making it configurable and always stripping the source code. That would be easiest. But perhaps someone does want source code to be included in the bytecode?

## Why am I making this change?

We observed that the size of the QuickJS bytecode for the same source code was often substantially larger than with version 7.1.0 of Javy. I've observed it being 30% to 300% larger on real-world test cases I've given it. It looks like this was related to changes to [quickjs-ng where it started to default to including source code in the bytecode](https://github.com/quickjs-ng/quickjs/pull/218).

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
