### PR TITLE
v8.1.0 of javy, v7.1.0 of javy-plugin-api, v9.1.0 of CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "8.1.0-alpha.1"
+version = "8.1.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "javy-cli"
-version = "9.0.0"
+version = "9.1.0"
 dependencies = [
  "anyhow",
  "brotli",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "7.1.0-alpha.1"
+version = "7.1.0"
 dependencies = [
  "anyhow",
  "javy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "9.0.0"
+version = "9.1.0"
 authors = ["The Javy Project Developers"]
 edition = "2024"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -33,7 +33,7 @@ wasmtime-wasi = "46.0.0"
 wasmtime-wizer = "46.0.0"
 wasm-opt = "0.116.1"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "8.1.0-alpha.1" }
+javy = { path = "crates/javy", version = "8.1.0" }
 tempfile = "3.27.0"
 tokio = "1"
 uuid = { version = "1.23", features = ["v4"] }

--- a/crates/javy/CHANGELOG.md
+++ b/crates/javy/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [8.1.0] - 2026-07-30
+
 ### Added
 
 - Added `Config::bytecode_stripping` to configure which optional information is

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "8.1.0-alpha.1"
+version = "8.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin-api/CHANGELOG.md
+++ b/crates/plugin-api/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [7.1.0] - 2026-06-30
+
 ### Added
 
 - Added `Config::bytecode_stripping` to configure which optional information is

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "7.1.0-alpha.1"
+version = "7.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Publishing v8.1.0 of the `javy` crate. Publishing v7.1.0 of the `javy-plugin-api` crate. Releasing v9.1.0 of the Javy CLI.

The big change is stripping source code from the QuickJS bytecode to shrink the size of the produced Wasm modules.

## Why am I making this change?

I want to publish these crates and the CLI.

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
