### PR TITLE
Re-add version suffixes to crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "javy"
-version = "8.1.0"
+version = "8.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "javy-plugin-api"
-version = "7.1.0"
+version = "7.1.1-alpha.1"
 dependencies = [
  "anyhow",
  "javy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wasmtime-wasi = "46.0.0"
 wasmtime-wizer = "46.0.0"
 wasm-opt = "0.116.1"
 anyhow = "1.0"
-javy = { path = "crates/javy", version = "8.1.0" }
+javy = { path = "crates/javy", version = "8.1.1-alpha.1" }
 tempfile = "3.27.0"
 tokio = "1"
 uuid = { version = "1.23", features = ["v4"] }

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy"
-version = "8.1.0"
+version = "8.1.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/plugin-api/Cargo.toml
+++ b/crates/plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "javy-plugin-api"
-version = "7.1.0"
+version = "7.1.1-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Description of the change

Re-adds version suffixes to crates.

## Why am I making this change?

Following the [versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates).

## Checklist

- [x] I've updated the default plugin import namespace and incremented the major version of `javy-plugin-api` if the QuickJS bytecode has changed.
- [x] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli`, `javy-plugin`, and `javy-plugin-processing` do not require updating CHANGELOG files.
- [x] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [x] I've updated documentation including crate documentation if necessary.
